### PR TITLE
fix: Fix for issue #254

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.22
 
+- Bugfix Delete button does not check for 'toolingApi' parameter [issue 254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/254) (contribution by [Oscar Gomez Balaguer](https://github.com/ogomezba))
 - Add Apex classes documentation in shortcut [feature 247](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/247)
 - Disable "Delete records" button when a query returns more than 20k records [feature 251](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/251)
 - Automatically request SObject type for data import and SObject record id for data export [feature 45](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/45) SObject record (#45)) (contribution by [Olivier Dufour](https://github.com/dufoli))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -245,6 +245,7 @@ class Model {
     let args = new URLSearchParams();
     args.set("host", this.sfHost);
     args.set("data", encodedData);
+    if (this.queryTooling) args.set("apitype", 'Tooling');
 
     window.open("data-import.html?" + args, getLinkTarget(e));
   }

--- a/addon/data-import-test.js
+++ b/addon/data-import-test.js
@@ -367,22 +367,40 @@ export async function dataImportTest(test) {
     separator = localStorage.getItem("csvSeparator");
   }
 
-  let data = [
+  let generateDataParam = data => {
+    let encodedData = btoa(data.map(r => r.join(separator)).join("\r\n"));
+    let args = new URLSearchParams();
+    args.set("data", encodedData);
+    return args;
+  };
+
+  let args = generateDataParam([
     ["_", "Id", "Name"],
     ["[Account]", "0010Y00000kCUn3QAG", "GenePoint1111"],
     ["[Account]", "0010Y00000kCUn1QAG", "United Oil & Gas UK2222"]
-  ];
-  let encodedData = btoa(data.map(r => r.join(separator)).join("\r\n"));
-  let args = new URLSearchParams();
-  args.set("data", encodedData);
+  ]);
 
   let result = await loadPage("data-import.html", args);
   let importModel = result.model;
+
   assertEquals([
     ["[Account]", "0010Y00000kCUn3QAG", "GenePoint1111"],
     ["[Account]", "0010Y00000kCUn1QAG", "United Oil & Gas UK2222"]
   ], importModel.importData.importTable.data);
+  assertEquals("Enterprise", importModel.apiType);
   assertEquals("delete", importModel.importAction);
+
+  args = generateDataParam([
+    ["_", "Id", "ApexCode"],
+    ["[TraceFlag]", "7tf1n000006zoecAAA", "FINEST"],
+    ["[TraceFlag]", "7tf1n000007GUCAAA4", "DEBUG"]
+  ]);
+  args.set("apitype", "Tooling");
+
+  result = await loadPage("data-import.html", args)
+  importModel = result.model;
+  assertEquals("Tooling", importModel.apiType);
+
 
   // Big result
   // TODO Write test for clipboard copy

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -49,11 +49,13 @@ class Model {
       this.userInfo = res.userFullName + " / " + res.userName + " / " + res.organizationName;
     }));
 
+    let apiTypeParam = args.get("apitype");
+    this.apiType = this.importType.endsWith("__mdt") ? "Metadata" : apiTypeParam ? apiTypeParam : 'Enterprise';
+
     if (args.has("data")) {
       let data = atob(args.get("data"));
       this.dataFormat = "csv";
       this.setData(data);
-      this.apiType = this.importType.endsWith("__mdt") ? "Metadata" : "Enterprise";
       this.updateAvailableActions();
       this.importAction = this.importType.endsWith("__mdt") ? "deleteMetadata" : "delete";
       this.importActionName = this.importType.endsWith("__mdt") ? "Delete Metadata" : "Delete";
@@ -175,7 +177,8 @@ class Model {
     //automatically select the SObject if possible
     let sobj = this.getSObject(data);
     if (sobj) {
-      this.apiType = sobj.endsWith("__mdt") ? "Metadata" : "Enterprise";
+      //We avoid overwriting the Tooling option in case it was already set
+      this.apiType = sobj.endsWith("__mdt") ? "Metadata" : this.apiType === 'Tooling' ? 'Tooling' : 'Enterprise';
       this.updateAvailableActions();
       this.importType = sobj;
     }


### PR DESCRIPTION
Fixing the Delete button for the cases where the "Tooling API" option has been selected when querying

## Describe your changes
Included logic for sending the apiType as a parameter to the data-import.

## Issue ticket number and link
[Issue 254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/254)

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

