### PR TITLE
fix: next future release displayed in org tab

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1149,8 +1149,8 @@ class AllDataBoxOrg extends React.PureComponent {
     if (instanceStatusLocal == null){
       fetch(`https://api.status.salesforce.com/v1/instances/${instanceName}/status`).then(response => {
         response.json().then(result => {
-          //manually sort maintenance since list in not ordered by default
-          result.Maintenances.sort((a, b) => (a.plannedStartTime > b.plannedStartTime) ? 1 : ((b.plannedStartTime > a.plannedStartTime) ? -1 : 0));
+          //manually filter to get only the future releases (based on today's date) and sort maintenance since list in not ordered by default
+          result.Maintenances = result.Maintenances.filter(dt => dt.plannedEndTime >= new Date().toISOString()).sort((a, b) => (a.plannedStartTime > b.plannedStartTime) ? 1 : ((b.plannedStartTime > a.plannedStartTime) ? -1 : 0));
           this.setState({instanceStatus: result});
           sessionStorage.setItem(sfHost + "_instanceStatus", JSON.stringify(result));
         });


### PR DESCRIPTION
## Describe your changes
When calling the Salesforce Status API, the list of maintenances returned in the JSON response is not filtered by date, so the previous release is included in the response.

The goal is to filter the result so only the future releases will be displayed.

Code example here: https://jsfiddle.net/nc3v1jmy/

Solves #282 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

