### PR TITLE
[feat]: Support configurable keyboard shortcuts on Firefox

### DIFF
--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion} from "./inspector.js";
-import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile} from "./utils.js";
+import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile, getBrowserType} from "./utils.js";
 /* global initButton */
 import {Enumerable, DescribeInfo, initScrollTable, s} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
@@ -1965,7 +1965,12 @@ class App extends React.Component {
               ),
               h("p", {className: "slds-m-bottom_x-small"}, "Press Ctrl+Space to insert all field name autosuggestions or to load suggestions for field values."),
               h("p", {className: "slds-m-bottom_x-small"}, "Press Ctrl+Enter or F5 to execute the export."),
-              h("p", {}, "Those shortcuts can be customized in chrome://extensions/shortcuts"),
+              h("p", {}, "Those shortcuts can be customized in your browser's extension settings.",
+                h("br"),
+                getBrowserType() === "chrome"
+                  ? "Chrome/Edge: chrome://extensions/shortcuts or edge://extensions/shortcuts"
+                  : "Firefox: Add-ons Manager (Ctrl+Shift+A) → gear icon → Manage Extension Shortcuts"
+              ),
               h("p", {className: "slds-m-bottom_x-small"}, "Supports the full SOQL language. The columns in the CSV output depend on the returned data. Using subqueries may cause the output to grow rapidly. Bulk API is not supported. Large data volumes may freeze or crash your browser.")
             ),
             h("div", {hidden: !model.showAI},

--- a/addon/manifest-firefox.json
+++ b/addon/manifest-firefox.json
@@ -80,8 +80,65 @@
     "field-creator.html",
     "options.html",
     "event-monitor.html",
-    "flow-scanner.html"
+    "flow-scanner.html",
+    "debug-log.html"
   ],
   "incognito": "spanning",
-  "manifest_version": 2
+  "manifest_version": 2,
+  "commands": {
+    "open-popup": {
+      "description": "Open popup"
+    },
+    "open-export-autocomplete": {
+      "description": "Fields suggestion in Data Export"
+    },
+    "open-export-execute": {
+      "description": "Run Query in Data Export"
+    },
+    "open-save-modifications": {
+      "description": "Save modifications in Show All Data"
+    },
+    "link-setup": {
+      "description": "Open Setup"
+    },
+    "link-home": {
+      "description": "Open Home Page"
+    },
+    "link-dev": {
+      "description": "Open Developer Console"
+    },
+    "data-export": {
+      "description": "Data Export"
+    },
+    "data-import": {
+      "description": "Data Import"
+    },
+    "options": {
+      "description": "Options"
+    },
+    "metadata-retrieve": {
+      "description": "Retrieve Metadata"
+    },
+    "limits": {
+      "description": "Org Limits"
+    },
+    "field-creator": {
+      "description": "Field Creator"
+    },
+    "explore-api": {
+      "description": "Explore API"
+    },
+    "rest-explore": {
+      "description": "REST Explore"
+    },
+    "event-monitor": {
+      "description": "Event Monitor"
+    },
+    "flow-scanner": {
+      "description": "Flow Scanner"
+    },
+    "debug-log": {
+      "description": "Logs Viewer"
+    }
+  }
 }

--- a/docs/data-export.md
+++ b/docs/data-export.md
@@ -49,7 +49,10 @@ Example:
 
 ## Customize Select all fields in a query shortcut
 
-If the default `Ctrl + space` shortcut is already used by another extension or app, you can customize it in `chrome://extensions/shortcuts` and choose the one you prefer.
+If the default `Ctrl + space` shortcut is already used by another extension or app, you can customize it in your browser's extension settings:
+* Chrome: `chrome://extensions/shortcuts`
+* Edge: `edge://extensions/shortcuts`
+* Firefox: Open the Add-ons Manager (`Ctrl+Shift+A`), click the gear icon, then select "Manage Extension Shortcuts"
 
 <img width="1133" alt="Customize Select all fields in a query shortcut" src="https://github.com/user-attachments/assets/f0bca12a-7c92-4fbe-9ca4-a8db51b050e9">
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -278,6 +278,7 @@ Navigate to your browser shortcut menu and choose dedicated shortcuts for the pa
 
 * Chrome: [chrome://extensions/shortcut](chrome://extensions/shortcut)
 * Edge: [edge://extensions/shortcuts](edge://extensions/shortcuts)
+* Firefox: Open the Add-ons Manager (`Ctrl+Shift+A` or `about:addons`), click the gear icon, then select "Manage Extension Shortcuts"
 
 <img width="660" alt="Use Chrome Shortcuts" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/382aea2d-5278-4dfe-89e6-6dcec4c724c9">
 


### PR DESCRIPTION
## Summary

Adds Firefox support for configurable keyboard shortcuts.

- Added all extension commands to `manifest-firefox.json` so they appear in Firefox's Add-ons Manager under "Manage Extension Shortcuts"
- Fixed `background.js` to use `moz-extension://` protocol when opening extension pages via shortcut — previously hardcoded `chrome-extension://` silently failed in Firefox
- Updated help text in Data Export to show browser-specific instructions (Firefox vs Chrome/Edge) for managing shortcuts
- Updated docs with Firefox shortcut management instructions

## Testing

Tested on Firefox (Mac):
- Commands appear in Add-ons Manager → gear icon → Manage Extension Shortcuts
- Assigning a shortcut and pressing it correctly opens the target extension page
- Data Export help text shows Firefox-specific instructions when running on Firefox

## Notes

**This PR is superseded by branch `feat/firefox-keyboard-shortcuts`** which is rebased onto the latest `releaseCandidate` and includes the `moz-extension://` bug fix.