### PR TITLE
[show-all-data] Add calculated type for formula fiels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Restyle Org Limits [feature 626](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/626) request by [Vincent FINET](https://github.com/VinceFINET)
 - Add new options to hide buttons in popup [feature 618](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/618)
 - Added an option for Data Exporter to use local browser time [feature 527](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/527) (contribution by [David Moruzzi](https://github.com/dmoruzzi))
-- Add `calculated` to type column [feature 620](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/680) (contribution by [Lars Lipman](https://github.com/lrlip))
+- Add `calculated` to type column [feature 680](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/680) (contribution by [Lars Lipman](https://github.com/lrlip))
 
 ## Version 1.25
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Restyle Org Limits [feature 626](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/626) request by [Vincent FINET](https://github.com/VinceFINET)
 - Add new options to hide buttons in popup [feature 618](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/618)
 - Added an option for Data Exporter to use local browser time [feature 527](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/527) (contribution by [David Moruzzi](https://github.com/dmoruzzi))
+- Add `calculated` to type column [feature 620](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/680) (contribution by [Lars Lipman](https://github.com/lrlip))
 
 ## Version 1.25
 

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -668,7 +668,7 @@ class FieldRow extends TableRow {
         + (!fieldDescribe.nillable ? ", required" : "")
         + (fieldDescribe.restrictedPicklist ? ", restricted" : "")
         + (fieldDescribe.unique ? ", unique" : "")
-        + (fieldDescribe.calculated ? "*" : "");
+        + (fieldDescribe.calculated ? ", calculated" : "");
     }
     let particle = this.entityParticle;
     if (particle) {
@@ -685,7 +685,7 @@ class FieldRow extends TableRow {
         + (particle.IsHtmlFormatted ? ", html" : "")
         + (!particle.IsNillable ? ", required" : "")
         + (particle.IsUnique ? ", unique" : "")
-        + (particle.IsCalculated ? "*" : "");
+        + (particle.IsCalculated ? ", calculated" : "");
     }
     return undefined;
   }


### PR DESCRIPTION
## Add the `calculated` type for formula fields in the show-all-data 

## [#680](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/680)

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

