### PR TITLE
[feature] Add hide fields api name button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.23
+
+- Add the possibility to hide fields API names after users clicked "Show fields API names"
+
 ## Version 1.22
 
 - Add "Enable Logs" button in the User tab [feature 245](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/245) (contribution by [Antoine Leleu](https://github.com/AntoineLeleu-Salesforce))

--- a/addon/button.js
+++ b/addon/button.js
@@ -151,18 +151,22 @@ function initButton(sfHost, inInspector) {
         showStdPageDetails(e.data.insextData, e.data.insextAllFieldSetupLinks);
       }
       if (e.data.insextShowApiName) {
-        document.querySelectorAll("record_flexipage-record-field > div, records-record-layout-item > div, div .forcePageBlockItemView").forEach(field => {
-          let label = field.querySelector("span");
-          if (field.dataset.targetSelectionName && label.querySelector("mark") == null){
-            label.innerText = label.innerText + " ";
-            const fieldApiName = document.createElement("mark");
-            fieldApiName.className = "field-api-name";
-            fieldApiName.style.cursor = "copy";
-            fieldApiName.innerText = field.dataset.targetSelectionName.split(".")[2];
-            label.appendChild(fieldApiName);
-            document.addEventListener("click", copy);
-          }
-        });
+        if (e.data.btnLabel.startsWith("Show")){
+          document.querySelectorAll("record_flexipage-record-field > div, records-record-layout-item > div, div .forcePageBlockItemView").forEach(field => {
+            let label = field.querySelector("span");
+            if (field.dataset.targetSelectionName && label.querySelector("mark") == null){
+              label.innerText = label.innerText + " ";
+              const fieldApiName = document.createElement("mark");
+              fieldApiName.className = "field-api-name";
+              fieldApiName.style.cursor = "copy";
+              fieldApiName.innerText = field.dataset.targetSelectionName.split(".")[2];
+              label.appendChild(fieldApiName);
+              document.addEventListener("click", copy);
+            }
+          });
+        } else {
+          document.querySelectorAll(".field-api-name").forEach(e => e.remove());
+        }
       }
     });
     rootEl.appendChild(popupEl);

--- a/addon/button.js
+++ b/addon/button.js
@@ -151,13 +151,14 @@ function initButton(sfHost, inInspector) {
         showStdPageDetails(e.data.insextData, e.data.insextAllFieldSetupLinks);
       }
       if (e.data.insextShowApiName) {
+        let apiNamesClass = "field-api-name";
         if (e.data.btnLabel.startsWith("Show")){
           document.querySelectorAll("record_flexipage-record-field > div, records-record-layout-item > div, div .forcePageBlockItemView").forEach(field => {
             let label = field.querySelector("span");
             if (field.dataset.targetSelectionName && label.querySelector("mark") == null){
               label.innerText = label.innerText + " ";
               const fieldApiName = document.createElement("mark");
-              fieldApiName.className = "field-api-name";
+              fieldApiName.className = apiNamesClass;
               fieldApiName.style.cursor = "copy";
               fieldApiName.innerText = field.dataset.targetSelectionName.split(".")[2];
               label.appendChild(fieldApiName);
@@ -165,7 +166,7 @@ function initButton(sfHost, inInspector) {
             }
           });
         } else {
-          document.querySelectorAll(".field-api-name").forEach(e => e.remove());
+          document.querySelectorAll(apiNamesClass).forEach(e => e.remove());
         }
       }
     });

--- a/addon/manifest-template.json
+++ b/addon/manifest-template.json
@@ -1,7 +1,7 @@
 {
   "name": "Salesforce Inspector reloaded",
   "description": "Productivity tools for Salesforce administrators and developers to inspect data and metadata directly from the Salesforce UI.",
-  "version": "1.21",
+  "version": "1.23",
   "icons": {
     "128": "icon128.png"
   },

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Salesforce Inspector reloaded",
   "description": "Productivity tools for Salesforce administrators and developers to inspect data and metadata directly from the Salesforce UI.",
-  "version": "1.22",
-  "version_name": "1.22",
+  "version": "1.23",
+  "version_name": "1.23",
   "icons": {
     "128": "icon128.png"
   },

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -31,8 +31,13 @@ function closePopup() {
   parent.postMessage({insextClosePopup: true}, "*");
 }
 
-function showApiName() {
-  parent.postMessage({insextShowApiName: true}, "*");
+function showApiName(e) {
+  parent.postMessage({insextShowApiName: true, btnLabel: e.target.innerText}, "*");
+  if (e.target.innerText.startsWith("Show")){
+    e.target.innerText = e.target.innerText.replace("Show", "Hide");
+  } else {
+    e.target.innerText = e.target.innerText.replace("Hide", "Show");
+  }
 }
 
 function init({sfHost, inDevConsole, inLightning, inInspector}) {
@@ -1643,7 +1648,7 @@ class AllDataSelection extends React.PureComponent {
           : button == "toolingApi" ? " (Tooling API)"
           : " (Not readable)"
         ))),
-        isFieldsPresent ? h("a", {ref: "showFieldApiNameBtn", onClick: showApiName, target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, "Show ", h("u", {}, "f"), "ields API names")) : null,
+        isFieldsPresent ? h("a", {ref: "showFieldApiNameBtn", id: "showFieldApiNameBtn", onClick: showApiName, target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, "Show ", h("u", {}, "f"), "ields API names")) : null,
         selectedValue.sobject.isEverCreatable ? h("a", {ref: "showNewBtn", href: this.getNewObjectUrl(sfHost, selectedValue.sobject.newUrl), target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, h("u", {}, "N"), "ew " + selectedValue.sobject.label)) : null,
       )
     );

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1648,7 +1648,7 @@ class AllDataSelection extends React.PureComponent {
           : button == "toolingApi" ? " (Tooling API)"
           : " (Not readable)"
         ))),
-        isFieldsPresent ? h("a", {ref: "showFieldApiNameBtn", id: "showFieldApiNameBtn", onClick: showApiName, target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, "Show ", h("u", {}, "f"), "ields API names")) : null,
+        isFieldsPresent ? h("a", {ref: "showFieldApiNameBtn", onClick: showApiName, target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, "Show ", h("u", {}, "f"), "ields API names")) : null,
         selectedValue.sobject.isEverCreatable ? h("a", {ref: "showNewBtn", href: this.getNewObjectUrl(sfHost, selectedValue.sobject.newUrl), target: linkTarget, className: "slds-m-top_xx-small page-button slds-button slds-button_neutral"}, h("span", {}, h("u", {}, "N"), "ew " + selectedValue.sobject.label)) : null,
       )
     );


### PR DESCRIPTION
## Describe your changes
When users clicked "Show fields API names" they were not able to hide the added information, this feature has been requested by several users

## Issue ticket number and link
N/A 

## Checklist before requesting a review
- [ ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] Target branch is releaseCandidate and not master
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

