### PR TITLE
[data-export] fix : Remove client id from data export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.23
 
+- Remove Consumer key input from data export [issue 338](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/338)
 - Customize extension's favicon [feature 197](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/197)
 - Save default batch size and thread for data import [feature 329](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/329) (feature request by [ritterblau](https://github.com/ritterblau))
 - Load recently viewed records on popup [feature 321](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/321)

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -102,7 +102,6 @@ class Model {
     this.autocompleteProgress = {};
     this.exportProgress = {};
     this.queryName = "";
-    this.clientId = localStorage.getItem(sfHost + "_clientId") ? localStorage.getItem(sfHost + "_clientId") : "";
     this.queryTemplates = localStorage.getItem("queryTemplates") ? this.queryTemplates = localStorage.getItem("queryTemplates").split("//") : [
       "SELECT Id FROM ",
       "SELECT Id FROM WHERE",
@@ -145,9 +144,6 @@ class Model {
   }
   setQueryName(value) {
     this.queryName = value;
-  }
-  setClientId(value) {
-    this.clientId = value;
   }
   setQueryInput(queryInput) {
     this.queryInput = queryInput;
@@ -250,9 +246,6 @@ class Model {
   }
   addToHistory() {
     this.savedHistory.add({query: this.getQueryToSave(), useToolingApi: this.queryTooling});
-  }
-  saveClientId() {
-    localStorage.setItem(this.sfHost + "_clientId", this.clientId);
   }
   removeFromHistory() {
     this.savedHistory.remove({query: this.getQueryToSave(), useToolingApi: this.queryTooling});
@@ -1035,7 +1028,6 @@ class App extends React.Component {
     this.onClearHistory = this.onClearHistory.bind(this);
     this.onSelectSavedEntry = this.onSelectSavedEntry.bind(this);
     this.onAddToHistory = this.onAddToHistory.bind(this);
-    this.onSaveClientId = this.onSaveClientId.bind(this);
     this.onRemoveFromHistory = this.onRemoveFromHistory.bind(this);
     this.onClearSavedHistory = this.onClearSavedHistory.bind(this);
     this.onToggleHelp = this.onToggleHelp.bind(this);
@@ -1050,7 +1042,6 @@ class App extends React.Component {
     this.onDeleteRecords = this.onDeleteRecords.bind(this);
     this.onResultsFilterInput = this.onResultsFilterInput.bind(this);
     this.onSetQueryName = this.onSetQueryName.bind(this);
-    this.onSetClientId = this.onSetClientId.bind(this);
     this.onStopExport = this.onStopExport.bind(this);
   }
   onQueryAllChange(e) {
@@ -1095,12 +1086,6 @@ class App extends React.Component {
     e.preventDefault();
     let {model} = this.props;
     model.addToHistory();
-    model.didUpdate();
-  }
-  onSaveClientId(e) {
-    e.preventDefault();
-    let {model} = this.props;
-    model.saveClientId();
     model.didUpdate();
   }
   onRemoveFromHistory(e) {
@@ -1189,11 +1174,6 @@ class App extends React.Component {
   onSetQueryName(e) {
     let {model} = this.props;
     model.setQueryName(e.target.value);
-    model.didUpdate();
-  }
-  onSetClientId(e) {
-    let {model} = this.props;
-    model.setClientId(e.target.value);
     model.didUpdate();
   }
   onStopExport() {
@@ -1320,9 +1300,7 @@ class App extends React.Component {
               ),
               h("input", {placeholder: "Query Label", type: "save", value: model.queryName, onInput: this.onSetQueryName}),
               h("button", {onClick: this.onAddToHistory, title: "Add query to saved history"}, "Save Query"),
-              h("button", {className: model.expandSavedOptions ? "toggle contract" : "toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"})),
-              h("input", {placeholder: "Consumer Key", type: "default", value: model.clientId, onInput: this.onSetClientId}),
-              h("button", {onClick: this.onSaveClientId, title: "Save Consumer Key"}, "Save"),
+              h("button", {className: model.expandSavedOptions ? "toggle contract" : "toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"}))
             ),
           ),
           h("div", {className: "query-options"},

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -319,12 +319,12 @@ class App extends React.PureComponent {
                 },
                 h("span", {}, "Setup ", h("u", {}, "H"), "ome")),
             ),
-          ),
-          h("div", {className: "slds-p-vertical_x-small slds-p-horizontal_x-small"},
-            h("div", {className: "slds-m-bottom_xx-small"},
-              h("a", {ref: "optionsBtn", href: "options.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "O", h("u", {}, "p"), "tions"))
-            ),
           )
+        ),
+        h("div", {className: "slds-p-vertical_x-small slds-p-horizontal_x-small"},
+          h("div", {className: "slds-m-bottom_xx-small"},
+            h("a", {ref: "optionsBtn", href: "options.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "O", h("u", {}, "p"), "tions"))
+          ),
         ),
         h("div", {className: "slds-grid slds-theme_shade slds-p-around_x-small slds-border_top"},
           h("div", {className: "slds-col slds-size_5-of-12 footer-small-text slds-m-top_xx-small"},


### PR DESCRIPTION
## Describe your changes
Entering consumer key from data export was failing since the sf host was null.
Removing the input and keep the normal process on Option page.

## Issue ticket number and link
#338 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

