### PR TITLE
[feat] Popup - Transferring hyperlinks in the Org tab to values from labels.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - `Show All Data` Support keyboard shortcut to save edited record values [feature 951](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/951) request by [Mohak Gaur](https://github.com/mohakgaurrr)
 - `Documentation` Revised instructions for creating an External Client App, reflecting the deprecation of Connected Apps and added detailed steps for OAuth configuration and known issues related to Incognito mode [bug 962](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/962) (contribution by [Thomas Malidin Delabriere](https://github.com/tmalidin33))
 - `Authentication` Implement OAuth 2.0 Web Server Flow with [Proof Key for Code Exchange (PKCE)](https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_pkce.htm&type=5) for orgs with API Access Control enabled - [feature 873](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/873) (contribution by [Mehdi Cherfaoui](https://github.com/mehdicherf))
+- Transferring hyperlinks in the Org tab to values from labels button [feature 971](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/971) (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 
 ## Version 1.27
 

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -2678,21 +2678,21 @@ class AllDataBoxOrg extends React.PureComponent {
                 h(
                   "th",
                   {},
-                  h(
-                    "a",
-                    {
-                      href:
-                        "https://"
-                        + sfHost
-                        + "/lightning/setup/CompanyProfileInfo/home",
-                      title: "Company Information",
-                      target: linkTarget,
-                      onClick: handleLightningLinkClick,
-                    },
-                    "Org Id"
-                  )
+                  "Org Id"
                 ),
-                h("td", {}, orgInfo?.Id.substring(0, 15))
+                h("td", {}, h(
+                  "a",
+                  {
+                    href:
+                      "https://"
+                      + sfHost
+                      + "/lightning/setup/CompanyProfileInfo/home",
+                    title: orgInfo?.Id.substring(0, 15),
+                    target: linkTarget,
+                    onClick: handleLightningLinkClick,
+                  },
+                  orgInfo?.Id.substring(0, 15)
+                ))
               ),
               h(
                 "tr",
@@ -2700,19 +2700,19 @@ class AllDataBoxOrg extends React.PureComponent {
                 h(
                   "th",
                   {},
-                  h(
-                    "a",
-                    {
-                      href:
-                        "https://status.salesforce.com/instances/"
-                        + orgInfo?.InstanceName,
-                      title: "Instance status",
-                      target: linkTarget,
-                    },
-                    "Instance"
-                  )
+                  "Instance"
                 ),
-                h("td", {}, orgInfo?.InstanceName)
+                h("td", {}, h(
+                  "a",
+                  {
+                    href:
+                      "https://status.salesforce.com/instances/"
+                      + orgInfo?.InstanceName,
+                    title: orgInfo?.InstanceName,
+                    target: "_blank",
+                  },
+                  orgInfo?.InstanceName
+                ))
               ),
               h(
                 "tr",
@@ -2758,24 +2758,25 @@ class AllDataBoxOrg extends React.PureComponent {
                 h(
                   "th",
                   {},
-                  h(
+                  "Maint."
+                ),
+                h(
+                  "td",
+                  {}, h(
                     "a",
                     {
                       href:
                         "https://status.salesforce.com/instances/"
                         + orgInfo?.InstanceName
                         + "/maintenances",
-                      title: "Maintenance List",
-                      target: linkTarget,
+                      title: this.getNextMajorRelease(
+                        this.state.instanceStatus?.Maintenances
+                      ),
+                      target: "_blank",
                     },
-                    "Maint."
-                  )
-                ),
-                h(
-                  "td",
-                  {},
-                  this.getNextMajorRelease(
-                    this.state.instanceStatus?.Maintenances
+                    this.getNextMajorRelease(
+                      this.state.instanceStatus?.Maintenances
+                    )
                   )
                 )
               )


### PR DESCRIPTION
## Describe your changes
Transferring hyperlinks in the Org tab to values from labels. Below is preview:

<img width="280" height="444" alt="image" src="https://github.com/user-attachments/assets/ec553ab8-595d-47dd-bdc5-bdae7b10a517" />

## Issue ticket number and link
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/971
## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

