### PR TITLE
[options] Add new option to hide buttons and start release 1.26

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.26
+
+- Add new options to hide buttons in popup
+
 ## Version 1.25
 
 - Fix `Field Creator` shortcut key [issue 608](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/608)

--- a/addon/manifest-template.json
+++ b/addon/manifest-template.json
@@ -1,8 +1,8 @@
 {
   "name": "Salesforce Inspector Reloaded",
   "description": "Productivity tools for Salesforce administrators and developers to inspect data and metadata directly from the Salesforce UI.",
-  "version": "1.25",
-  "version_name": "1.25",
+  "version": "1.26",
+  "version_name": "1.26",
   "icons": {
     "128": "icon128.png"
   },
@@ -10,7 +10,9 @@
     "default_title": "Open popup"
   },
   "minimum_chrome_version": "88",
-  "permissions": ["cookies"],
+  "permissions": [
+    "cookies"
+  ],
   "host_permissions": [
     "https://*.salesforce.com/*",
     "https://*.salesforce-setup.com/*",
@@ -50,8 +52,14 @@
         "https://*.builder.salesforce-experience.com/*"
       ],
       "all_frames": true,
-      "css": ["button.css", "inspect-inline.css"],
-      "js": ["button.js", "inspect-inline.js"]
+      "css": [
+        "button.css",
+        "inspect-inline.css"
+      ],
+      "js": [
+        "button.js",
+        "inspect-inline.js"
+      ]
     }
   ],
   "background": {
@@ -72,7 +80,9 @@
         "field-creator.html",
         "options.html"
       ],
-      "matches": ["https://*/*"],
+      "matches": [
+        "https://*/*"
+      ],
       "extension_ids": []
     }
   ],

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Salesforce Inspector Reloaded",
   "description": "Productivity tools for Salesforce administrators and developers to inspect data and metadata directly from the Salesforce UI.",
-  "version": "1.25",
-  "version_name": "1.25",
+  "version": "1.26",
+  "version_name": "1.26",
   "icons": {
     "128": "icon128.png"
   },
@@ -10,7 +10,9 @@
     "default_title": "Open popup"
   },
   "minimum_chrome_version": "88",
-  "permissions": ["cookies"],
+  "permissions": [
+    "cookies"
+  ],
   "host_permissions": [
     "https://*.salesforce.com/*",
     "https://*.salesforce-setup.com/*",
@@ -50,8 +52,14 @@
         "https://*.builder.salesforce-experience.com/*"
       ],
       "all_frames": true,
-      "css": ["button.css", "inspect-inline.css"],
-      "js": ["button.js", "inspect-inline.js"]
+      "css": [
+        "button.css",
+        "inspect-inline.css"
+      ],
+      "js": [
+        "button.js",
+        "inspect-inline.js"
+      ]
     }
   ],
   "background": {
@@ -73,7 +81,9 @@
         "options.html",
         "event-monitor.html"
       ],
-      "matches": ["https://*/*"],
+      "matches": [
+        "https://*/*"
+      ],
       "extension_ids": []
     }
   ],

