### PR TITLE
Enhance Shortcut Search to Include Any Part of Title, not only beginning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.21
 
+- Enhance shortcut search to include any part of the shortcut title, not only the beginning (contribution by [Joshua Yarmak](https://github.com/toly11))
 - Org instance in not correct with after Hyperforce migration: store org instance in sessionStorage to retrieve it once per session [issue 167](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/167)
 - Add Salesforce SObject documentation links [feature 219](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/219) (idea by [Antoine Audollent])
 - Add centering buttons section in footer after edit field (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -882,7 +882,7 @@ class AllDataBoxShortcut extends React.PureComponent {
       setIsLoading(true);
 
       //search for shortcuts
-      let result = setupLinks.filter(item => item.label.toLowerCase().startsWith(shortcutSearch.toLowerCase()));
+      let result = setupLinks.filter(item => item.label.toLowerCase().includes(shortcutSearch.toLowerCase()));
       result.forEach(element => {
         element.detail = element.section;
         element.name = element.link;


### PR DESCRIPTION
**Overview:**
This pull request introduces an improvement to the shortcut search functionality. Previously, the search was limited to matching only the beginning of shortcut titles. With this update, users can now search for shortcuts by using terms that appear anywhere within the shortcut title, for example: previously, in order to find "Company Information", you couldn't just type "Info", but now you can. This change better aligns with Salesforce's setup search functionality witch allows searching for terms that appear anywhere in the node title. In addition this change is beneficial since users don't always remember the exact title and it's beginning.

**Testing**
This feature has been tested across different environments to ensure compatibility and smooth integration with existing functionalities. I encourage further testing to validate its efficiency and usability enhancements.

**Documentation**
I have documented this change in the CHANGES.md file

**Request for Review**
I kindly request a review of this pull request and am open to making any necessary adjustments based on your feedback. Thank you for considering this valuable enhancement to the user experience.

![image](https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/82345405/bdb7849d-edb0-4030-8a9b-beb417736380)
