### PR TITLE
Field creator improve UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Implement search on `Event Monitor` to filter on event details
 - Prevent selection of an API version higher than the latest available [feature 464](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/464) (contribution by [Salwa Hammou](https://github.com/SalwaHm))
 - Fix error propagation on rest 403 [issue 881](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/881) (contribution by [Sebastien Colladon](https://github.com/scolladon))
+- Improvement of the modal interface for Options in the Field Creator (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.26
 

--- a/addon/field-creator.css
+++ b/addon/field-creator.css
@@ -64,13 +64,14 @@ body {
 #user-info span {
   font-size: 1em;}
 .input-textBox{
-  width: 335px;
+  width: 100%;
     font-family: inherit;
     padding: 5px 13px;
     border: 1px solid #DDDBDA;
     border-radius: 0.25rem;
     height: 32px;
-    position: relative;}
+    position: relative;
+    margin-top: 4px;}
 .firstHeader{
   overflow-y: clip;
     min-height: 130px;}
@@ -128,7 +129,8 @@ textarea {
   font-size: 0.9rem;
   padding: 8px 10px;
   border-radius: 0.25rem;
-  border: 1px solid #DDDBDA;}
+  border: 1px solid #DDDBDA;
+  margin-top: 4px;}
 .fieldsLink:visited {
   color: rgb(0, 0, 238)}
 textarea[hidden] {

--- a/addon/field-creator.css
+++ b/addon/field-creator.css
@@ -232,7 +232,8 @@ input[type=save] {
   padding-left: 35px;}
 input[type="checkbox"] {
   width: 1rem;
-  height: 1rem;}
+  height: 1rem;
+  margin-right: 5px;}
 textarea:not([readonly]):focus,
 button:active,
 button:focus,
@@ -703,3 +704,6 @@ button.toggle .button-icon {
 .verticalAlignMiddle { vertical-align: middle;}
 .fontSize20 { font-size: 20px;}
 .btn100 { width: 100%;}
+.centerHorizontally {
+    display:flex;
+    align-items:center;}

--- a/addon/field-creator.js
+++ b/addon/field-creator.js
@@ -628,7 +628,7 @@ class FieldOptionModal extends React.Component {
   renderRequiredCheckbox = () => {
     const {field} = this.state;
     return h("div", {className: "checkbox"},
-      h("label", null,
+      h("label", {className: "centerHorizontally"},
         h("input", {
           type: "checkbox",
           id: "required",
@@ -636,7 +636,7 @@ class FieldOptionModal extends React.Component {
           checked: field.required,
           onChange: this.handleInputChange
         }),
-        " Required"
+        "Required"
       )
     );
   };
@@ -644,7 +644,7 @@ class FieldOptionModal extends React.Component {
   renderUniqueCheckbox = () => {
     const {field} = this.state;
     return h("div", {className: "checkbox"},
-      h("label", null,
+      h("label", {className: "centerHorizontally"},
         h("input", {
           type: "checkbox",
           id: "unique",
@@ -652,7 +652,7 @@ class FieldOptionModal extends React.Component {
           checked: field.uniqueSetting,
           onChange: this.handleInputChange
         }),
-        " Unique"
+        "Unique"
       )
     );
   };
@@ -660,7 +660,7 @@ class FieldOptionModal extends React.Component {
   renderExternalIdCheckbox = () => {
     const {field} = this.state;
     return h("div", {className: "checkbox"},
-      h("label", null,
+      h("label", {className: "centerHorizontally"},
         h("input", {
           type: "checkbox",
           id: "externalId",
@@ -668,7 +668,7 @@ class FieldOptionModal extends React.Component {
           checked: field.external,
           onChange: this.handleInputChange
         }),
-        " External ID"
+        "External ID"
       )
     );
   };

--- a/addon/field-creator.js
+++ b/addon/field-creator.js
@@ -686,13 +686,12 @@ class FieldOptionModal extends React.Component {
       className: "modal-dialog maxWidth500 maxHeight90vh overflowYAuto",
       onClick: (e) => e.stopPropagation()
     },
-    h("div", {className: "modal-content borderNone backgroundTransparent"},
-      h("div", {className: "modal-header borderBottomNone padding0_0_10_0 relativePosition"},
-        h("h4", {className: "modal-title textAlignCenter width100 margin0"}, "Set Field Options"),
+    h("div", {className: "modal-content relativePosition height100 flexColumn"},
+      h("div", {className: "modal-header flexSpaceBetween alignItemsCenter"},
+        h("h1", {className: "modal-title"}, "Set Field Options"),
         h("button", {
-          "aria-label": "Close Button",
-          type: "button",
-          className: "close absoluteRightTop backgroundTransparent borderNone fontSize1_5 fontWeightBold cursorPointer",
+          type: "button","aria-label": "Close Set Field Options",
+          className: "close cursorPointer backgroundNone borderNone fontSize1_5 fontWeightBold",
           onClick: this.props.onClose
         },
         h("span", {"aria-hidden": "true"}, "×")


### PR DESCRIPTION
## Describe your changes
Improvement of the modal interface for Options in the Field Creator.
What has been changed:
- Uniform appearance of the modal header for Options and Permissions 
- Increased margin between labels and text area
- Vertical centering of the checkbox section

<img width="509" height="518" alt="Options_Modal" src="https://github.com/user-attachments/assets/0e1b70ae-6339-4312-abb6-1ea83622c88b" />


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

