### PR TITLE
fix: Handle empty lines in picklist values for field creator (fixes #787)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 1.27
 
-- Fix empty lines in picklist values causing deployment errors in Field Creator [issue 787](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/787)
+- Fix empty lines in picklist values causing deployment errors in Field Creator [issue 787](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/787) (contribution by [Vivek Sharma](https://github.com/vicky773h))
 - Add `convertCurrency()` , `FORMAT()` and `GROUPING()` to autocomplete suggestions in Data Export [feature 818](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/818) request by [Hubert](https://github.com/dollarSignUsername)
 - Update sandbox banner feature to match with new AppDev Bar [feature 815](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/815)
 - Add refresh button on Org Limits and persist filter in url

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.27
 
+- Fix empty lines in picklist values causing deployment errors in Field Creator [issue 787](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/787)
 - Add `convertCurrency()` , `FORMAT()` and `GROUPING()` to autocomplete suggestions in Data Export [feature 818](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/818) request by [Hubert](https://github.com/dollarSignUsername)
 - Update sandbox banner feature to match with new AppDev Bar [feature 815](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/815)
 - Add refresh button on Org Limits and persist filter in url

--- a/addon/field-creator.js
+++ b/addon/field-creator.js
@@ -1089,10 +1089,14 @@ class App extends React.Component {
         newField.Metadata.valueSet = {
           valueSetDefinition: {
             sorted: field.sortalpha || false,
-            value: field.picklistvalues.split("\n").map((value, index) => ({
-              fullName: value.trim(),
-              default: field.firstvaluedefault && index === 0
-            }))
+            value: field.picklistvalues
+              .split("\n")
+              .map(value => value.trim())
+              .filter(value => value.length > 0)
+              .map((value, index) => ({
+                fullName: value,
+                default: field.firstvaluedefault && index === 0
+              }))
           }
         };
         if (field.type === "MultiselectPicklist") {


### PR DESCRIPTION
## Describe your changes
This PR fixes issue #787 where empty lines in picklist values were causing deployment errors in the Field Creator feature. The changes include:
- Modified picklist value processing in field-creator.js to:
  - Split values by newlines
  - Trim each value
  - Filter out empty values
  - Map remaining values to required format
- Updated CHANGES.md to document the fix

## Issue ticket number and link
Fixes #787

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)