### PR TITLE
Bugfix: simplify getSfHost

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -13,7 +13,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
       const currentDomain = new URL(request.url).hostname;
       sendResponse(currentDomain);
-    });
     return true; // Tell Chrome that we want to call sendResponse asynchronously.
   }
   if (request.message == "getSession") {

--- a/addon/background.js
+++ b/addon/background.js
@@ -13,23 +13,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
     chrome.cookies.get({url: request.url, name: "sid", storeId: sender.tab.cookieStoreId}, cookie => {
       const currentDomain = new URL(request.url).hostname;
-      if (!cookie) {
-        sendResponse(currentDomain);
-        return;
-      }
-      let [orgId] = cookie.value.split("!");
-      let orderedDomains = ["salesforce.com", "cloudforce.com", "salesforce.mil", "cloudforce.mil", "sfcrmproducts.cn"];
-
-      orderedDomains.forEach(currentDomain => {
-        chrome.cookies.getAll({name: "sid", domain: currentDomain, secure: true, storeId: sender.tab.cookieStoreId}, cookies => {
-          let sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!"));
-          if (sessionCookie) {
-            sendResponse(sessionCookie.domain);
-          } else if (orderedDomains[orderedDomains.length] === currentDomain){
-            sendResponse(currentDomain);
-          }
-        });
-      });
+      sendResponse(currentDomain);
     });
     return true; // Tell Chrome that we want to call sendResponse asynchronously.
   }

--- a/addon/background.js
+++ b/addon/background.js
@@ -11,7 +11,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // http://salesforce.stackexchange.com/questions/23277/different-session-ids-in-different-contexts
     // There is no straight forward way to unambiguously understand if the user authenticated against salesforce.com or cloudforce.com
     // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
-    chrome.cookies.get({url: request.url, name: "sid", storeId: sender.tab.cookieStoreId}, cookie => {
       const currentDomain = new URL(request.url).hostname;
       sendResponse(currentDomain);
     });

--- a/addon/background.js
+++ b/addon/background.js
@@ -4,15 +4,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // Firefox does not support incognito split mode, so we use sender.tab.cookieStoreId to select the right cookie store.
   // Chrome does not support sender.tab.cookieStoreId, which means it is undefined, and we end up using the default cookie store according to incognito split mode.
   if (request.message == "getSfHost") {
-    // When on a *.visual.force.com page, the session in the cookie does not have API access,
-    // so we read the corresponding session from *.salesforce.com page.
-    // The first part of the session cookie is the OrgID,
-    // which we use as key to support being logged in to multiple orgs at once.
-    // http://salesforce.stackexchange.com/questions/23277/different-session-ids-in-different-contexts
-    // There is no straight forward way to unambiguously understand if the user authenticated against salesforce.com or cloudforce.com
-    // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
-      const currentDomain = new URL(request.url).hostname;
-      sendResponse(currentDomain);
+    const currentDomain = new URL(request.url).hostname;
+    sendResponse(currentDomain);
     return true; // Tell Chrome that we want to call sendResponse asynchronously.
   }
   if (request.message == "getSession") {


### PR DESCRIPTION
## Describe your changes

This is to fix a regression on .mcas domains (maybe after [PR#141](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/141/)?)
I simplified the `getSfHost` logic: now it simply returns the current domain.
**I'm not sure why the previous logic was so complex**, since the extension should not show on non-Salesforce domains based on its manifest. But maybe I missed the point, and broke something? @tprouvot @victorgz your feedback is more than welcome.

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [X] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

