### PR TITLE
[feat] Data Import: Make attributes property not mandatory for JSON import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Version 2.0
 
-- Fix: Line Wrap in Export Does Not Work [issue #1027](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1027)
+- `Data Import` Make attributes property not mandatory for JSON import [feature #1041](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1041) (request by [Devin Schlegel](https://github.com/TachyonicSpace))
+- Fix: Line Wrap in Export Does Not Work [issue #1027](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1027) (request by [Andrew Russo](https://github.com/TachyonicSpace))
 - `Rest Explore` Add customizable headers, detect language from response and fix [issue 786](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/786)
 - `Data Export` Fix CSV export encoding for non-Latin characters (Hebrew, Arabic, Chinese, etc.) by adding UTF-8 BOM for Excel compatibility (contribution by [Samuel Krissi](https://github.com/samuelkrissi))
 - `Logs Viewer` Allow users to display, filter, delete, share and explain debug logs (contribution by [Samuel Krissi](https://github.com/samuelkrissi))

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -206,7 +206,6 @@ class Model {
 
   getDataFromJson(json) {
     json = JSON.parse(json);
-    let csv;
     let fields = ["_"].concat(Object.keys(json[0]));
     fields = fields.filter(field => field != "attributes");
 
@@ -215,25 +214,28 @@ class Model {
       separator = localStorage.getItem("csvSeparator");
     }
 
-    let sobject = json[0]["attributes"]["type"];
-    if (sobject) {
-      csv = json
-        .map((row) => fields
-          .map((fieldName) => {
-            const ignore = fieldName == "_";
-            let value = ignore ? sobject : row[fieldName];
-            if (typeof value == "boolean" || (value && typeof value !== "object")) {
-              return ignore ? `"[${sobject}]"` : JSON.stringify(value);
-            } else {
-              return null;
-            }
-          })
-          .filter(value => value !== null)
-          .join(separator));
-      fields = fields.map(str => `"${str}"`);
-      csv.unshift(fields.join(separator));
-      csv = csv.join("\r\n");
+    let sobject = json[0]?.attributes?.type;
+    if (!sobject) {
+      // Remove the "_" column if no sobject type
+      fields = fields.filter(field => field != "_");
     }
+
+    let csv = json
+      .map((row) => fields
+        .map((fieldName) => {
+          const ignore = fieldName == "_";
+          let value = ignore ? sobject : row[fieldName];
+          if (typeof value == "boolean" || (value && typeof value !== "object")) {
+            return ignore ? `"[${sobject}]"` : JSON.stringify(value);
+          } else {
+            return null;
+          }
+        })
+        .filter(value => value !== null)
+        .join(separator));
+    fields = fields.map(str => `"${str}"`);
+    csv.unshift(fields.join(separator));
+    csv = csv.join("\r\n");
     return csv;
   }
 


### PR DESCRIPTION
## Describe your changes
Make attributes property not mandatory for JSON import

## Issue ticket number and link
Fix #1041 

## Checklist before requesting a review
- [ ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] Target branch is releaseCandidate and not master
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

