### PR TITLE
[feat] add dynamic popup height capability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0
 
-- `User Experience` add the capability to have the popup using the available height in the window (Activated by default - Eanble/Disable in User Experience -> Enable Dynamic Popup Height)
+- `User Experience` Add dynamic popup height and option to enable / disable setting (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - Add Flow Compare button to quickly access Salesforce's Flow Compare feature (Winter '26) (from `Flow Scanner` and `Popup`)
 - `Data Import` Only reset action if user hasn't manually selected one [issue #986](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/986) (contribution by [Ruben Halman](https://github.com/RubenHalman))
 - `Data Export` Fix query tab index numbering when adding new tabs after closing existing ones [issue #1059](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1059) (contribution by [mshivakumar2023-debug](https://github.com/mshivakumar2023-debug))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `User Experience` add the capability to have the popup using the available height in the window (Activated by default - Eanble/Disable in User Experience -> Enable Dynamic Popup Height)
 - Add Flow Compare button to quickly access Salesforce's Flow Compare feature (Winter '26) (from `Flow Scanner` and `Popup`)
 - `Data Import` Only reset action if user hasn't manually selected one [issue #986](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/986) (contribution by [Ruben Halman](https://github.com/RubenHalman))
 - `Data Export` Fix query tab index numbering when adding new tabs after closing existing ones [issue #1059](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1059) (contribution by [mshivakumar2023-debug](https://github.com/mshivakumar2023-debug))

--- a/addon/button.css
+++ b/addon/button.css
@@ -23,7 +23,7 @@
   #insext .insext-popup {
     box-sizing: border-box;
     width: 280px;
-    height: 450px;
+    min-height: 450px;
     position: absolute;
     background-color: var(--sfir-btn-white);
     border-radius: var(--sfir-btn-radius-sm);
@@ -31,7 +31,7 @@
     border: 1px solid #d8dde6;
     display: none;
   }
-  
+
   #insext .insext-popup-vertical {
     right: 0%;
     border-top-right-radius: 0;
@@ -41,10 +41,10 @@
     border-top-left-radius: var(--sfir-btn-radius);
     border-bottom-left-radius: var(--sfir-btn-radius);
   }
-  
-  #insext .insext-popup-vertical-up {
+
+  #insext .insext-popup-vertical.insext-popup-vertical-up {
     /*bottom: 100%;*/
-    top: calc(100% - 400px) !important;
+    top: calc(100% - 400px);
   }
   
   #insext .insext-popup-horizontal {
@@ -59,7 +59,7 @@
   }
   
   #insext .insext-popup-horizontal-right {
-    left: -200px;
+    left: -160px;
   }
   
   #insext.insext-active .insext-popup {
@@ -106,10 +106,15 @@
       border: none;
       box-shadow: none;
     }
+
     #insext.insext-active .insext-btn-horizontal {
       left: 4px;
       bottom: 416px;
       border-top-right-radius: 0px;
+    }
+    
+    #insext.insext-active .insext-btn-horizontal.insext-btn-dynamic-height {
+      bottom: calc(95vh);
     }
     
   #insext .insext-btn-vertical:hover,

--- a/addon/button.css
+++ b/addon/button.css
@@ -19,7 +19,7 @@
     display: block;
     position: fixed;
   }
-  
+
   #insext .insext-popup {
     box-sizing: border-box;
     width: 280px;
@@ -46,22 +46,22 @@
     /*bottom: 100%;*/
     top: calc(100% - 400px);
   }
-  
+
   #insext .insext-popup-horizontal {
     bottom: 0;
     box-shadow: 2px 0 2px 0 var(--sfir-btn-shadow-light);
     border-top-left-radius: var(--sfir-btn-radius);
     border-top-right-radius: var(--sfir-btn-radius);
   }
-  
+
   #insext .insext-popup-horizontal-left {
     left: 0%;
   }
-  
+
   #insext .insext-popup-horizontal-right {
     left: -160px;
   }
-  
+
   #insext.insext-active .insext-popup {
     display: block;
   }
@@ -112,11 +112,11 @@
       bottom: 416px;
       border-top-right-radius: 0px;
     }
-    
+
     #insext.insext-active .insext-btn-horizontal.insext-btn-dynamic-height {
       bottom: calc(95vh);
     }
-    
+
   #insext .insext-btn-vertical:hover,
   #insext.insext-active .insext-btn-vertical {
     opacity: 1;
