### PR TITLE
[data-export] Add number of filtered records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.23
 
+- Show the number of filtered records in data export [feature 300](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/300) (feature by Vranisimo(https://github.com/vranisimo))
 - Hide RecType and Name field from popup when field is not set [feature 298](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/298)
 - Display API version in Org tab [feature 293](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/293) (feature by [Camille Guillory](https://github.com/CamilleGuillory))
 - Add the possibility to hide fields API names after users clicked "Show fields API names"

--- a/addon/data-export-test.js
+++ b/addon/data-export-test.js
@@ -308,7 +308,7 @@ export async function dataExportTest(test) {
   // Filter results
   vm.setResultsFilter("TRU");
   assertEquals(false, vm.isWorking);
-  assertEquals("Exported 4 records", vm.exportStatus);
+  assertEquals("Filtered 2 records out of 4 records", vm.exportStatus);
   assertEquals([
     ["_", "Name", "Checkbox__c", "Number__c"],
     [{type: "Inspector_Test__c"}, "test1", false, 100.01],
@@ -323,7 +323,7 @@ export async function dataExportTest(test) {
   // Clear filter
   vm.setResultsFilter("");
   assertEquals(false, vm.isWorking);
-  assertEquals("Exported 4 records", vm.exportStatus);
+  assertEquals("Filtered 4 records out of 4 records", vm.exportStatus);
   assertEquals([
     ["_", "Name", "Checkbox__c", "Number__c"],
     [{type: "Inspector_Test__c"}, "test1", false, 100.01],

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -981,6 +981,7 @@ function RecordTable(vm) {
         if (isVisible(rt.table[r], filter)) countOfVisibleRecords++;
       }
       this.countOfVisibleRecords = countOfVisibleRecords;
+      vm.exportStatus = "Filtered " + countOfVisibleRecords + " records out of " + rt.records.length + " records";
     },
     getVisibleTable() {
       if (vm.resultsFilter) {


### PR DESCRIPTION
## Describe your changes
Added number of filtered records in data export page

<img width="1334" alt="image" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/3770d8f7-a005-4857-99c1-48ed064ca1c8">

## Issue ticket number and link
Closes #300 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

