### PR TITLE
Fix Delete Button when only one record is filtered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ## Version 1.20.1
 
+- Bugfix Delete Button not enabled when only one record is queried/filtered
 - Bugfix User selection not displaying information (for orgs without community enabled) [issue 211](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/211)
 
 ## Version 1.20

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@
 
 ## Version 1.20.1
 
-- Bugfix Delete Button not enabled when only one record is queried/filtered
+- Bugfix Delete Button not enabled when only one record is queried/filtered (contribution by [Oscar Gomez Balaguer](https://github.com/ogomezba))
+
 - Bugfix User selection not displaying information (for orgs without community enabled) [issue 211](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/211)
 
 ## Version 1.20

--- a/addon/data-export-test.js
+++ b/addon/data-export-test.js
@@ -558,6 +558,14 @@ export async function dataExportTest(test) {
   await waitForSpinner();
   assert(vm.canDelete(), "The Delete button should be enabled");
 
+  vm.setResultsFilter("test3");
+  assert(vm.canDelete(), "The Delete button should be enabled");
+
+  vm.setResultsFilter("test5");
+  assert(!vm.canDelete(), "The Delete button should be disabled as there are no results after filtering");
+
+  vm.setResultsFilter("");
+
   // Autocomplete load errors
   let restOrig = sfConn.rest;
   let restError = () => Promise.reject();

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -224,7 +224,7 @@ class Model {
   canDelete() {
     //In order to allow deletion, we should have at least 1 element and the Id field should have been included in the query
     return this.exportedData
-          && (this.exportedData.countOfVisibleRecords === null /* no filtering has been done yet*/ || this.exportedData.countOfVisibleRecords > 1)
+          && (this.exportedData.countOfVisibleRecords === null /* no filtering has been done yet*/ || this.exportedData.countOfVisibleRecords > 0)
           && this.exportedData?.table?.at(0)?.find(header => header.toLowerCase() === "id");
   }
   copyAsExcel() {


### PR DESCRIPTION
Fix for also enabling the delete button when only one record is queried/filtered. Tests have been included and the full test suite has been executed successfully.