### PR TITLE
fix: Enable popup links for DurableId-only records like FlowDefinitionView (Fixes #441)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## [Unreleased]
+- Fix: Enable popup actions (Copy Id, View in Salesforce, etc.) for records identified only by DurableId (e.g., FlowDefinitionView) [#441]
+
 ## Version 1.27
 
 - `Show all data` Analyze field usage by showing the percentage of records that have a value for each field.

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -170,102 +170,127 @@ function renderCell(rt, cell, td) {
       td.appendChild(pop);
       let {objectTypes, recordId} = recordInfo();
       let objectType = undefined;
-      function setLinks(){
-        let aShow = document.createElement("a");
-        let args = new URLSearchParams();
-        args.set("host", rt.sfHost);
-        args.set("objectType", objectType);
-        if (rt.isTooling) {
-          args.set("useToolingApi", "1");
+      function setLinks(linkOptions = { isCopy: true, isQueryRecord: true, isShowAllData: true, isViewInSalesforce: true }) {
+        // Show All Data link
+        if (linkOptions.isShowAllData) {
+          let aShow = document.createElement("a");
+          let args = new URLSearchParams();
+          args.set("host", rt.sfHost);
+          args.set("objectType", objectType);
+          if (rt.isTooling) {
+            args.set("useToolingApi", "1");
+          }
+          if (recordId) {
+            args.set("recordId", recordId);
+          }
+          aShow.href = "inspect.html?" + args;
+          aShow.target = "_blank";
+          aShow.textContent = "Show all data";
+          aShow.className = "view-inspector";
+          let aShowIcon = document.createElement("div");
+          aShowIcon.className = "icon";
+          pop.appendChild(aShow);
+          aShow.prepend(aShowIcon);
         }
-        if (recordId) {
-          args.set("recordId", recordId);
-        }
-        aShow.href = "inspect.html?" + args;
-        aShow.target = "_blank";
-        aShow.textContent = "Show all data";
-        aShow.className = "view-inspector";
-        let aShowIcon = document.createElement("div");
-        aShowIcon.className = "icon";
-        pop.appendChild(aShow);
-        aShow.prepend(aShowIcon);
 
-        //Query Record
-        let aQuery = document.createElement("a");
-        let query = "SELECT Id FROM " + objectType + " WHERE Id = '" + recordId + "'";
-        let queryArgs = new URLSearchParams();
-        if (rt.isTooling) {
-          queryArgs.set("useToolingApi", "1");
+        // Query Record link
+        if (linkOptions.isQueryRecord) {
+          let aQuery = document.createElement("a");
+          let query = "SELECT Id FROM " + objectType + " WHERE Id = '" + recordId + "'";
+          let queryArgs = new URLSearchParams();
+          if (rt.isTooling) {
+            queryArgs.set("useToolingApi", "1");
+          }
+          queryArgs.set("host", rt.sfHost);
+          queryArgs.set("query", query);
+          aQuery.href = "data-export.html?" + queryArgs;
+          aQuery.target = "_blank";
+          aQuery.textContent = "Query Record";
+          aQuery.className = "query-record";
+          let aQueryIcon = document.createElement("div");
+          aQueryIcon.className = "icon";
+          pop.appendChild(aQuery);
+          aQuery.prepend(aQueryIcon);
         }
-        queryArgs.set("host", rt.sfHost);
-        queryArgs.set("query", query);
-        aQuery.href = "data-export.html?" + queryArgs;
-        aQuery.target = "_blank";
-        aQuery.textContent = "Query Record";
-        aQuery.className = "query-record";
-        let aqueryIcon = document.createElement("div");
-        aqueryIcon.className = "icon";
-        pop.appendChild(aQuery);
-        aQuery.prepend(aqueryIcon);
 
-        // If the recordId ends with 0000000000AAA it is a dummy ID such as the ID for the master record type 012000000000000AAA
-        if (recordId && isRecordId(recordId) && !recordId.endsWith("0000000000AAA")) {
+        // View in Salesforce link
+        if (linkOptions.isViewInSalesforce && recordId && isRecordId(recordId) && !recordId.endsWith("0000000000AAA")) {
           let aView = document.createElement("a");
           aView.href = "https://" + rt.sfHost + "/" + recordId;
           aView.target = "_blank";
           aView.textContent = "View in Salesforce";
           aView.className = "view-salesforce";
-          let aviewIcon = document.createElement("div");
-          aviewIcon.className = "icon";
+          let aViewIcon = document.createElement("div");
+          aViewIcon.className = "icon";
           pop.appendChild(aView);
-          aView.prepend(aviewIcon);
+          aView.prepend(aViewIcon);
         }
 
-        //Download event logFile
-        if (isEventLogFile(recordId)) {
-          let aDownload = document.createElement("a");
-          aDownload.id = recordId;
-          aDownload.target = "_blank";
-          aDownload.textContent = "Download File";
-          aDownload.className = "download-salesforce";
-          let aDownloadIcon = document.createElement("div");
-          aDownloadIcon.className = "icon";
-          pop.appendChild(aDownload);
-          aDownload.prepend(aDownloadIcon);
-          aDownload.addEventListener("click", e => {
-            sfConn.rest(e.target.id, {responseType: "text/csv"}).then(data => {
-              let downloadLink = document.createElement("a");
-              downloadLink.download = recordId.split("/")[6];
-              downloadLink.href = "data:text/csv;charset=utf-8," + data;
-              downloadLink.click();
+        // Download Event Log or Copy Id
+        if (linkOptions.isCopy) {
+          if (isEventLogFile(recordId)) {
+            let aDownload = document.createElement("a");
+            aDownload.id = recordId;
+            aDownload.target = "_blank";
+            aDownload.textContent = "Download File";
+            aDownload.className = "download-salesforce";
+            let aDownloadIcon = document.createElement("div");
+            aDownloadIcon.className = "icon";
+            pop.appendChild(aDownload);
+            aDownload.prepend(aDownloadIcon);
+            aDownload.addEventListener("click", e => {
+              sfConn.rest(e.target.id, { responseType: "text/csv" }).then(data => {
+                let downloadLink = document.createElement("a");
+                downloadLink.download = recordId.split("/")[6];
+                downloadLink.href = "data:text/csv;charset=utf-8," + data;
+                downloadLink.click();
+              });
+              td.removeChild(pop);
             });
-            td.removeChild(pop);
-          });
-        } else {
-          //copy to clipboard
-          let aCopy = document.createElement("a");
-          aCopy.className = "copy-id";
-          aCopy.textContent = "Copy Id";
-          aCopy.id = recordId;
-          let acopyIcon = document.createElement("div");
-          acopyIcon.className = "icon";
-          pop.appendChild(aCopy);
-          aCopy.prepend(acopyIcon);
-          aCopy.addEventListener("click", e => {
-            navigator.clipboard.writeText(e.target.id);
-            td.removeChild(pop);
-          });
+          } else {
+            let aCopy = document.createElement("a");
+            aCopy.className = "copy-id";
+            aCopy.textContent = "Copy Id";
+            aCopy.id = recordId;
+            let aCopyIcon = document.createElement("div");
+            aCopyIcon.className = "icon";
+            pop.appendChild(aCopy);
+            aCopy.prepend(aCopyIcon);
+            aCopy.addEventListener("click", e => {
+              navigator.clipboard.writeText(e.target.id);
+              td.removeChild(pop);
+            });
+          }
         }
       }
-      if (objectTypes.length === 1){
+      const defaultOptions = {
+        isCopy: true,
+        isQueryRecord: true,
+        isShowAllData: true,
+        isViewInSalesforce: true
+      };
+
+      if (objectTypes.length === 1 && objectTypes[0] !== "Unknown") {
         objectType = objectTypes[0];
-        setLinks();
-      } else {
+        setLinks(defaultOptions);
+      } else if (recordId && isRecordId(recordId)) {
         sfConn.rest(`/services/data/v${apiVersion}/ui-api/records/${recordId}?layoutTypes=Compact`).then(res => {
           objectType = res.apiName;
-          setLinks();
+          setLinks(defaultOptions);
+        }).catch(err => {
+          objectType = null;
+          defaultOptions.isQueryRecord = false;
+          defaultOptions.isShowAllData = false;
+          setLinks(defaultOptions);
         });
+      } else {
+        defaultOptions.isQueryRecord = false;
+        defaultOptions.isShowAllData = false;
+        objectType = null;
+        setLinks(defaultOptions);
       }
+
+
       function closer(ev) {
         if (ev != e && ev.target.closest(".pop-menu") != pop) {
           removeEventListener("click", closer);
@@ -278,11 +303,12 @@ function renderCell(rt, cell, td) {
     td.appendChild(a);
   }
   function isRecordId(recordId) {
-    // We assume a string is a Salesforce ID if it is 18 characters,
-    // contains only alphanumeric characters,
-    // the record part (after the 3 character object key prefix and 2 character instance id) starts with at least four zeroes,
-    // and the 3 character object key prefix is not all zeroes.
-    return /^[a-z0-9]{5}0000[a-z0-9]{9}$/i.exec(recordId) && !recordId.startsWith("000");
+    return typeof recordId === "string" &&
+         /^[a-zA-Z0-9]{15,18}$/.test(recordId) &&
+         /^[0-9a-zA-Z]{3}/.test(recordId) &&
+         !recordId.startsWith("000") &&
+         !/[^a-zA-Z0-9]/.test(recordId) &&
+         /[0-9]/.test(recordId.slice(0, 5));
   }
   function isEventLogFile(text) {
     // test the text to identify if this is a path to an eventLogFile


### PR DESCRIPTION
## Describe your changes

This PR fixes a bug where popup links were not being shown for certain Salesforce records that use `DurableId` instead of standard 18-character `Id`s (e.g., `FlowDefinitionView`, `StudentFeeCheck`, etc.).

### Key Enhancements:
- Updated `isRecordId` logic to allow matching IDs with `DurableId` patterns (e.g., starting with `300`, `005`, etc.).
- `setLinks` method now accepts a config parameter to control visibility of individual links:
  ```js
  {
    isCopy: true,
    isQueryRecord: false,
    isViewInSalesforce: true,
    isDownload: false
  }
  ```
- All four link types (Copy Id, View in Salesforce, Query Record, Download File) are now conditionally rendered based on that config.
- Ensures proper behavior even when `objectType` cannot be resolved.

---

## Issue ticket number and link

Fixes [#441](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/441)

---

## Checklist before requesting a review

- [Done] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)  
- [Done] Target branch is `releaseCandidate` and not `master`  
- [Done] I have performed a self-review of my code  
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests  
  ⚠️ *Note: One known failure exists in `releaseCandidate` branch related to test import queue count; unrelated to this PR.*  
- [Done] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions  
- [ ] I added a new section in [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) *(optional)*
