### PR TITLE
Hide RecType field in popup when field is not set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.23
 
+- Hide RecType field from popup when record has no record type [feature 298](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/298)
 - Display API version in Org tab [feature 293](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/293) (feature by [Camille Guillory](https://github.com/CamilleGuillory))
 - Add the possibility to hide fields API names after users clicked "Show fields API names"
 - Add performance On data export with option to disable in Options/Data Export tab (contribution by [Nathan Shulman](https://github.com/nshulman))

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1701,12 +1701,12 @@ class AllDataRecordDetails extends React.PureComponent {
                 h("a", {href: this.getRecordLink(sfHost, selectedValue.recordId), target: linkTarget}, recordIdDetails.recordName)
               )
             ),
-            h("tr", {},
+            recordIdDetails.recordTypeName ? h("tr", {},
               h("th", {}, "RecType:"),
               h("td", {},
                 h("a", {href: this.getRecordTypeLink(sfHost, selectedValue.sobject.name, recordIdDetails.recordTypeId), target: linkTarget}, recordIdDetails.recordTypeName)
               )
-            ),
+            ) : null,
             h("tr", {},
               h("th", {}, "Created:"),
               h("td", {}, recordIdDetails.created + " (" + recordIdDetails.createdBy + ")")


### PR DESCRIPTION
## Describe your changes
Hide RecType field when no record type on record.

## Issue ticket number and link
Closing #298 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