--- a/addon/options.js
+++ b/addon/options.js
@@ -87,6 +87,14 @@ class OptionsTabSelector extends React.Component {
           {option: Option, props: {type: "toggle", title: "Search metadata from Shortcut tab", key: "metadataShortcutSearch"}},
           {option: Option, props: {type: "toggle", title: "Disable query input autofocus", key: "disableQueryInputAutoFocus"}},
           {option: Option, props: {type: "toggle", title: "Popup Dark theme", key: "popupDarkTheme"}},
+          {option: MultiCheckboxButtonGroup, props: {title: "Show buttons", key: "hideButtonsOption",
+            checkboxes: [
+              {label: "Explore API", name: "explore-api", checked: true },
+              {label: "Org Limits", name: "org-limits", checked: true },
+              {label: "Options", name: "options", checked: true },
+              {label: "Generate Access Token", name: "generate-token", checked: true }
+            ]}
+          },
           {option: Option, props: {type: "toggle", title: "Show 'Generate Access Token' button", key: "popupGenerateTokenButton", default: true}},
           {option: FaviconOption, props: {key: this.sfHost + "_customFavicon", tooltip: "You may need to add this domain to CSP trusted domains to see the favicon in Salesforce."}},
           {option: Option, props: {type: "toggle", title: "Use favicon color on sandbox banner", key: "colorizeSandboxBanner"}},
@@ -566,6 +574,69 @@ class FaviconOption extends React.Component {
         ),
         h("div", {className: "slds-form-element__control"},
           h("button", {className: "button button-brand", onClick: this.populateFaviconColors, title: "Use favicon for all orgs I've visited"}, "Populate All")
+        )
+      )
+    );
+  }
+}
+
+class MultiCheckboxButtonGroup extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
+
+    this.title = props.title;
+    this.storageKey = props.storageKey;
+
+    // Load checkboxes from localStorage or default to props.checkboxes
+    const storedCheckboxes = localStorage.getItem(this.storageKey) ? JSON.parse(localStorage.getItem(this.storageKey)) : [];
+
+    // Merge checkboxes only if the size is different
+    const mergedCheckboxes = storedCheckboxes.length === props.checkboxes.length
+      ? storedCheckboxes
+      : this.mergeCheckboxes(storedCheckboxes, props.checkboxes);
+
+    this.state = { checkboxes: mergedCheckboxes };
+    if (storedCheckboxes.length !== props.checkboxes.length) {
+      localStorage.setItem(this.storageKey, JSON.stringify(mergedCheckboxes)); // Save the merged state to localStorage
+    }
+  }
+
+  mergeCheckboxes = (storedCheckboxes, propCheckboxes) => {
+    return propCheckboxes.map((checkbox) => {
+      const storedCheckbox = storedCheckboxes.find((item) => item.name === checkbox.name);
+      return storedCheckbox || checkbox;
+    });
+  };
+
+  handleCheckboxChange = (event) => {
+    const { name, checked } = event.target;
+    const updatedCheckboxes = this.state.checkboxes.map((checkbox) =>
+      checkbox.name === name ? { ...checkbox, checked } : checkbox
+    );
+    localStorage.setItem(this.storageKey, JSON.stringify(updatedCheckboxes));
+    this.setState({ checkboxes: updatedCheckboxes });
+  };
+
+  render() {
+    return h("div", {className: "slds-grid slds-border_bottom slds-p-horizontal_small slds-p-vertical_xx-small"},
+      h("div", {className: "slds-col slds-size_4-of-12 text-align-middle"},
+        h("span", {}, this.title)
+      ),
+      h("div", {className: "slds-col slds-size_2-of-12 slds-form-element slds-grid slds-grid_align-end slds-grid_vertical-align-center slds-gutters_small"}),
+      h("div", {className: "slds-col slds-size_6-of-12 slds-form-element slds-grid slds-grid_align-end slds-grid_vertical-align-center slds-gutters_small"},
+        h("div", { className: "slds-form-element__control" },
+          h( "div", { className: "slds-checkbox_button-group" },
+            this.state.checkboxes.map((checkbox, index) =>
+              h( "span", { className: "slds-button slds-checkbox_button", key: index },
+                h("input", { type: "checkbox",  id: `unique-id-${checkbox.value}-${index}`, name: checkbox.name, checked: checkbox.checked, onChange: this.handleCheckboxChange, title: checkbox.title}),
+                h("label",  { className: "slds-checkbox_button__label",  htmlFor: `unique-id-${checkbox.value}-${index}`},
+                  h("span", { className: "slds-checkbox_faux" }, checkbox.label)
+                )
+              )
+            )
+          )
         )
       )
     );

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -84,7 +84,8 @@ class App extends React.PureComponent {
       eventMonitorHref: "event-monitor.html?" + hostArg,
       fieldCreatorHref: "field-creator.html?" + hostArg,
       limitsHref: "limits.html?" + hostArg,
-      latestNotesViewed: localStorage.getItem("latestReleaseNotesVersionViewed") === this.props.addonVersion || browser.extension.inIncognitoContext
+      latestNotesViewed: localStorage.getItem("latestReleaseNotesVersionViewed") === this.props.addonVersion || browser.extension.inIncognitoContext,
+      hideButtonsOption: JSON.parse(localStorage.getItem("hideButtonsOption"))
     };
     this.onContextUrlMessage = this.onContextUrlMessage.bind(this);
     this.onShortcutKey = this.onShortcutKey.bind(this);
@@ -210,6 +211,14 @@ class App extends React.PureComponent {
     url = `https://${sfHost}/services/oauth2/authorize?response_type=token&client_id=` + clientId + "&redirect_uri=" + browser + "-extension://" + chrome.i18n.getMessage("@@extension_id") + "/data-export.html";
     return {title, url, text};
   }
+  displayButton(name){
+    const button = this.state.hideButtonsOption.find((element) => element.name == name);
+    if(button){
+      return button.checked;
+    }
+    //if no option was found, display the button
+    return true;
+  }
   render() {
     let {
       sfHost,
@@ -301,9 +310,9 @@ class App extends React.PureComponent {
             h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "dataImportBtn", href: importHref, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "Data ", h("u", {}, "I"), "mport"))
             ),
-            h("div", {className: "slds-m-bottom_xx-small"},
+            this.displayButton("org-limits") ? h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "limitsBtn", href: limitsHref, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "Org ", h("u", {}, "L"), "imits"))
-            ),
+            ) : null,
             h("div", {},
               h("a", {ref: "fieldCreatorBtn", href: fieldCreatorHref, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "Field Crea", h("u", {}, "t"), "or (beta)"))
             ),
