### PR TITLE
[popup] Add API Version to Org tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.23
 
+- Display API version in Org tab [feature 293](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/293) (feature by [Camille Guillory](https://github.com/CamilleGuillory))
 - Add the possibility to hide fields API names after users clicked "Show fields API names"
 - Add performance On data export with option to disable in Options/Data Export tab (contribution by [Nathan Shulman](https://github.com/nshulman))
 - Clean up popup header and footer (contribution by [Nathan Shulman](https://github.com/nshulman))

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Salesforce Inspector reloaded",
   "description": "Productivity tools for Salesforce administrators and developers to inspect data and metadata directly from the Salesforce UI.",
-  "version": "1.22",
-  "version_name": "1.22",
+  "version": "1.23",
+  "version_name": "1.23",
   "icons": {
     "128": "icon128.png"
   },

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1154,6 +1154,14 @@ class AllDataBoxOrg extends React.PureComponent {
     return null;
   }
 
+  getApiVersion(instanceStatus){
+    if (instanceStatus){
+      let apiVersion = (instanceStatus.releaseNumber.substring(0, 3) / 2) - 64;
+      return apiVersion;
+    }
+    return null;
+  }
+
   setInstanceStatus(instanceName, sfHost){
     let instanceStatusLocal = JSON.parse(sessionStorage.getItem(sfHost + "_instanceStatus"));
     if (instanceStatusLocal == null){
@@ -1204,6 +1212,10 @@ class AllDataBoxOrg extends React.PureComponent {
                 h("tr", {},
                   h("th", {}, "Location:"),
                   h("td", {}, this.state.instanceStatus?.location)
+                ),
+                h("tr", {},
+                  h("th", {}, "API version:"),
+                  h("td", {}, this.getApiVersion(this.state.instanceStatus))
                 ),
                 h("tr", {},
                   h("th", {}, h("a", {href: "https://status.salesforce.com/instances/" + orgInfo.InstanceName + "/maintenances", title: "Maintenance List", target: linkTarget}, "Maintenance:")),


### PR DESCRIPTION
## Describe your changes
Display API version in the org tab

<img width="279" alt="image" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/887b5edc-2a73-42e7-a740-2f983356dcf7">

## Issue ticket number and link
#293 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

