### PR TITLE
[feat] #806 :  Use nameField on Show All Data page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.27
 
+- `Show All Data` Use alternative field Name in the header (ie CaseNumber) [feature 806](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/806) request by [Mart](https://github.com/Mart-User)
 - Implement search on `Event Monitor` to filter on event details
 
 ## Version 1.26

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -40,6 +40,7 @@ class Model {
     this.objectSetupLinksRequested = false;
     this.popupTmpReactElement = undefined;
     this.popupReactElement = undefined;
+    this.recordName;
     let trialExpDate = localStorage.getItem(sfHost + "_trialExpirationDate");
     if (localStorage.getItem(sfHost + "_isSandbox") != "true" && (!trialExpDate || trialExpDate === "null")) {
       //change background color for production
@@ -82,7 +83,11 @@ class Model {
   recordHeading() {
     let parts;
     if (this.recordData) {
-      parts = [this.recordData.Name, this.recordData.Id];
+      if (!this.recordName){
+        let fieldName = this.recordData.Name ? "Name" : this.objectData.fields.find(field => field.nameField).name;
+        this.recordName = this.recordData[fieldName];
+      }
+      parts = [this.recordName, this.recordData.Id];
     } else if (this.objectData) {
       parts = [this.objectData.label, this.objectData.keyPrefix];
     } else {


### PR DESCRIPTION
## Describe your changes
For objects that have no "Name" field, use the one available in the metadata api "nameField":

<img width="778" alt="image" src="https://github.com/user-attachments/assets/d622de00-f3f0-4695-afab-1e0525fecec4" />


## Issue ticket number and link
#806 

## Checklist before requesting a review
- [ ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] Target branch is releaseCandidate and not master
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

