### PR TITLE
Dynamically display text in show / hide borders menu.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Org instance in not correct with after Hyperforce migration: store org instance in sessionStorage to retrieve it once per session [issue 167](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/167)
 - Add Salesforce SObject documentation links [feature 219](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/219) (idea by [Antoine Audollent])
 - Add centering buttons section in footer after edit field (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
+- Add dynamic display text show/hide borders table popup in record field preview setting (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.20.1
 

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -27,7 +27,7 @@ class Model {
     this.errorMessages = [];
     this.rowsFilter = "";
     this.useTab = "all";
-    this.showTableBorder = localStorage.getItem("displayInspectTableBorders") == "true";
+    this.showTableBorder = localStorage.getItem("displayInspectTableBorders") === "true";
     this.fieldRows = new FieldRowList(this);
     this.childRows = new ChildRowList(this);
     this.detailsFilter = "";
@@ -1273,10 +1273,16 @@ class RowTable extends React.Component {
     this.tableSettingsOpen = false;
   }
   onToggleTableSettings() {
+    this.state = {
+      showOrHideBorders: localStorage.getItem("displayInspectTableBorders") === "true" ? "Hide table borders" : "Show table borders"
+    };
     this.tableSettingsOpen = !this.tableSettingsOpen;
     this.props.model.didUpdate();
   }
   onClickTableBorderSettings() {
+    this.setState({
+      showOrHideBorders: localStorage.getItem("displayInspectTableBorders") === "false" ? "Show table borders" : "Hide table borders"
+    });
     this.props.onUpdateTableBorderSettings();
     this.tableSettingsOpen = false;
   }
@@ -1295,7 +1301,7 @@ class RowTable extends React.Component {
             ),
             this.tableSettingsOpen && h("div", {className: "pop-menu-container"},
               h("div", {className: "pop-menu"},
-                h("a", {className: "table-settings-link", onClick: this.onClickTableBorderSettings}, "Show / Hide table borders"),
+                h("a", {className: "table-settings-link", onClick: this.onClickTableBorderSettings}, this.state.showOrHideBorders),
               )
             ),
           ),


### PR DESCRIPTION
Text is substituted dynamically to show/hide table borders.

![image](https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/28691476/4d258345-604c-450e-94bf-71ba12d9cdbe)
