### PR TITLE
[feat] Show All Data: Add Agentforce formula helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Show All Data` Add `Agentforce Helper` feature for formula fields, allowing users to analyze or use AI to generate some evolutions to current formula.
 - `Popup` Use banner to display success / errors when enabling logs, unfreeze user and enabling debug mode
 - `Data Import` Make attributes property not mandatory for JSON import [feature #1041](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1041) (request by [Devin Schlegel](https://github.com/TachyonicSpace))
 - Fix: Line Wrap in Export Does Not Work [issue #1027](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1027) (request by [Andrew Russo](https://github.com/TachyonicSpace))

--- a/addon/components/AgentforceModal.js
+++ b/addon/components/AgentforceModal.js
@@ -1,0 +1,247 @@
+/* global React */
+import ConfirmModal from "./ConfirmModal.js";
+import {copyToClipboard} from "../utils.js";
+
+const h = React.createElement;
+
+/**
+ * Reusable Agentforce analysis modal component
+ * @param {Object} props
+ * @param {boolean} props.isOpen - Whether the modal is open
+ * @param {string} props.title - Modal title
+ * @param {Function} props.onClose - Close handler
+ * @param {Function} props.onAnalyze - Analyze handler
+ * @param {boolean} props.isAnalyzing - Whether analysis is in progress
+ * @param {string} props.analysis - Analysis results
+ * @param {string} props.error - Error message
+ * @param {string} props.instructions - Current instructions
+ * @param {string} props.defaultInstructions - Default instructions
+ * @param {boolean} props.editMode - Whether in edit mode
+ * @param {Function} props.onToggleEditMode - Toggle edit mode handler
+ * @param {Function} props.onUpdateInstructions - Update instructions handler
+ * @param {Function} props.onResetInstructions - Reset instructions handler
+ * @param {React.ReactNode} props.headerContent - Optional header content (field info, etc.)
+ * @param {React.ReactNode} props.footerContent - Optional footer content
+ * @param {string} props.analyzingMessage - Message to show while analyzing
+ * @param {string} props.analyzingSubMessage - Sub-message to show while analyzing
+ * @param {string} props.resultTitle - Title for results section
+ * @param {string} props.resultTagName - Tag name to extract from results (e.g., "formulaHelper", "logAnalysis")
+ * @param {Function} props.onCopy - Optional custom copy handler (receives text to copy)
+ */
+export default class AgentforceModal extends React.Component {
+  render() {
+    const {
+      isOpen,
+      title,
+      onClose,
+      onAnalyze,
+      isAnalyzing,
+      analysis,
+      error,
+      instructions,
+      defaultInstructions,
+      editMode,
+      onToggleEditMode,
+      onUpdateInstructions,
+      onResetInstructions,
+      headerContent,
+      footerContent,
+      analyzingMessage = "Agentforce is analyzing...",
+      analyzingSubMessage = "This may take a moment",
+      resultTitle = "Agentforce Analysis Results",
+      resultTagName,
+      onCopy
+    } = this.props;
+
+    if (!isOpen) return null;
+
+    const isCustomized = instructions !== defaultInstructions;
+    const hasResults = analysis || error;
+
+    // Extract analysis from tag if specified
+    let displayAnalysis = analysis;
+    if (analysis && resultTagName) {
+      const regex = new RegExp(`<${resultTagName}>([\\s\\S]*?)</${resultTagName}>`, "i");
+      const match = analysis.match(regex);
+      if (match) {
+        displayAnalysis = match[1].trim();
+      }
+    }
+
+    // Copy handler - use custom if provided, otherwise use default
+    const handleCopy = () => {
+      if (onCopy) {
+        onCopy(displayAnalysis);
+      } else {
+        copyToClipboard(displayAnalysis);
+      }
+    };
+
+    return h(ConfirmModal, {
+      isOpen: true,
+      title: h("div", {className: "slds-grid slds-grid_vertical-align-center"},
+        h("span", {className: "slds-icon_container slds-icon-utility-einstein slds-m-right_small"},
+          h("svg", {className: "slds-icon slds-icon_small", "aria-hidden": "true"},
+            h("use", {xlinkHref: "symbols.svg#einstein"})
+          )
+        ),
+        h("span", {}, title)
+      ),
+      onConfirm: isAnalyzing ? null : onAnalyze,
+      onCancel: onClose,
+      confirmLabel: isAnalyzing ? "Analyzing..." : (hasResults ? "Analyze Again" : "Analyze"),
+      cancelLabel: "Close",
+      confirmVariant: "brand",
+      cancelVariant: "neutral",
+      confirmDisabled: isAnalyzing,
+      containerClassName: "modalContainer"
+    },
+    // Header content (optional - field info, etc.)
+    headerContent,
+
+    // Instructions Section with Edit/View toggle
+    !hasResults && h("div", {className: "slds-form-element slds-m-bottom_medium"},
+      h("div", {className: "slds-grid slds-grid_align-spread slds-m-bottom_x-small"},
+        h("label", {className: "slds-form-element__label slds-text-heading_small"},
+          h("span", {}, "Analysis Instructions"),
+          isCustomized && h("span", {
+            className: "slds-theme_info slds-badge slds-m-left_x-small",
+            style: {fontSize: "0.75rem"}
+          }, "Customized")
+        ),
+        h("div", {className: "slds-button-group", role: "group"},
+          h("button", {
+            className: `slds-button slds-button_${editMode ? "brand" : "neutral"}`,
+            title: "Edit instructions",
+            onClick: onToggleEditMode,
+            disabled: isAnalyzing
+          },
+          h("svg", {className: "slds-button__icon slds-button__icon_left", "aria-hidden": "true"},
+            h("use", {xlinkHref: "symbols.svg#edit"})
+          ),
+          "Edit"
+          ),
+          isCustomized && h("button", {
+            className: "slds-button slds-button_neutral",
+            title: "Reset to default instructions",
+            onClick: onResetInstructions,
+            disabled: isAnalyzing
+          },
+          h("svg", {className: "slds-button__icon slds-button__icon_left", "aria-hidden": "true"},
+            h("use", {xlinkHref: "symbols.svg#refresh"})
+          ),
+          "Reset"
+          )
+        )
+      ),
+
+      // Edit Mode - Editable textarea
+      editMode ? h("div", {},
+        h("textarea", {
+          className: "slds-textarea sfir-agentforce-textarea",
+          value: instructions,
+          onInput: (e) => onUpdateInstructions(e.target.value),
+          placeholder: "Enter your custom analysis instructions...",
+          disabled: isAnalyzing
+        }),
+        h("div", {className: "slds-form-element__help slds-m-top_small"},
+          h("div", {className: "slds-text-body_small slds-text-color_weak"},
+            "💡 Tip: Customize these instructions to focus on specific aspects. Changes are automatically saved."
+          )
+        )
+      ) : h("div", {},
+        // View Mode - Read-only display
+        h("div", {
+          className: "slds-box slds-theme_shade slds-m-top_x-small sfir-agentforce-instructions-container"
+        },
+        h("div", {
+          className: "slds-text-body_small sfir-agentforce-instructions-content",
+          style: {whiteSpace: "pre-wrap"}
+        }, instructions)
+        )
+      )
+    ),
+
+    // Analyzing State
+    isAnalyzing && h("div", {className: "slds-align_absolute-center slds-m-vertical_large sfir-agentforce-analyzing-container"},
+      h("div", {className: "slds-spinner_container"},
+        h("div", {role: "status", className: "slds-spinner slds-spinner_medium slds-spinner_brand"},
+          h("span", {className: "slds-assistive-text"}, "Analyzing..."),
+          h("div", {className: "slds-spinner__dot-a"}),
+          h("div", {className: "slds-spinner__dot-b"})
+        )
+      ),
+      h("div", {className: "slds-text-heading_small slds-m-top_medium slds-text-align_center"},
+        h("div", {}, analyzingMessage),
+        h("div", {className: "slds-text-body_small slds-text-color_weak slds-m-top_x-small"},
+          analyzingSubMessage
+        )
+      )
+    ),
+
+    // Error State
+    error && h("div", {className: "slds-m-top_medium"},
+      h("div", {className: "slds-notify slds-notify_alert slds-alert_error", role: "alert"},
+        h("span", {className: "slds-icon_container slds-icon-utility-error slds-m-right_small"},
+          h("svg", {className: "slds-icon slds-icon_x-small", "aria-hidden": "true"},
+            h("use", {xlinkHref: "symbols.svg#error"})
+          )
+        ),
+        h("h2", {},
+          h("span", {className: "slds-text-heading_small"}, "Analysis Failed")
+        )
+      ),
+      h("div", {className: "slds-box slds-box_small slds-theme_error slds-m-top_small"},
+        h("div", {className: "slds-text-body_regular sfir-agentforce-error-content"},
+          error
+        )
+      )
+    ),
+
+    // Success State with Results
+    displayAnalysis && h("div", {className: "slds-m-top_medium"},
+      h("div", {className: "slds-notify slds-notify_alert slds-alert_success slds-m-bottom_small", role: "alert"},
+        h("span", {className: "slds-icon_container slds-icon-utility-success slds-m-right_small"},
+          h("svg", {className: "slds-icon slds-icon_x-small", "aria-hidden": "true"},
+            h("use", {xlinkHref: "symbols.svg#success"})
+          )
+        ),
+        h("h2", {},
+          h("span", {className: "slds-text-heading_small"}, "Analysis Complete")
+        )
+      ),
+      h("div", {className: "slds-card"},
+        h("div", {className: "slds-card__header slds-grid"},
+          h("header", {className: "slds-media slds-media_center slds-has-flexi-truncate"},
+            h("div", {className: "slds-media__body"},
+              h("h2", {className: "slds-card__header-title"},
+                h("span", {}, resultTitle)
+              )
+            ),
+            h("div", {className: "slds-no-flex"},
+              h("button", {
+                className: "slds-button slds-button_icon slds-button_icon-border-filled",
+                title: "Copy to clipboard",
+                onClick: handleCopy
+              },
+              h("svg", {className: "slds-button__icon", "aria-hidden": "true"},
+                h("use", {xlinkHref: "symbols.svg#copy"})
+              )
+              )
+            )
+          )
+        ),
+        h("div", {className: "slds-card__body slds-card__body_inner"},
+          h("div", {
+            className: "slds-text-body_regular sfir-agentforce-results",
+            style: {whiteSpace: "pre-wrap"}
+          }, displayAnalysis)
+        )
+      )
+    ),
+
+    // Footer content (optional)
+    footerContent
+    );
+  }
+}

--- a/addon/debug-log.css
+++ b/addon/debug-log.css
@@ -1,27 +1,3 @@
-.modalContainer{
-  max-width: 100rem;
-  width: 90%;
-  position: relative;
-  z-index: 9001; /* Above backdrop */
-}
-
-/* Backdrop for Agentforce modal */
-.slds-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 9000;
-}
-
-.slds-backdrop_open {
-  visibility: visible;
-  opacity: 1;
-  transition: opacity 0.2s linear;
-}
-
 /* Ensure action buttons have consistent height */
 .sfir-actions .slds-button {
   height: 32px; /* match SLDS default small button height */
@@ -128,46 +104,6 @@ mark.sfir-highlight.current {
 .sfir-logs-table tbody td[role="gridcell"]:first-child {
   text-align: center;
   vertical-align: middle;
-}
-
-/* Agentforce Modal Styles */
-.sfir-agentforce-textarea {
-  min-height: 60vh;
-  font-size: 0.875rem;
-  line-height: 1.7;
-}
-
-.sfir-agentforce-instructions-container {
-  max-height: 60vh;
-  overflow-y: auto;
-}
-
-.sfir-agentforce-instructions-content {
-  white-space: pre-wrap;
-  line-height: 1.7;
-  color: #3e3e3c;
-  padding: 0.75rem;
-}
-
-.sfir-agentforce-analyzing-container {
-  min-height: 60vh;
-}
-
-.sfir-agentforce-error-content {
-  font-size: 0.875rem;
-}
-
-.sfir-agentforce-results {
-  white-space: pre-wrap;
-  line-height: 1.8;
-  max-height: 60vh;
-  overflow-y: auto;
-  background-color: #fafaf9;
-  border: 1px solid #e5e5e5;
-  border-radius: 0.25rem;
-  padding: 1.25rem;
-  font-size: 0.9375rem;
-  color: #181818;
 }
 
 /* Preview Modal Styles */

--- a/addon/options.js
+++ b/addon/options.js
@@ -365,6 +365,14 @@ class OptionsTabSelector extends React.Component {
               ]}
           }
         ]
+      },
+      {
+        id: "show-all",
+        tabTitle: "Show All",
+        content: [
+          {option: Option, props: {type: "toggle", title: "Enable Agentforce Helper for formula fields", key: "showAgentforceHelperInspect", default: true, tooltip: "When enabled, shows the 'Agentforce Helper' link in the field actions menu for calculated/formula fields."}},
+          {option: Option, props: {type: "text", title: "Formula Helper Prompt Template Name", key: this.sfHost + "_formulaAgentForcePrompt", default: "FormulaHelper", tooltip: "Developer name of the prompt template to use for Formula Field Analysis in the Inspect page"}},
+        ]
       }
     ];
     this.onTabSelect = this.onTabSelect.bind(this);

--- a/addon/styles/sfir.css
+++ b/addon/styles/sfir.css
@@ -111,3 +111,72 @@ a.copy-id,
 a.download-salesforce {
     cursor: pointer;
 }
+
+/* Modal Container - shared across pages */
+.modalContainer {
+  max-width: 100rem;
+  width: 90%;
+  min-width: 60vw;
+  position: relative;
+  z-index: 9001; /* Above backdrop */
+}
+
+/* Backdrop for modals */
+.slds-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 9000;
+}
+
+.slds-backdrop_open {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.2s linear;
+}
+
+/* Agentforce Modal Styles - shared across pages */
+.sfir-agentforce-textarea {
+  min-height: 60vh;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  font-family: monospace;
+}
+
+.sfir-agentforce-instructions-container {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.sfir-agentforce-instructions-content {
+  white-space: pre-wrap;
+  line-height: 1.7;
+  color: #3e3e3c;
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.sfir-agentforce-analyzing-container {
+  min-height: 60vh;
+}
+
+.sfir-agentforce-error-content {
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+}
+
+.sfir-agentforce-results {
+  white-space: pre-wrap;
+  line-height: 1.8;
+  max-height: 60vh;
+  overflow-y: auto;
+  background-color: #fafaf9;
+  border: 1px solid #e5e5e5;
+  border-radius: 0.25rem;
+  padding: 1.25rem;
+  font-size: 0.9375rem;
+  color: #181818;
+}

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -4,6 +4,7 @@ export class Constants {
   static PromptTemplateSOQL = "GenerateSOQL";
   static PromptTemplateFlow = "DescribeFlow";
   static PromptTemplateDebugLog = "AnalyzeDebugLog";
+  static PromptTemplateFormula = "FormulaHelper";
   // Consumer Key of default connected app
   static DEFAULT_CLIENT_ID = "3MVG9HB6vm3GZZR9qrol39RJW_sZZjYV5CZXSWbkdi6dd74gTIUaEcanh7arx9BHhl35WhHW4AlNUY8HtG2hs";
   static ACCESS_TOKEN = "_access_token";

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -446,6 +446,88 @@ This feature is particularly useful for:
 
 ![Smart Field Usage demo](https://github.com/user-attachments/assets/ef93bf3c-8737-4a21-b38b-ce4822f8b573)
 
+## Use Agentforce to analyze formula fields
+
+The Agentforce Helper feature provides AI-powered analysis and explanations for formula fields, helping you understand complex formulas, identify issues, and get recommendations for improvements.
+
+### Prerequisites
+
+> **Prerequisite**
+> Agentforce needs to be enabled.
+> The prompt FormulaHelper needs to be deployed in the org.
+
+> **Note**
+> The standard Salesforce 'Prompt Template User' permission is required to use this feature.
+
+### How to use
+
+1. **Navigate to an SObject**: Select an SObject from the popup or navigate to any SObject page in Salesforce
+2. **Open Show All Data**: Click the "Show all data" button to open the field inspection page
+3. **Access Agentforce Helper**: For any calculated/formula field:
+   * Click the dropdown arrow (⋮) in the Actions column
+   * Select "Agentforce Helper" from the menu
+4. **Review the Analysis**: The modal will display:
+   * Field metadata (name, type, formula expression)
+   * A customizable prompt with your instructions
+   * An "Analyze" button to generate the AI analysis
+5. **Customize Instructions** (optional):
+   * Click "Edit" to modify the prompt instructions
+   * Add specific requirements or questions about the formula
+   * Click "Reset" to restore default instructions
+6. **View Results**: After clicking "Analyze", Agentforce will provide:
+   * Plain language explanation of the formula
+   * Step-by-step logic breakdown
+   * Dependencies and referenced fields
+   * Edge cases and potential issues
+   * Best practices review and recommendations
+   * Example calculations with sample data
+
+### Configuration Options
+
+#### Enable/Disable Agentforce Helper
+
+You can control whether the Agentforce Helper link appears in the field actions menu:
+
+1. Open the extension and click the "Options" button
+2. Navigate to the "Show All" tab
+3. Find the "Enable Agentforce Helper for formula fields" toggle
+4. Enable or disable the feature as needed (enabled by default)
+
+> **Note**
+> When disabled, the "Agentforce Helper" link will not appear in the field actions menu for formula fields.
+
+#### Customize Prompt Template
+
+You can configure which AI prompt template is used for formula analysis:
+
+1. In the same "Show All" tab in Options
+2. Find the "Formula Helper Prompt Template Name" field
+3. Enter the developer name of your custom prompt template (default: "FormulaHelper")
+
+> **Important**
+> The prompt template must exist in your Salesforce org as a GenAI Prompt Template and should be configured to accept two inputs: `Prompt` and `FieldMetadata`.
+
+#### Customize Analysis Instructions
+
+For each formula field analysis, you can customize the instructions:
+
+1. Open the Agentforce Helper modal for any formula field
+2. Click the "Edit" button to modify the instructions
+3. Add or modify the analysis requirements
+4. Your custom instructions are saved per org and will be used for future analyses
+5. Click "Reset" at any time to restore the default instructions
+
+### Use Cases
+
+This feature is particularly useful for:
+
+* **Understanding complex formulas**: Get plain-language explanations of intricate formula logic
+* **Formula reviews**: Identify potential issues, edge cases, and best practice violations
+* **Knowledge transfer**: Document formula behavior for team members
+* **Formula optimization**: Get recommendations for improving formula efficiency
+* **Troubleshooting**: Understand why a formula might not be working as expected
+* **Modification planning**: Get guidance on how to safely modify existing formulas
+
 ## User Tab Toggle Reset Password button
 
 This feature enables a **Reset Password** button on the **User Tab** page in Salesforce Inspector Reloaded. The button can be displayed **on or off** from the extension **Options** page.

--- a/force-app/main/default/genAiPromptTemplates/FormulaHelper.genAiPromptTemplate-meta.xml
+++ b/force-app/main/default/genAiPromptTemplates/FormulaHelper.genAiPromptTemplate-meta.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">
+    <activeVersionIdentifier>kHV1dE2/3c+Ln69ej5g+TuywC22Qn/hIXhG7gDkb9JA=_1</activeVersionIdentifier>
+    <description>This template is used to provide help to users with formula fields (explain a formula, make some evolution to an existing formula etc.)</description>
+    <developerName>FormulaHelper</developerName>
+    <masterLabel>Formula Helper</masterLabel>
+    <templateVersions>
+        <content>As a Salesforce expert specializing in formula fields and declarative automation, analyze the formula field provided below based on the user&apos;s request.
+
+**User Request:**
+{!$Input:Prompt}
+
+**Formula Field Metadata:**
+{!$Input:FieldMetadata}
+
+**Your Task:**
+Based on the user&apos;s request, provide a comprehensive response that may include:
+
+1. **Plain Language Explanation:** Describe what this formula does in simple, non-technical terms that any user could understand.
+
+2. **Logic Breakdown:** Break down the formula step-by-step, explaining each function, operator, and field reference.
+
+3. **Dependencies:** Identify all referenced fields and their purpose in the calculation.
+
+4. **Edge Cases &amp; Considerations:** Highlight any null handling, division by zero protection, conditional logic, or potential issues.
+
+5. **Best Practices Review:** Evaluate if the formula follows Salesforce best practices and suggest improvements.
+
+6. **Modifications (if requested):** If the user requested changes to the formula, provide:
+  - The updated formula code
+  - Explanation of what changed and why
+  - Any considerations or warnings about the changes
+  - Testing recommendations
+
+7. **Examples:** Provide example scenarios showing how the formula evaluates with sample data.
+
+**Output Format:**
+Output the generated analysis clearly enclosed within &amp;lt;formulaHelper&amp;gt; tags.
+
+Structure your response clearly with appropriate headings. If providing a modified formula, include it in a code block. Be thorough but concise, focusing on what the user specifically asked for in their request.
+
+**Important Guidelines:**
+- Always explain in business terms first, then technical details
+- Point out any potential governor limit concerns
+- Highlight null handling and edge cases
+- If suggesting changes, explain the impact and benefits
+- Provide practical examples with realistic data
+- Consider maintainability and future modifications
+</content>
+        <inputs>
+            <apiName>Prompt</apiName>
+            <definition>primitive://String</definition>
+            <masterLabel>Prompt</masterLabel>
+            <referenceName>Input:Prompt</referenceName>
+            <required>true</required>
+        </inputs>
+        <inputs>
+            <apiName>FieldMetadata</apiName>
+            <definition>primitive://String</definition>
+            <masterLabel>Field Metadata</masterLabel>
+            <referenceName>Input:FieldMetadata</referenceName>
+            <required>true</required>
+        </inputs>
+        <primaryModel>sfdc_ai__DefaultOpenAIGPT4OmniMini</primaryModel>
+        <status>Published</status>
+        <versionIdentifier>kHV1dE2/3c+Ln69ej5g+TuywC22Qn/hIXhG7gDkb9JA=_1</versionIdentifier>
+    </templateVersions>
+    <type>einstein_gpt__flex</type>
+    <visibility>Global</visibility>
+</GenAiPromptTemplate>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,6 +3,9 @@
     {
       "path": "test",
       "default": true
+    },
+    {
+      "path": "force-app"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
## Describe your changes

From the Show All Data page, for formula fields we added a new link "Agentforce Helper".

<img width="1437" height="550" alt="agentforce helper" src="https://github.com/user-attachments/assets/0fb055db-b311-4181-8ef4-456312017b5f" />

When the link is clicked
<img width="1337" height="723" alt="image" src="https://github.com/user-attachments/assets/b33b8a62-463d-43ee-9125-65e3a813ed5e" />

Display Result:
<img width="1321" height="719" alt="image" src="https://github.com/user-attachments/assets/a9b2d7e2-be08-45a5-8345-108435855d7a" />


## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] Target branch is releaseCandidate and not master
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

