### PR TITLE
Fix getSfHost on .mcas.ms domains

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -4,6 +4,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // Firefox does not support incognito split mode, so we use sender.tab.cookieStoreId to select the right cookie store.
   // Chrome does not support sender.tab.cookieStoreId, which means it is undefined, and we end up using the default cookie store according to incognito split mode.
   if (request.message == "getSfHost") {
+    const currentDomain = new URL(request.url).hostname;
     // When on a *.visual.force.com page, the session in the cookie does not have API access,
     // so we read the corresponding session from *.salesforce.com page.
     // The first part of the session cookie is the OrgID,
@@ -11,26 +12,29 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // http://salesforce.stackexchange.com/questions/23277/different-session-ids-in-different-contexts
     // There is no straight forward way to unambiguously understand if the user authenticated against salesforce.com or cloudforce.com
     // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
-    chrome.cookies.get({url: request.url, name: "sid", storeId: sender.tab.cookieStoreId}, cookie => {
-      const currentDomain = new URL(request.url).hostname;
-      if (!cookie) {
-        sendResponse(currentDomain);
-        return;
-      }
-      let [orgId] = cookie.value.split("!");
-      let orderedDomains = ["salesforce.com", "cloudforce.com", "salesforce.mil", "cloudforce.mil", "sfcrmproducts.cn"];
+    if (currentDomain.endsWith("force.com.mcas.ms")) { // when the org is protected by Microsoft Defender for Cloud Apps (.mcas.ms domain), the extension won't have access to cookies
+      sendResponse(currentDomain);
+    } else {
+      chrome.cookies.get({url: request.url, name: "sid", storeId: sender.tab.cookieStoreId}, cookie => {
+        if (!cookie) {
+          sendResponse(currentDomain);
+          return;
+        }
+        let [orgId] = cookie.value.split("!");
+        let orderedDomains = ["salesforce.com", "cloudforce.com", "salesforce.mil", "cloudforce.mil", "sfcrmproducts.cn"];
 
-      orderedDomains.forEach(currentDomain => {
-        chrome.cookies.getAll({name: "sid", domain: currentDomain, secure: true, storeId: sender.tab.cookieStoreId}, cookies => {
-          let sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!"));
-          if (sessionCookie) {
-            sendResponse(sessionCookie.domain);
-          } else if (orderedDomains[orderedDomains.length] === currentDomain){
-            sendResponse(currentDomain);
-          }
+        orderedDomains.forEach(currentDomain => {
+          chrome.cookies.getAll({name: "sid", domain: currentDomain, secure: true, storeId: sender.tab.cookieStoreId}, cookies => {
+            let sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!"));
+            if (sessionCookie) {
+              sendResponse(sessionCookie.domain);
+            } else if (orderedDomains[orderedDomains.length] === currentDomain){
+              sendResponse(currentDomain);
+            }
+          });
         });
       });
-    });
+    }
     return true; // Tell Chrome that we want to call sendResponse asynchronously.
   }
   if (request.message == "getSession") {

--- a/addon/background.js
+++ b/addon/background.js
@@ -14,6 +14,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // (and thereby the domain of the relevant cookie) cookie domains are therefore tried in sequence.
     if (currentDomain.endsWith("force.com.mcas.ms")) { // when the org is protected by Microsoft Defender for Cloud Apps (.mcas.ms domain), the extension won't have access to cookies
       sendResponse(currentDomain);
+      return;
     } else {
       chrome.cookies.get({url: request.url, name: "sid", storeId: sender.tab.cookieStoreId}, cookie => {
         if (!cookie) {


### PR DESCRIPTION
## Describe your changes

The beta version was not working anymore on orgs protected by Microsoft Defender for Cloud Apps (.mcas.ms domain).
This PR contains a fix for that issue. 
Not the most elegant solution, but apparently `chrome.cookies.get()` does not work as expect when Microsoft Defender for Cloud Apps is used, which is why I added a check on the domain before.

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [X] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

