### PR TITLE
Fix for #218 adding durableId if unset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add centering buttons section in footer after edit field (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - Add dynamic display text show/hide borders table popup in record field preview setting (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - Add "Download" option on event log files (contribution by [Annubis45](https://github.com/Annubis45))
+- Fix 'Custom Object Name Links Don't Work' in popup [issue 218](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/218) (contribution by [Jeferson Chaves](https://github.com/JefersonChaves))
 
 ## Version 1.20.1
 

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -369,6 +369,9 @@ class AllDataBox extends React.PureComponent {
         if (!entity.keyPrefix) { // For some objects the keyPrefix is only available in some of the APIs.
           entity.keyPrefix = keyPrefix;
         }
+        if (!entity.durableId) { // For some objects the durableId is only available in some of the APIs
+          entity.durableId = durableId;
+        }
       } else {
         entity = {
           availableApis: [],


### PR DESCRIPTION
## Describe your changes
Add a check if `durableId` was not previously set but the entry is already added into the map.

## Issue ticket number and link
#218 

## Checklist before requesting a review
- [ X ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ X ] Target branch is releaseCandidate and not master
- [ X ] I have performed a self-review of my code
- [ X ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ X ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ N/A ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