@@ -130,7 +130,7 @@
     position: absolute;
     border-bottom-left-radius: 0px;
   }
-  
+
   #insext .insext-btn-horizontal:hover,
   #insext.insext-active .insext-btn-horizontal {
     opacity: 1;
@@ -139,17 +139,17 @@
     border-color: var(--sfir-btn-border-active);
     transform: translateY(-2px);
   }
-  
+
   #insext .insext-btn img {
     box-sizing: border-box;
   }
-  
+
     #insext .insext-btn-vertical img {
       width: 24px;
       height: 24px;
       margin: 0 0 0 5px;
     }
-    
+
 #insext.insext-active .insext-btn-vertical img {
   margin-left: 15px;
   margin-top: 5px;
@@ -168,23 +168,23 @@
 #insext.insext-active .insext-btn-horizontal img {
   transform: rotateX(0turn);
 }
-  
+
   #insext .insext-btn:hover img {
     transform: scale(1.1);
   }
-  
+
   #insext.insext-active .insext-btn-vertical:hover img {
     transform: rotateY(0.5turn) scale(1.1);
   }
-  
+
   #insext .insext-btn-horizontal:hover img {
     transform: rotateX(0.5turn) scale(1.1);
   }
-  
+
   #insext.insext-active .insext-btn-horizontal:hover img {
     transform: rotateX(0turn) scale(1.1);
   }
-  
+
   .checkboxScrollSandbox {
     position: fixed;
     top: 10px;
@@ -223,7 +223,7 @@
     vertical-align: middle;
     animation: fadeOut 2s forwards;
   }
