### PR TITLE
fix: Flow Scrolling in flow builder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- Fix flow scrolling feature by [Camille Guillory](https://github.com/CamilleGuillory) [issue #837](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/837)
 - `Flow Scanner` Implement 'Purge' old flow versions by [Camille Guillory](https://github.com/CamilleGuillory)
 - `Options` Add color picker for favicon color by [Camille Guillory](https://github.com/CamilleGuillory)
 - Fix Popup issue when Org is default tab [issue #988](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/988) (contribution by [juanlu-interdiscount](https://github.com/juanlu-interdiscount))

--- a/addon/button.js
+++ b/addon/button.js
@@ -83,7 +83,6 @@ function initButton(sfHost, inInspector) {
       function wheelHandler(e) {
         if (overflowCheckbox.checked) {
           if (e.target.matches(".canvas, .builder-canvas, .flow-builder-canvas") || e.target.classList.contains("flow-container")) {
-            e.stopImmediatePropagation();
             e.stopPropagation();
           }
         }

--- a/addon/button.js
+++ b/addon/button.js
@@ -79,6 +79,19 @@ function initButton(sfHost, inInspector) {
         // Set the overflow property to "auto"
         this.checked ? style.textContent = ".canvas {overflow : auto!important ; }" : style.textContent = ".canvas {overflow : hidden!important ; }";
       });
+
+      function wheelHandler(e) {
+        if (overflowCheckbox.checked) {
+          if (e.target.matches(".canvas, .builder-canvas, .flow-builder-canvas") || e.target.classList.contains("flow-container")) {
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+          }
+        }
+      }
+
+      observeElement(".canvas, .builder-canvas, .flow-builder-canvas", (canvas) => {
+        canvas.addEventListener("wheel", wheelHandler, { capture: true, passive: false });
+      });
     }
   }
 

--- a/addon/button.js
+++ b/addon/button.js
@@ -29,31 +29,49 @@ function initButton(sfHost, inInspector) {
   loadPopup(sfHost);
   document.body.appendChild(rootEl);
 
-  addFlowScrollability();
-
   function addFlowScrollability(popupEl) {
     const currentUrl = window.location.href;
     // Check the current URL for the string "builder_platform_interaction"
     if (currentUrl.includes("builder_platform_interaction")) {
-      // Create a new checkbox element
-      const headerFlow = document.querySelector("builder_platform_interaction-container-common");
+      const checkboxState = iFrameLocalStorage.scrollOnFlowBuilder;
+
+      // Create toggle container with styling to match navbar
+      const toggleContainer = document.createElement("div");
+      toggleContainer.className = "slds-form-element__control";
+      toggleContainer.style.cssText = "margin-left: auto; display: flex; align-items: center; gap: 0.5rem;";
+
+      // Create descriptive label text
+      const labelText = document.createElement("span");
+      labelText.textContent = "Enable flow scrollability";
+      labelText.style.color = "white";
+
+      // Create label wrapper
+      const overflowLabel = document.createElement("label");
+      overflowLabel.className = "slds-checkbox_toggle slds-grid";
+
+      // Create checkbox input
       const overflowCheckbox = document.createElement("input");
       overflowCheckbox.type = "checkbox";
       overflowCheckbox.id = "overflow-checkbox";
-      const checkboxState = iFrameLocalStorage.scrollOnFlowBuilder;
-      // Check local storage for the checkbox state
-      (checkboxState != null) ? (overflowCheckbox.checked = checkboxState) : (overflowCheckbox.checked = true);
-      // Create a new label element for the checkbox
-      const overflowLabel = document.createElement("label");
-      overflowLabel.textContent = "Enable flow scrollability";
-      overflowLabel.htmlFor = "overflow-checkbox";
-      if (currentUrl.includes("sandbox")){
-        overflowCheckbox.className = "checkboxScrollSandbox";
-        overflowLabel.className = "labelCheckboxScrollSandbox";
-      } else {
-        overflowCheckbox.className = "checkboxScrollProd";
-        overflowLabel.className = "labeCheckboxScrollProd";
-      }
+      overflowCheckbox.className = "slds-input";
+      overflowCheckbox.checked = (checkboxState != null) ? checkboxState : true;
+
+      // Create faux container
+      const fauxContainer = document.createElement("span");
+      fauxContainer.className = "slds-checkbox_faux_container center-label";
+      fauxContainer.setAttribute("aria-live", "assertive");
+
+      // Create faux checkbox
+      const fauxCheckbox = document.createElement("span");
+      fauxCheckbox.className = "slds-checkbox_faux";
+
+      // Assemble the structure
+      fauxContainer.appendChild(fauxCheckbox);
+      overflowLabel.appendChild(overflowCheckbox);
+      overflowLabel.appendChild(fauxContainer);
+      toggleContainer.appendChild(labelText);
+      toggleContainer.appendChild(overflowLabel);
+
       // Get a reference to the <head> element
       const head = document.head;
       // Create a new <style> element
@@ -62,9 +80,16 @@ function initButton(sfHost, inInspector) {
       style.textContent = ".canvas {overflow : auto!important ; }";
       // Append the <style> element to the <head> element
       head.appendChild(style);
-      // Append the checkbox and label elements to the body of the document
-      headerFlow.appendChild(overflowCheckbox);
-      headerFlow.appendChild(overflowLabel);
+
+      // Add toggle before last child of .slds-builder-header
+      observeElement(".slds-builder-header", (builderHeader) => {
+        const lastChild = builderHeader.lastElementChild;
+        if (lastChild) {
+          builderHeader.insertBefore(toggleContainer, lastChild);
+        } else {
+          builderHeader.appendChild(toggleContainer);
+        }
+      });
       // Set the overflow property to "auto"
       overflowCheckbox.checked ? style.textContent = ".canvas {overflow : auto!important ; }" : style.textContent = ".canvas {overflow : hidden!important ; }";
       // Listen for changes to the checkbox state
@@ -89,7 +114,7 @@ function initButton(sfHost, inInspector) {
       }
 
       observeElement(".canvas, .builder-canvas, .flow-builder-canvas", (canvas) => {
-        canvas.addEventListener("wheel", wheelHandler, { capture: true, passive: false });
+        canvas.addEventListener("wheel", wheelHandler, {capture: true, passive: false});
       });
     }
   }
@@ -102,8 +127,8 @@ function initButton(sfHost, inInspector) {
     pos = pos ? Math.min(95, pos) + "%" : "122px";
     const [posStyle, oStyle] = isVertical ? ["top", "right"] : ["left", "bottom"];
     const imgSrc = isVertical
-    ? "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M14 7l-5 5 5 5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"
-    : "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M7 10l5 5 5-5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
+      ? "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M14 7l-5 5 5 5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"
+      : "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M7 10l5 5 5-5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
     const btnClass = `insext-btn-${o}`;
     return {pos, posStyle, oStyle, imgSrc, btnClass};
   }


### PR DESCRIPTION
**Summary**  
Fix an issue where scrolling in the Salesforce Flow Builder would only work when hovering over specific elements (like nodes), but failed when hovering over the empty canvas background.

**Problem**  
The Salesforce Flow Builder canvas appears to have internal event listeners that block or consume `wheel` events on the background container, preventing the default scroll behavior.

**Solution**  
- **Event Handling**: Added a capturing `wheel` event listener to the canvas elements (`.canvas`, `.builder-canvas`, `.flow-builder-canvas`). When "Flow Scrollability" is enabled, this listener calls `e.stopImmediatePropagation()` and `e.stopPropagation()`. This effectively "steals" the event from Salesforce's internal handlers, allowing the browser's default scrolling behavior to occur on the container.

**Changes**  
Modified `addon/button.js`:  
- Added `wheelHandler` function and `observeElement` logic to attach the listener.

## Issue ticket number and link
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/837

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

