### PR TITLE
[field-creator] fix : remove special characters from API Name field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 - Add `calculated` to type column [feature 680](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/680) (contribution by [Lars Lipman](https://github.com/lrlip))
 - Fix LWC Debug mode force page refresh before User update [issue 718](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/718) (contribution by [Paul Kalinin](https://github.com/Paul-Kalynyn))
 - Fix `event-monitor` Error on Edge [issue 716](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/716) (contribution by [Paul Kalinin](https://github.com/Paul-Kalynyn))
+- - Fix remove special characters from API Name field [issue 728](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/728) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.25
 

--- a/addon/field-creator.js
+++ b/addon/field-creator.js
@@ -1318,18 +1318,13 @@ class App extends React.Component {
     const namingConvention = localStorage.getItem("fieldNamingConvention") || "pascal";
 
     // First, replace any special characters with underscores and convert to proper case
-    let apiName = label.trim().replace(/[^a-zA-Z0-9\s]/g, "_");
+    let apiName = label.trim().replace(/[&\/\\#, +()$~%.'":*?<>{}]/g, "_");
     if (namingConvention === "underscore") {
       // Convert spaces to underscores: "My Field Name" -> "My_Field_Name"
       apiName = apiName.replace(/\s+/g, "_");
-    } else {
-      // Remove underscores and convert to PascalCase: "My_Field_Name" -> "MyFieldName"
-      apiName = apiName.replace(/[\s_]+(\w)/g, (_, letter) => letter.toUpperCase());
     }
-    // Remove leading/trailing underscores
-    apiName = apiName.replace(/^_+|_+$/g, "");
-    // Replace multiple underscores with single underscore
-    return apiName.replace(/_+/g, "_");
+
+    return apiName.replace(/_{2,}/g, '_');
   }
 
   onLabelChange = (index, label) => {


### PR DESCRIPTION
## Describe your changes
Special characters handled incorrectly in field creator

![Image](https://github.com/user-attachments/assets/d1f8faec-8e18-418d-aac2-716acae491ae)

## Issue ticket number and link
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/728

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

