### PR TITLE
Improved fetch object name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Version 1.27
 
 - `Show All Data` Save fields selection [feature 914](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/914)
+- `Show all data` Fix error with loading after open [issue 925](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/925) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - Fix 'unexpected query key(s): cache' error in REST Explore [issue 909](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/909) issued by [Martin Krchnak](https://github.com/mascot4m)
 - `Show All Data` Limit polymorphic reference types shown to 5 with "Show more" / "Show less" toggle in the field details tooltip [feature 865](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/865) (contribution by [Tushar Dangayach](https://github.com/rockstartushar))
 - Fix: Enable popup actions for records identified only by DurableId (e.g., FlowDefinitionView) [issue 441](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/441) (contribution by [Tushar Dangayach](https://github.com/rockstartushar))

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -88,7 +88,7 @@ class Model {
     let parts;
     if (this.recordData) {
       if (!this.recordName){
-        let fieldName = this.recordData.Name ? "Name" : (this.objectData?.fields.find(field => field.nameField)?.name || "Id");
+        let fieldName = this.recordData.Name ? "Name" : this.recordData.attributes.type;
         this.recordName = this.recordData[fieldName];
       }
       parts = [this.recordName, this.recordData.Id];


### PR DESCRIPTION
## Describe your changes
When retrieving data using REST, there is always a list of attributes with the object type, from which you can safely retrieve its name.
## Issue ticket number and link
[bug]: ALL DATA for CaseMilestone doesn't load https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/925
## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

