### PR TITLE
Allows User to Unfreeze users from User Tab.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## Version 1.27
-
+- Unfreeze User from User tab
 - Fix sandbox banner colorization for Winter 26 changes
 - `Show All Data` Save fields selection [feature 914](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/914)
 - Fix 'unexpected query key(s): cache' error in REST Explore [issue 909](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/909) issued by [Martin Krchnak](https://github.com/mascot4m)

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1617,15 +1617,10 @@ class UserDetails extends React.PureComponent {
     ).catch(err => console.log("Error during user debug mode activation", err));
   }
 
-  async unfreezeUser(user){
-    try {
-      await sfConn.rest("/services/data/v" + apiVersion + "/sobjects/UserLogin/" + user.UserLogins?.records?.[0].Id, {method: "PATCH",
+   unfreezeUser(user){
+       sfConn.rest("/services/data/v" + apiVersion + "/sobjects/UserLogin/" + user.UserLogins?.records?.[0]?.Id, {method: "PATCH",
         body: {IsFrozen: false} 
-      });
-    } catch (e) {
-      console.error(e);
-      return null;
-    }
+      }).catch(err => console.log("Error during user unfreeze", err));
   }
 
   toggleMenu(){
@@ -1636,7 +1631,11 @@ class UserDetails extends React.PureComponent {
     this.refs.logButtonMenu.classList.toggle("slds-is-open");
   }
 
-  toggleDetailsMenu(){
+  toggleLogMenu(){
+    this.refs.logButtonMenu.classList.toggle("slds-is-open");
+  }
+
+    toggleDetailsMenu(){
     this.refs.detailsButtonMenu.classList.toggle("slds-is-open");
   }
 


### PR DESCRIPTION
## Describe your changes
When we try to login as user and if the user is frozen, we should again go to the user detail page and unfreeze and then login as. This change will show a drop down box if the user is frozen, and when we click unfreeze, it will unfreeze the user.

Frozen User:
<img width="257" height="164" alt="image" src="https://github.com/user-attachments/assets/52b095eb-c1b4-4fd2-a826-b1ec7eb9f04b" />

Unfrozen User
<img width="248" height="120" alt="image" src="https://github.com/user-attachments/assets/605e36d3-1455-435d-803a-7628771ca4cf" />

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests - 
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

