### PR TITLE
[feat] Add new header for allowing users to defined upsert updateOnly parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.28
 
+- Add new header for allowing users to defined upsert updateOnly parameter in Data Import [feature 955](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/955) request by [Alexandre Bousquet](https://github.com/aleb33)
 - `Data Export` Allow users to reorganize and edit query tabs names [feature 950](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/950) request by [Scott Shapiro](https://github.com/sshapiro-articulate)
 - `Show All Data` Support keyboard shortcut to save edited record values [feature 951](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/951) request by [Mohak Gaur](https://github.com/mohakgaurrr)
 

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -23,7 +23,8 @@ const allActions = [
 const headersTemplates = [
   '{"OwnerChangeOptions": {"options": [{"type": "KeepAccountTeam", "execute": true}]}}',
   '{"AssignmentRuleHeader": {"useDefaultRule": true}}',
-  '{"DuplicateRuleHeader": {"allowSave": true}}'
+  '{"DuplicateRuleHeader": {"allowSave": true}}',
+  '{"UpdateHeader": {"updateOnly": true}}'
 ];
 
 class Model {

--- a/docs/data-import.md
+++ b/docs/data-import.md
@@ -21,6 +21,11 @@ If true for a Case or Lead, uses the default (active) assignment rule for a Case
   '{"AssignmentRuleHeader": {"useDefaultRule": true}}',
 ```
 
+For the upsert method, you can define a particular header to prevent the creation of new records and only perform updates:
+``` json
+  '{"UpdateHeader": {"updateOnly": true}}'
+```
+
 <img width="503" alt="SOAP Custom Headers" src="https://github.com/user-attachments/assets/e2d21970-ddc5-4c42-a54e-ffb7ffdcb278">
 
 ## Grey out skipped columns in data import


### PR DESCRIPTION
## Describe your changes
Add new header for allowing users to defined upsert updateOnly parameter in Data Import

## Issue ticket number and link
#955 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