-  
+
   @keyframes fadeOut {
     to {
       opacity: 0;

--- a/addon/button.js
+++ b/addon/button.js
@@ -120,8 +120,7 @@ function initButton(sfHost, inInspector) {
   }
 
   // Calulates default position, left to right for horizontal, and adds boundaries to keep it on screen
-  // Calulates default position, left to right for horizontal, and adds boundaries to keep it on screen
-  function calcPopup({popupArrowOrientation: o, popupArrowPosition: pos}) {
+  function calcPopup({popupArrowOrientation: o, popupArrowPosition: pos, popupHeighDynamictMode: dynamicHeight}) {
     o = o || "vertical"; // Default to vertical
     const isVertical = o === "vertical";
     pos = pos ? Math.min(95, pos) + "%" : "122px";
@@ -129,8 +128,12 @@ function initButton(sfHost, inInspector) {
     const imgSrc = isVertical
       ? "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M14 7l-5 5 5 5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"
       : "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M7 10l5 5 5-5' stroke='%230176d3' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
-    const btnClass = `insext-btn-${o}`;
-    return {pos, posStyle, oStyle, imgSrc, btnClass};
+    let btnClasses = [];
+    btnClasses.push(`insext-btn-${o}`);
+    if (dynamicHeight === "true") {
+      btnClasses.push("insext-btn-dynamic-height");
+    }
+    return {pos, posStyle, oStyle, imgSrc, btnClasses};
   }
 
   function setRootCSSProperties(rootElement, buttonElement) {
@@ -140,7 +143,7 @@ function initButton(sfHost, inInspector) {
     img.src = p.imgSrc;
     rootElement.style[p.posStyle] = p.pos;
     rootElement.style[p.oStyle] = 0;
-    buttonElement.classList.add(p.btnClass);
+    p.btnClasses.forEach(item => buttonElement.classList.add(item))
     buttonElement.appendChild(img);
   }
 
@@ -258,12 +261,16 @@ function initButton(sfHost, inInspector) {
 
     let popupSrc = chrome.runtime.getURL("popup.html?host=" + sfHost);
     let popupEl = document.createElement("iframe");
+
     function getOrientation(source) {
-      const o = (source === "localStorage")
-        ? localStorage.getItem("popupArrowOrientation")
-        : iFrameLocalStorage.popupArrowOrientation;
-      return o || "vertical";
+      return getKeyFromStorage(source, "popupArrowOrientation", "vertical");
     }
+
+    function getKeyFromStorage(source, key, defaultValue) {
+      const o = (source === "localStorage") ? localStorage.getItem(key) : iFrameLocalStorage?.[key];
+      return o || defaultValue;
+    }
+
     // return a value for direction popup will expand, based on position and orientation
     function calcDirection(pos, o) {
       if (o === "horizontal") {
@@ -271,11 +278,29 @@ function initButton(sfHost, inInspector) {
       }
       return pos >= 55 ? "up" : null;
     }
-    function resetPopupClass(o) {
+
+    function resetPopupClass(source, dynamicHeight, orientation, position = '20', direction = null) {
       popupEl.className = "insext-popup";
-      popupEl.classList.add(`insext-popup-${o}`);
+      popupEl.classList.add(`insext-popup-${orientation}`);
+
+      //manage dynamic height of popup
+      const intPosition = Number(position)
+      
+      if (dynamicHeight) {
+        const height = direction === "up" ? intPosition : (98 - (orientation === "horizontal" ? 0 : intPosition)); //the height is the total height minus the position and the popup margin at the bottom
+        popupEl.style.height = `calc(${height}vh)`;
+
+        //in up direction, we need to adjust the top position to keep the popup on screen
+        if (direction === "up") {
+          popupEl.style.top = `calc(-${intPosition - 5}vh)`;
+        }
+      }
+      else {
+        popupEl.style.height = "";
+      }
     }
-    resetPopupClass(getOrientation("localStorage"));
+
+    resetPopupClass("localStorage",  getKeyFromStorage("localStorage", "popupHeighDynamictMode"), getOrientation("localStorage"));
     popupEl.src = popupSrc;
     addEventListener("message", e => {
       if (e.source != popupEl.contentWindow) {
@@ -286,8 +311,9 @@ function initButton(sfHost, inInspector) {
         iFrameLocalStorage = e.data.iFrameLocalStorage;
         const {popupArrowPosition: pos} = iFrameLocalStorage;
         const o = getOrientation("iframe");
+        const dynamicHeight = getKeyFromStorage("iframe", "popupHeighDynamictMode", "true") === "true";
         const dir = calcDirection(pos, o);
-        resetPopupClass(o);
+        resetPopupClass("iframe", dynamicHeight, o, pos, dir);
         if (dir) {
           popupEl.classList.add(`insext-popup-${o}-${dir}`);
         }

--- a/addon/button.js
+++ b/addon/button.js
@@ -143,7 +143,7 @@ function initButton(sfHost, inInspector) {
     img.src = p.imgSrc;
     rootElement.style[p.posStyle] = p.pos;
     rootElement.style[p.oStyle] = 0;
-    p.btnClasses.forEach(item => buttonElement.classList.add(item))
+    p.btnClasses.forEach(item => buttonElement.classList.add(item));
     buttonElement.appendChild(img);
   }
 
@@ -279,13 +279,13 @@ function initButton(sfHost, inInspector) {
       return pos >= 55 ? "up" : null;
     }
 
-    function resetPopupClass(source, dynamicHeight, orientation, position = '20', direction = null) {
+    function resetPopupClass(source, dynamicHeight, orientation, position = "20", direction = null) {
       popupEl.className = "insext-popup";
       popupEl.classList.add(`insext-popup-${orientation}`);
 
       //manage dynamic height of popup
-      const intPosition = Number(position)
-      
+      const intPosition = Number(position);
+
       if (dynamicHeight) {
         const height = direction === "up" ? intPosition : (98 - (orientation === "horizontal" ? 0 : intPosition)); //the height is the total height minus the position and the popup margin at the bottom
         popupEl.style.height = `calc(${height}vh)`;
@@ -294,13 +294,12 @@ function initButton(sfHost, inInspector) {
         if (direction === "up") {
           popupEl.style.top = `calc(-${intPosition - 5}vh)`;
         }
-      }
-      else {
+      } else {
         popupEl.style.height = "";
       }
     }
 
-    resetPopupClass("localStorage",  getKeyFromStorage("localStorage", "popupHeighDynamictMode"), getOrientation("localStorage"));
+    resetPopupClass("localStorage", getKeyFromStorage("localStorage", "popupHeighDynamictMode"), getOrientation("localStorage"));
     popupEl.src = popupSrc;
     addEventListener("message", e => {
       if (e.source != popupEl.contentWindow) {

--- a/addon/options.js
+++ b/addon/options.js
@@ -166,7 +166,7 @@ class OptionsTabSelector extends React.Component {
                 }
               }}
           },
-          {option: Option, props: {type: "toggle", title: "Enable Dynamic Popup Height", key: "popupHeighDynamictMode", default: true, tooltip: "When enabled, the popup height will be dynamically adjusted based on the content."}},
+          {option: Option, props: {type: "toggle", title: "Enable Dynamic Popup Height", key: "popupHeighDynamictMode", default: false, tooltip: "When enabled, the popup height will be dynamically adjusted based on the content."}},
         ]
       },
       {

--- a/addon/options.js
+++ b/addon/options.js
@@ -166,6 +166,7 @@ class OptionsTabSelector extends React.Component {
                 }
               }}
           },
+          {option: Option, props: {type: "toggle", title: "Enable Dynamic Popup Height", key: "popupHeighDynamictMode", default: true, tooltip: "When enabled, the popup height will be dynamically adjusted based on the content."}},
         ]
       },
       {

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -50,28 +50,21 @@ if (typeof browser === "undefined") {
 }
 
 function getFilteredLocalStorage() {
-  const existingFilteredStorage = sessionStorage.getItem("filteredStorage");
-  if (existingFilteredStorage) {
-    return JSON.parse(existingFilteredStorage);
-  }
-
-  let host = new URLSearchParams(window.location.search).get("host");
-
-  let domainStart = host?.split(".")[0];
+  const host = new URLSearchParams(window.location.search).get("host");
+  const domainStart = host?.split(".")[0];
   const storedData = {...localStorage};
   const keysToSend = [
     "scrollOnFlowBuilder",
     "colorizeProdBanner",
     "colorizeSandboxBanner",
-    "popupArrowOrientation",
-    "popupArrowPosition",
     "prodBannerText",
   ];
-  const filteredStorage = Object.fromEntries(
-    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
+
+  // Always get fresh values for keysToSend from localStorage
+  // to avoid cache issues when these values change in options
+  return Object.fromEntries(
+    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || key.startsWith('hide') || key.startsWith('popup') || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
   );
-  sessionStorage.setItem("filteredStorage", JSON.stringify(filteredStorage));
-  return filteredStorage;
 }
 function closePopup() {
   parent.postMessage({insextClosePopup: true}, "*");

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -63,7 +63,7 @@ function getFilteredLocalStorage() {
   // Always get fresh values for keysToSend from localStorage
   // to avoid cache issues when these values change in options
   return Object.fromEntries(
-    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || key.startsWith("hide") || key.startsWith("popup") || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
+    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || key.startsWith("popup") || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
   );
 }
 function closePopup() {

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -63,7 +63,7 @@ function getFilteredLocalStorage() {
   // Always get fresh values for keysToSend from localStorage
   // to avoid cache issues when these values change in options
   return Object.fromEntries(
-    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || key.startsWith('hide') || key.startsWith('popup') || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
+    Object.entries(storedData).filter(([key]) => (key.startsWith(domainStart) || key.startsWith("hide") || key.startsWith("popup") || keysToSend.includes(key)) && !key.endsWith(Constants.ACCESS_TOKEN))
   );
 }
 function closePopup() {

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -432,7 +432,7 @@ Because the IsPortalEnabled field does not exist in orgs where there is no porta
 
 ### Dynamic Popup Height
 
-You can leverage more window height in the popup, to reduce the scroll (Activated by default). To disable this feature, go to User Experience -> Enable Dynamic Popup Height and uncheck it.
+You can leverage more window height in the popup, to reduce the scroll. To enable this feature, go to User Experience -> Enable Dynamic Popup Height and check it.
 
 ## Generate a package.xml from a deployment
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -430,6 +430,10 @@ Because the IsPortalEnabled field does not exist in orgs where there is no porta
    * **Exclude Portal users** - Hides users who have portal access enabled
    * **Exclude Inactive users** - Hides users who are marked as inactive
 
+### Dynamic Popup Height
+
+You can leverage more window height in the popup, to reduce the scroll (Activated by default). To disable this feature, go to User Experience -> Enable Dynamic Popup Height and uncheck it.
+
 ## Generate a package.xml from a deployment
 
 From a DeployRequest record, click on the `Generate package.xml` button to download the package.xml for this deployment.


### PR DESCRIPTION
## Describe your changes
To reduce the scroll in the popup, the height of the popup has been increased by default (leveraging the window height)
- fix some CSS rules to remove the usage of !important and leverage CSS order of precedence
- calculate height/position based on the orientation/position
- fix popup parameter not taken into account after a window refresh
- add option to disable the feature User Experience -> Enable Dynamic Popup Height

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

