### PR TITLE
Centering footer buttons.

### DIFF
--- a/addon/inspect.css
+++ b/addon/inspect.css
@@ -720,7 +720,7 @@ th[tabindex] {
   padding: 4px;
   border: 1px solid #d8dde6;
   background-color: #f7f9fb;;
-  justify-content: flex-end;
+  justify-content: center;
 }
 
 .edit-bar .button {


### PR DESCRIPTION
The change relates to the centring of the button section. By default in SF this section is centred and this is now more intuitive to use.