### PR TITLE
Load extension from chrome extension path instead of github

### DIFF
--- a/addon/button.js
+++ b/addon/button.js
@@ -106,7 +106,6 @@ function initButton(sfHost, inInspector) {
       link.orgType = "image/x-icon";
       if (fav.indexOf("http") == -1){
         fav = chrome.runtime.getURL("images/favicons/" + fav + ".png");
-        //fav = "https://raw.githubusercontent.com/tprouvot/Salesforce-Inspector-reloaded/releaseCandidate/addon/images/favicons/" + fav + ".png";
       }
       link.href = fav;
       document.head.appendChild(link);

--- a/addon/button.js
+++ b/addon/button.js
@@ -105,7 +105,8 @@ function initButton(sfHost, inInspector) {
       link.setAttribute("rel", "icon");
       link.orgType = "image/x-icon";
       if (fav.indexOf("http") == -1){
-        fav = "https://raw.githubusercontent.com/tprouvot/Salesforce-Inspector-reloaded/releaseCandidate/addon/images/favicons/" + fav + ".png";
+        fav = chrome.runtime.getURL("images/favicons/" + fav + ".png");
+        //fav = "https://raw.githubusercontent.com/tprouvot/Salesforce-Inspector-reloaded/releaseCandidate/addon/images/favicons/" + fav + ".png";
       }
       link.href = fav;
       document.head.appendChild(link);

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -63,7 +63,8 @@
         "metadata-retrieve.html",
         "explore-api.html",
         "limits.html",
-        "options.html"
+        "options.html",
+        "/images/favicons/*"
       ],
       "matches": ["https://*/*"],
       "extension_ids": []


### PR DESCRIPTION
## Describe your changes
Fix issue on summer24 when loading favicon

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] Target branch is releaseCandidate and not master
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

