### PR TITLE
Fix for #218 adding durableId if unset

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -369,6 +369,9 @@ class AllDataBox extends React.PureComponent {
         if (!entity.keyPrefix) { // For some objects the keyPrefix is only available in some of the APIs.
           entity.keyPrefix = keyPrefix;
         }
+        if (!entity.durableId) {
+          entity.durableId = durableId;
+        }
       } else {
         entity = {
           availableApis: [],


### PR DESCRIPTION
This is based on my understanding but please feel free to correct me if I'm wrong.

I don't understand yet unit tests for Chrome Extensions, so, I need some guidance there if needed.