@@ -313,16 +322,16 @@ class App extends React.PureComponent {
             h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "metaRetrieveBtn", href: "metadata-retrieve.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, h("u", {}, "D"), "ownload Metadata"))
             ),
-            h("div", {className: "slds-m-bottom_xx-small"},
+            this.displayButton("explore-api") ? h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "apiExploreBtn", href: "explore-api.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "E", h("u", {}, "x"), "plore API"))
-            ),
+            ) : null,
             h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "restExploreBtn", href: "rest-explore.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, h("u", {}, "R"), "EST Explore"))
             ),
             h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "eventMonitorBtn", href: eventMonitorHref, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "Event ", h("u", {}, "M"), "onitor"))
             ),
-            localStorage.getItem("popupGenerateTokenButton") !== "false" ? h("div", {className: "slds-m-bottom_xx-small"},
+            this.displayButton("generate-token") ? h("div", {className: "slds-m-bottom_xx-small"},
               h("a",
                 {
                   ref: "generateToken",
@@ -357,11 +366,11 @@ class App extends React.PureComponent {
                 h("span", {}, "Setup ", h("u", {}, "H"), "ome")),
             ),
           ),
-          h("div", {className: "slds-p-vertical_x-small slds-p-horizontal_x-small"},
+          this.displayButton("options") ? h("div", {className: "slds-p-vertical_x-small slds-p-horizontal_x-small"},
             h("div", {className: "slds-m-bottom_xx-small"},
               h("a", {ref: "optionsBtn", href: "options.html?" + hostArg, target: linkTarget, className: "page-button slds-button slds-button_neutral"}, h("span", {}, "O", h("u", {}, "p"), "tions"))
             ),
-          )
+          ) : null
         ),
         h("div", {className: "slds-grid slds-theme_shade slds-p-around_x-small slds-border_top"},
           h("div", {className: "slds-col slds-size_4-of-12 footer-small-text slds-m-top_xx-small"},

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -325,3 +325,10 @@ Under `User Experience` tab, enable the option `Highlight PROD with a top border
 To export and import your current configuration, go to the options page and click the corresponding icon in the header:
 
 <img width="889" alt="Import / Export Configuration" src="https://github.com/user-attachments/assets/00428039-9b83-4c14-9a27-5e5034c52753">
+
+## Hide some buttons in the popup
+
+Since the extension offers more features, the number of button is increasing.
+Some of the users may don't need some of those, to make the popup lighter some of the buttons can be hidden:
+
+<img width="1024" alt="Hide Buttons" src="https://github.com/user-attachments/assets/50b4cb3c-7886-4b38-96a9-b5a6d93b69e6">


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
Fixes #618 
## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

