### PR TITLE
Handle LocaleSidKeys with multiple underscores + (Latin)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Version 1.19
 
 General
 -------
+* Fix country codes from LocalSidKey convention [PR117](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/117) (contribution by [Luca Bassani](https://github.com/baslu93))
 * Use custom shortcuts [feature 115](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/115)
 * Add Export Query button [feature 109](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/109) (idea by [Ryan Sherry](https://github.com/rpsherry-starburst))
 * Add permission set group assignment button from popup [feature 106](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/106)

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1483,7 +1483,8 @@ function getSfPathFromUrl(href) {
 function sfLocaleKeyToCountryCode(localeKey) {
   //Converts a Salesforce locale key to a lower case country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or "".
   if (!localeKey) { return ""; }
-  return localeKey.split("_").pop().toLowerCase();
+  const splitted = localeKey.split("_");
+  return splitted[(splitted.length > 1 && !localeKey.includes("_LATN_")) ? 1 : 0].toLowerCase();
 }
 
 window.getRecordId = getRecordId; // for unit tests


### PR DESCRIPTION
The current method isn't handling multiple underscores in LocalSidKey.
There are multiple values with 2 underscores:

- de_DE_EURO
- uz_LATN_UZ
- zh_CN_PINYIN
- zh_CN_STROKE
- zh_HK_STROKE
- zh_TW_STROKE

uz_LATN_UZ has been handled with an ad-hoc rule since LATN means Latin and the country is UZ.
One of the impact is the following flag, that is not showing correctly for the value de_DE_EURO (e.g.):

![image](https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/12510531/ff96764e-1094-4dda-bfca-2975cd499b76)
