### PR TITLE
fix: Data Export - Skip AggregateResult types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Data Export` Now Aggregate Queries avoid popup actions menu
 - `Flow Scanner` Implement Agentforce feature to describe a flow and its components
 - `Field Creator` Fix Text Field length defaulting to 255 [issue 923](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/923) (contribution by [DivyanshuBist](https://github.com/DivyanshuBist))
 - Fix flow scrolling feature by [Camille Guillory](https://github.com/CamilleGuillory) [issue #837](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/837)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0
 
-- `Data Export` Now Aggregate Queries avoid popup actions menu
+- `Data Export` Prevent popup actions menu for Aggregate result [feature #663](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/663) (contribution by [Phanidra Mangipudi](https://github.com/thephani))
 - `Flow Scanner` Implement Agentforce feature to describe a flow and its components
 - `Field Creator` Fix Text Field length defaulting to 255 [issue 923](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/923) (contribution by [DivyanshuBist](https://github.com/DivyanshuBist))
 - Fix flow scrolling feature by [Camille Guillory](https://github.com/CamilleGuillory) [issue #837](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/837)

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -347,7 +347,10 @@ function renderCell(rt, cell, td) {
     return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?([+-]\d{4})$/.test(text);
   }
   if (typeof cell == "object" && cell != null && cell.attributes && cell.attributes.type) {
-    if (cell.attributes.type == "AggregateResult") return;
+    if (cell.attributes.type == "AggregateResult") { 
+      td.textContent = cell.attributes.type;
+      return;
+    }
     popLink(
       () => {
         let recordId = null;

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -347,6 +347,7 @@ function renderCell(rt, cell, td) {
     return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?([+-]\d{4})$/.test(text);
   }
   if (typeof cell == "object" && cell != null && cell.attributes && cell.attributes.type) {
+    if (cell.attributes.type == "AggregateResult") return;
     popLink(
       () => {
         let recordId = null;

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -347,7 +347,7 @@ function renderCell(rt, cell, td) {
     return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?([+-]\d{4})$/.test(text);
   }
   if (typeof cell == "object" && cell != null && cell.attributes && cell.attributes.type) {
-    if (cell.attributes.type == "AggregateResult") { 
+    if (cell.attributes.type == "AggregateResult") {
       td.textContent = cell.attributes.type;
       return;
     }


### PR DESCRIPTION
…gic to skip AggregateResult types

Note: Tests are failing on `releaseCandidate` not on my code

## Describe your changes
- `Data Export` Now Aggregate Queries avoid popup actions menu

## Issue ticket number and link
ISSUE-663
https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/663

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [X] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [X] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

