### PR TITLE
Add Hyperforce China Support

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -27,7 +27,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             if (sessionCookie) {
               sendResponse(sessionCookie.domain);
             } else {
-              sendResponse(null);
+              //Get Session cookies for Hyperforce China Orgs
+              chrome.cookies.getAll({name: "sid", domain: "sfcrmproducts.cn", secure: true, storeId: sender.tab.cookieStoreId}, cookies => {
+                sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!"));
+                if (sessionCookie) {
+                  sendResponse(sessionCookie.domain);
+                } else {
+                  sendResponse(null);
+                }
+              });
             }
           });
         }

--- a/addon/manifest-template.json
+++ b/addon/manifest-template.json
@@ -19,7 +19,9 @@
     "https://*.salesforce.com/*",
     "https://*.force.com/*",
     "https://*.cloudforce.com/*",
-    "https://*.visualforce.com/*"
+    "https://*.visualforce.com/*",
+    "https://*.sfcrmapps.cn/*",
+    "https://*.sfcrmproducts.cn/*"
   ],
   "content_scripts": [
     {
@@ -29,7 +31,9 @@
         "https://*.vf.force.com/*",
         "https://*.lightning.force.com/*",
         "https://*.cloudforce.com/*",
-        "https://*.visualforce.com/*"
+        "https://*.visualforce.com/*",
+        "https://*.sfcrmapps.cn/*",
+        "https://*.sfcrmproducts.cn/*"
       ],
       "all_frames": true,
       "css": [

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -13,7 +13,9 @@
     "https://*.salesforce.com/*",
     "https://*.force.com/*",
     "https://*.cloudforce.com/*",
-    "https://*.visualforce.com/*"
+    "https://*.visualforce.com/*",
+    "https://*.sfcrmapps.cn/*",
+    "https://*.sfcrmproducts.cn/*"
   ],
   "content_scripts": [
     {
@@ -23,7 +25,9 @@
         "https://*.vf.force.com/*",
         "https://*.lightning.force.com/*",
         "https://*.cloudforce.com/*",
-        "https://*.visualforce.com/*"
+        "https://*.visualforce.com/*",
+        "https://*.sfcrmapps.cn/*",
+        "https://*.sfcrmproducts.cn/*"
       ],
       "all_frames": true,
       "css": [

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -24,7 +24,6 @@ function init({ sfHost, inDevConsole, inLightning, inInspector }) {
   let addonVersion = chrome.runtime.getManifest().version;
 
   sfConn.getSession(sfHost).then(() => {
-
     ReactDOM.render(h(App, {
       sfHost,
       inDevConsole,
@@ -1514,8 +1513,8 @@ function getRecordId(href) {
   let url = new URL(href);
   // Find record ID from URL
   let searchParams = new URLSearchParams(url.search.substring(1));
-  // Salesforce Classic and Console
-  if (url.hostname.endsWith(".salesforce.com")) {
+  // Salesforce Classic and Console (+ Hyperforce China Lightning & Classic)
+  if (url.hostname.endsWith(".salesforce.com") || url.hostname.endsWith(".sfcrmapps.cn") || url.hostname.endsWith(".sfcrmproducts.cn")) {
     let match = url.pathname.match(/\/([a-zA-Z0-9]{3}|[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18})(?:\/|$)/);
     if (match) {
       let res = match[1];


### PR DESCRIPTION
Hi, we have some clients that are now using a new Salesforce product called Hyperforce.
For China clients, Hyperforce are available only from new url.

So I implemented a way to retrieve the sessionCookie, the recordId, the hostname etc, and it's now works on differents clients that are using Hyperforce China.

My code supports both Classic and Lightning