### PR TITLE
[popup] Move popup icon in flow builder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version 1.20
 
+- Move popup arrow icon in Flow Builder because of Winter 24 UI changes [feature 200](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/200)
 - Add 'Login As' button for Experience users [feature 190](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/190)
 - Add 'Delete Records' button from data export page [feature 134](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/134) (contribution by [Oscar Gomez Balaguer](https://github.com/ogomezba))
 - Update popup title to show "Salesforce Inspector Reloaded" [feature 188](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/188) (idea by [Nicolas Vuillamy](https://github.com/nvuillam))

--- a/addon/button.js
+++ b/addon/button.js
@@ -15,7 +15,6 @@ if (document.querySelector("body.sfdcBody, body.ApexCSIPage, #auraLoadingBox") |
 }
 
 function initButton(sfHost, inInspector) {
-  addFlowScrollability();
   let rootEl = document.createElement("div");
   rootEl.id = "insext";
   let btn = document.createElement("div");
@@ -33,11 +32,19 @@ function initButton(sfHost, inInspector) {
     loadPopup();
   });
 
+  addFlowScrollability();
+
 
   function addFlowScrollability() {
     const currentUrl = window.location.href;
     // Check the current URL for the string "builder_platform_interaction"
     if (currentUrl.includes("builder_platform_interaction")) {
+      //add marging for the popup arrow to prevent overlap with standard close button in flow builder (Winter 24)
+      //temporary workaround, will be removed in next release when the popupArrow position will be updatable by users
+      const popupArrow = document.querySelector("#insext");
+      if (popupArrow){
+        popupArrow.style = "margin-top: 50px;";
+      }
       // Create a new checkbox element
       const headerFlow = document.querySelector("builder_platform_interaction-container-common");
       const overflowCheckbox = document.createElement("input");


### PR DESCRIPTION
Since Winter 24, some UI changes in flow builder affect the usability of the popup icon.

![image](https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/43fe2dde-8620-4bd1-a85b-9601702efaac)

There is an improvement which is in progress to let users decide where they want to place their icon.
Since this is not finished yet, this PR adds a margin to the button in flow builder to prevent the overlap

<img width="412" alt="image" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/6943e9a1-206d-4d7d-8a7e-1483e5317063">
