### PR TITLE
Bugfix: remove link CSS override

### DIFF
--- a/addon/popup.css
+++ b/addon/popup.css
@@ -65,7 +65,6 @@ body,
     flex-direction: column;
 }
 
-a:link,
 a:visited {
     color: #0176d3;
 }


### PR DESCRIPTION
## Describe your changes

Remove the color override on `a:link` (but kept it on `a:visited`).
The override on unvisited links was causing them to be unreadable on SLDS button with the brand style. 
It did not notice any issue remove the `a:link` style from the custom CSS.


## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

