### PR TITLE
Button View record in Salesforce has been moved to the main view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Version 1.27
 
-- `Data Export` Suggestions added for queries using IN clause on picklist fields [issue 892](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/892) (contribution by [Luca Bassani](https://github.com/baslu93))
+- `Show all data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
+- `Data Export` Suggestions added for queries using IN clause on picklist fields [feature 892](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/892) (contribution by [Luca Bassani](https://github.com/baslu93))
 - Support for multiple SOQL/SOSL tabs in `Data Export` [feature 132](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/132) (requested Erlend Hansen)
 - Add button in Option page to delete generated access token (cf [troubleshooting](https://tprouvot.github.io/Salesforce-Inspector-reloaded/troubleshooting/#generate-new-token-error))
 - Add option to configure default popup tab [feature 877](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/877) (requested by William Salomon)
@@ -25,9 +26,8 @@
 - Fix 'Query Record' not persisting the state of the 'Tooling Api' setting [issue 268](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/268) (contribution by [Kaustubh Dapurkar](https://github.com/kaustubhdapurkar))
 - `Show All Data` Use alternative field Name in the header (ie CaseNumber) [feature 806](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/806) request by [Mart](https://github.com/Mart-User)
 - Implement search on `Event Monitor` to filter on event details
-- Prevent selection of an API version higher than the latest available [issue 464](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/464) (contribution by [Salwa Hammou](https://github.com/SalwaHm))
+- Prevent selection of an API version higher than the latest available [feature 464](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/464) (contribution by [Salwa Hammou](https://github.com/SalwaHm))
 - Fix error propagation on rest 403 [issue 881](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/881) (contribution by [Sebastien Colladon](https://github.com/scolladon))
-- Button View record in Salesforce has been moved to the main view [issue 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Implement search on `Event Monitor` to filter on event details
 - Prevent selection of an API version higher than the latest available [issue 464](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/464) (contribution by [Salwa Hammou](https://github.com/SalwaHm))
 - Fix error propagation on rest 403 [issue 881](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/881) (contribution by [Sebastien Colladon](https://github.com/scolladon))
+- Button View record in Salesforce has been moved to the main view [issue 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.26
 

--- a/addon/inspect.css
+++ b/addon/inspect.css
@@ -126,31 +126,6 @@ a:hover {
   fill: white;
 }
 
-.sf-back,
-.sf-back:active,
-.sf-back:focus,
-.sf-back:hover{
-  background-color: rgb(6, 28, 63);
-  border-radius: 3px;
-  line-height: 1.8em;
-  text-decoration: none;
-  display: inline-block;
-  padding: 2px;
-  color: white;
-  margin-right: 4px;
-}
-
-.sf-back svg {
-  width: 1.8em;
-  height: 1.8em;
-  display: block;
-  margin: 1px;
-  float: left;
-  background-color: #62B7ED;
-  border-radius: 2px;
-  fill: white;
-}
-
 table {
   width: 100%;
   border-spacing: 0px;
@@ -469,7 +444,7 @@ th[tabindex] {
   width: 100%;
   display: flex;
   align-items: center;
-  padding: 0 4px;
+  padding: 0 12px;
   flex-wrap: wrap;
   border-bottom: 1px solid #d8dde6;
 }
@@ -780,4 +755,8 @@ th[tabindex] {
 .child-actions .pop-menu {
   right: 0;
   text-align: right;
+}
+.sf-nav-group > a.sf-back {
+  color: unset;
+  margin-right: 4px;
 }

--- a/addon/inspect.css
+++ b/addon/inspect.css
@@ -126,6 +126,31 @@ a:hover {
   fill: white;
 }
 
+.sf-back,
+.sf-back:active,
+.sf-back:focus,
+.sf-back:hover{
+  background-color: rgb(6, 28, 63);
+  border-radius: 3px;
+  line-height: 1.8em;
+  text-decoration: none;
+  display: inline-block;
+  padding: 2px;
+  color: white;
+  margin-right: 4px;
+}
+
+.sf-back svg {
+  width: 1.8em;
+  height: 1.8em;
+  display: block;
+  margin: 1px;
+  float: left;
+  background-color: #62B7ED;
+  border-radius: 2px;
+  fill: white;
+}
+
 table {
   width: 100%;
   border-spacing: 0px;
@@ -444,7 +469,7 @@ th[tabindex] {
   width: 100%;
   display: flex;
   align-items: center;
-  padding: 0 12px;
+  padding: 0 4px;
   flex-wrap: wrap;
   border-bottom: 1px solid #d8dde6;
 }

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -1211,6 +1211,7 @@ class App extends React.Component {
               )
             ),
             model.objectActionsOpen && h("div", {className: "pop-menu"},
+              model.viewLink() ? h("a", {href: model.viewLink()}, "View record in Salesforce") : null,
               model.editLayoutLink() ? h("a", {href: model.editLayoutLink(), target: linkTarget}, "Edit page layout") : null,
               model.objectSetupLinks && h("a", {href: model.objectSetupLinks.lightningSetupLink, target: linkTarget}, "Object setup (Lightning)"),
               model.objectSetupLinks && h("a", {href: model.objectSetupLinks.classicSetupLink, target: linkTarget}, "Object setup (Classic)")

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -1123,6 +1123,13 @@ class App extends React.Component {
               h("div", {className: "slds-spinner__dot-b"}),
             )
           ),
+          h("a", {href: model.viewLink(), title:"Back to Record", className: "sf-back"},
+            h("svg", {viewBox: "0 0 24 24"},
+              h("path", {
+                d: "M15 6l-6 6 6 6"
+              })
+            )
+          ),
           h("a", {href: model.sfLink, target: linkTarget, className: "sf-link"},
             h("svg", {viewBox: "0 0 24 24"},
               h("path", {d: "M18.9 12.3h-1.5v6.6c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-5.1h-3.6v5.1c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-6.6H5.1c-.1 0-.3-.1-.3-.2s0-.2.1-.3l6.9-7c.1-.1.3-.1.4 0l7 7v.3c0 .1-.2.2-.3.2z"})
@@ -1178,11 +1185,6 @@ class App extends React.Component {
             )
           ),
           h("span", {className: "object-actions"},
-            model.editMode == null && model.recordData && (model.useTab == "all" || model.useTab == "fields") ? h("button", {
-              title: "View record in Salesforce",
-              className: "button",
-              onClick: this.onGoToSalesforceRecord
-            }, "View record in Salesforce") : null,
             model.editMode == null && model.recordData && (model.useTab == "all" || model.useTab == "fields") ? h("button", {
               title: "Inline edit the values of this record",
               className: "button",

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -1123,18 +1123,18 @@ class App extends React.Component {
               h("div", {className: "slds-spinner__dot-b"}),
             )
           ),
-          h("a", {href: model.viewLink(), title:"Back to Record", className: "sf-back"},
-            h("svg", {viewBox: "0 0 24 24"},
-              h("path", {
-                d: "M15 6l-6 6 6 6"
-              })
-            )
-          ),
-          h("a", {href: model.sfLink, target: linkTarget, className: "sf-link"},
-            h("svg", {viewBox: "0 0 24 24"},
-              h("path", {d: "M18.9 12.3h-1.5v6.6c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-5.1h-3.6v5.1c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-6.6H5.1c-.1 0-.3-.1-.3-.2s0-.2.1-.3l6.9-7c.1-.1.3-.1.4 0l7 7v.3c0 .1-.2.2-.3.2z"})
+          h("div", {className: "sf-nav-group"},
+            h("a", {href: model.viewLink(), title: "Back to Record", className: "sf-back"},
+              h("svg", {className: "button-icon"},
+                h("use", {xlinkHref: "symbols.svg#back"})
+              )
             ),
-            " Salesforce Home"
+            h("a", {href: model.sfLink, title: "Salesforce Home", target: linkTarget, className: "sf-link"},
+              h("svg", {viewBox: "0 0 24 24"},
+                h("path", {d: "M18.9 12.3h-1.5v6.6c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-5.1h-3.6v5.1c0 .2-.1.3-.3.3h-3c-.2 0-.3-.1-.3-.3v-6.6H5.1c-.1 0-.3-.1-.3-.2s0-.2.1-.3l6.9-7c.1-.1.3-.1.4 0l7 7v.3c0 .1-.2.2-.3.2z"})
+              ),
+              " Salesforce Home"
+            )
           ),
           h("span", {className: "object-tab" + (model.useTab == "all" ? " active-tab" : "")},
             h("a", {href: "about:blank", onClick: this.onUseAllTab}, "All")

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -1084,6 +1084,9 @@ class App extends React.Component {
     model.didUpdate();
     // Save to local storage
   }
+  onGoToSalesforceRecord(){
+    history.back();
+  }
   handleClick(e){
     const {model} = this.props;
     if (model.popupReactElement){ // There is a popup
@@ -1176,6 +1179,11 @@ class App extends React.Component {
           ),
           h("span", {className: "object-actions"},
             model.editMode == null && model.recordData && (model.useTab == "all" || model.useTab == "fields") ? h("button", {
+              title: "View record in Salesforce",
+              className: "button",
+              onClick: this.onGoToSalesforceRecord
+            }, "View record in Salesforce") : null,
+            model.editMode == null && model.recordData && (model.useTab == "all" || model.useTab == "fields") ? h("button", {
               title: "Inline edit the values of this record",
               className: "button",
               disabled: !model.canUpdate(),
@@ -1201,7 +1209,6 @@ class App extends React.Component {
               )
             ),
             model.objectActionsOpen && h("div", {className: "pop-menu"},
-              model.viewLink() ? h("a", {href: model.viewLink()}, "View record in Salesforce") : null,
               model.editLayoutLink() ? h("a", {href: model.editLayoutLink(), target: linkTarget}, "Edit page layout") : null,
               model.objectSetupLinks && h("a", {href: model.objectSetupLinks.lightningSetupLink, target: linkTarget}, "Object setup (Lightning)"),
               model.objectSetupLinks && h("a", {href: model.objectSetupLinks.classicSetupLink, target: linkTarget}, "Object setup (Classic)")


### PR DESCRIPTION
## Describe your changes
The button from the drop-down menu has been moved to the main view.

![Preview](https://github.com/user-attachments/assets/fde7abd8-d3c9-45f0-ab8f-cdb23013e437)


## Issue ticket number and link
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

