### PR TITLE
Limit number of polymorphic reference types displayed in 'Show All Data' tooltip (fixes #865)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,6 @@
 - Fix: Enable popup actions for records identified only by DurableId (e.g., FlowDefinitionView) [issue 441](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/441) (contribution by [Tushar Dangayach](https://github.com/rockstartushar))
 - `Show All Data` Analyze field usage by showing the percentage of records that have a value for each field.
 - `Show All Data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
-
-- `Show all Data` Analyze field usage by showing the percentage of records that have a value for each field.
-- `Show all Data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - `Data Export` Suggestions added for queries using IN clause on picklist fields [feature 892](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/892) (contribution by [Luca Bassani](https://github.com/baslu93))
 - Support for multiple SOQL/SOSL tabs in `Data Export` [feature 132](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/132) (requested Erlend Hansen)
 - Add button in Option page to delete generated access token (cf [troubleshooting](https://tprouvot.github.io/Salesforce-Inspector-reloaded/troubleshooting/#generate-new-token-error))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,14 @@
 # Release Notes
 
-## [Unreleased]
-
-- `Show All Data` Limit polymorphic reference types shown to 5 with "Show more" / "Show less" toggle in the field details tooltip
-
 ## Version 1.27
 
-- `Show all data` Analyze field usage by showing the percentage of records that have a value for each field.
-- `Show all data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
+- `Show All Data` Limit polymorphic reference types shown to 5 with "Show more" / "Show less" toggle in the field details tooltip [feature 865](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/865) (contribution by [Tushar Dangayach](https://github.com/rockstartushar))
+- Fix: Enable popup actions for records identified only by DurableId (e.g., FlowDefinitionView) [issue 441](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/441) (contribution by [Tushar Dangayach](https://github.com/rockstartushar))
+- `Show All Data` Analyze field usage by showing the percentage of records that have a value for each field.
+- `Show All Data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
+
+- `Show all Data` Analyze field usage by showing the percentage of records that have a value for each field.
+- `Show all Data` Add 'back to record' button [feature 884](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/884) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - `Data Export` Suggestions added for queries using IN clause on picklist fields [feature 892](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/892) (contribution by [Luca Bassani](https://github.com/baslu93))
 - Support for multiple SOQL/SOSL tabs in `Data Export` [feature 132](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/132) (requested Erlend Hansen)
 - Add button in Option page to delete generated access token (cf [troubleshooting](https://tprouvot.github.io/Salesforce-Inspector-reloaded/troubleshooting/#generate-new-token-error))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [Unreleased]
+
+- `Show All Data` Limit polymorphic reference types shown to 5 with "Show more" / "Show less" toggle in the field details tooltip
+
 ## Version 1.27
 
 - `Show all data` Analyze field usage by showing the percentage of records that have a value for each field.

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -2021,27 +2021,41 @@ class FieldValueCell extends React.Component {
 class FieldTypeCell extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { expanded: false };
+    this.state = {expanded: false};
     this.toggleExpanded = this.toggleExpanded.bind(this);
   }
 
   toggleExpanded() {
-    this.setState(prev => ({ expanded: !prev.expanded }));
+    this.setState(prev => ({expanded: !prev.expanded}));
   }
 
   render() {
-    let { row, col } = this.props;
-    const { expanded } = this.state;
-    const referenceTypes = row.referenceTypes?.() || [];
+    let {row, col} = this.props;
+    const {expanded} = this.state;
+    let referenceTypes = row.referenceTypes?.() || [];
+    if (referenceTypes.length > 1 && row.dataTypedValue && row.rowList.model.globalDescribe){
+      // Get the first 3 characters of the ID (the keyPrefix)
+      const dataKeyPrefix = row.dataTypedValue.substring(0, 3);
 
-    const maxToShow = 5;
+      // Find the matching object from globalDescribe
+      const matchingObject = row.rowList.model.globalDescribe?.sobjects?.find(
+        sobject => sobject.keyPrefix === dataKeyPrefix
+      );
+
+      // If we found a matching object, filter referenceTypes to only include it
+      if (matchingObject) {
+        referenceTypes = [matchingObject.name];
+      }
+    }
+
+    const maxToShow = 3;
     const showAll = expanded || referenceTypes.length <= maxToShow;
     const visible = showAll ? referenceTypes : referenceTypes.slice(0, maxToShow);
     const remainingCount = referenceTypes.length - visible.length;
 
     const links = visible.map((data) =>
-      h("span", { key: data },
-        h("a", { href: row.showReferenceUrl(data) }, data),
+      h("span", {key: data},
+        h("a", {href: row.showReferenceUrl(data)}, data),
         " "
       )
     );
@@ -2052,7 +2066,7 @@ class FieldTypeCell extends React.Component {
         h("a", {
           className: "text-muted",
           onClick: this.toggleExpanded,
-          style: { cursor: "pointer", marginLeft: "5px" }
+          style: {cursor: "pointer", marginLeft: "5px"}
         }, `+${remainingCount} more`)
       );
     }
@@ -2063,19 +2077,17 @@ class FieldTypeCell extends React.Component {
         h("a", {
           className: "text-muted",
           onClick: this.toggleExpanded,
-          style: { cursor: "pointer", marginLeft: "5px" }
+          style: {cursor: "pointer", marginLeft: "5px"}
         }, "Show less")
       );
     }
 
-    return h("td", { className: col.className + " quick-select" },
+    return h("td", {className: col.className + " quick-select"},
       links,
-      referenceTypes.length === 0 ? h(TypedValue, { value: row.sortKey(col.name) }) : null
+      referenceTypes.length === 0 ? h(TypedValue, {value: row.sortKey(col.name)}) : null
     );
   }
 }
-
-
 
 class FieldUsageCell extends React.Component {
   constructor(props) {

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -2019,16 +2019,63 @@ class FieldValueCell extends React.Component {
 }
 
 class FieldTypeCell extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { expanded: false };
+    this.toggleExpanded = this.toggleExpanded.bind(this);
+  }
+
+  toggleExpanded() {
+    this.setState(prev => ({ expanded: !prev.expanded }));
+  }
+
   render() {
-    let {row, col} = this.props;
-    return h("td", {className: col.className + " quick-select"},
-      row.referenceTypes() ? row.referenceTypes().map(data =>
-        h("span", {key: data}, h("a", {href: row.showReferenceUrl(data)}, data), " ")
-      ) : null,
-      !row.referenceTypes() ? h(TypedValue, {value: row.sortKey(col.name)}) : null
+    let { row, col } = this.props;
+    const { expanded } = this.state;
+    const referenceTypes = row.referenceTypes?.() || [];
+
+    const maxToShow = 5;
+    const showAll = expanded || referenceTypes.length <= maxToShow;
+    const visible = showAll ? referenceTypes : referenceTypes.slice(0, maxToShow);
+    const remainingCount = referenceTypes.length - visible.length;
+
+    const links = visible.map((data) =>
+      h("span", { key: data },
+        h("a", { href: row.showReferenceUrl(data) }, data),
+        " "
+      )
+    );
+
+    // +X more link
+    if (!showAll && remainingCount > 0) {
+      links.push(
+        h("a", {
+          className: "text-muted",
+          onClick: this.toggleExpanded,
+          style: { cursor: "pointer", marginLeft: "5px" }
+        }, `+${remainingCount} more`)
+      );
+    }
+
+    // Show less link
+    if (expanded && referenceTypes.length > maxToShow) {
+      links.push(
+        h("a", {
+          className: "text-muted",
+          onClick: this.toggleExpanded,
+          style: { cursor: "pointer", marginLeft: "5px" }
+        }, "Show less")
+      );
+    }
+
+    return h("td", { className: col.className + " quick-select" },
+      links,
+      referenceTypes.length === 0 ? h(TypedValue, { value: row.sortKey(col.name) }) : null
     );
   }
 }
+
+
 
 class FieldUsageCell extends React.Component {
   constructor(props) {


### PR DESCRIPTION
## Describe your changes
This PR implements a toggle display for polymorphic reference types in the "Show All Data" view. When a field has more than 5 referenceTo types, only the first 5 are shown along with a "+X more" link. Clicking the link expands to show the full list with a "Show less" option.
Collapsed View(Default):
<img width="1915" height="571" alt="Screenshot 2025-07-13 131824" src="https://github.com/user-attachments/assets/e097a265-7340-455b-8f57-227b701ca8a1" />
Expanded View:
<img width="1918" height="712" alt="Screenshot 2025-07-13 132024" src="https://github.com/user-attachments/assets/c55b3bc3-fe7b-455a-a7f2-53dbd49378d9" />

This improves readability and user experience when dealing with polymorphic fields like WhoId, WhatId, etc.
## Issue ticket number and link
Fixes [#865](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/865)
## Checklist before requesting a review
- [ Done] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ Done] Target branch is releaseCandidate and not master
- [ Done] I have performed a self-review of my code
- [ Done but] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests but their is a problem i got, surely it is not because of my PR it is failing in releaseCandidate as well the same way.
- [Done ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

****