### PR TITLE
Fixed page reload before actual update on Enable Debug mode action

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1521,8 +1521,7 @@ class UserDetails extends React.PureComponent {
   enableDebugMode(user){
     sfConn.rest("/services/data/v" + apiVersion + "/sobjects/User/" + user.Id, {method: "PATCH",
       body: {UserPreferencesUserDebugModePref: !user.UserPreferencesUserDebugModePref
-      }}).then(
-      browser.runtime.sendMessage({message: "reloadPage"})
+      }}).then(() => browser.runtime.sendMessage({message: "reloadPage"})
     ).catch(err => console.log("Error during user debug mode activation", err));
   }
 


### PR DESCRIPTION
## Describe your changes
Updated call to page reload from instant call to call in callback after debug mode update

## Issue ticket number and link
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/718

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

