### PR TITLE
[fix] ensure that user context is loaded if user is the default tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0
 
-- Fix Popup issue when user is default tab [issue #974](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/974)
+- Fix Popup issue when User tab is configured as default one [issue #974](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/974) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - `Data Export` Data export new tab context [issue #1080](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1080)(contribution by [Maral Zakarian](https://github.com/MaralZak))
 - `Data Export` Add context menu (Close All, Close Others) for query tabs (contribution by [Idan Damari](https://github.com/iDamari))
 - `Data Export` Fix Save Query Menu with SLDS Styling (contribution by [Idan Damari](https://github.com/iDamari))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- Fix Popup issue when user is default tab [issue #974](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/974)
 - Add Flow Compare button to quickly access Salesforce's Flow Compare feature (Winter '26) (from `Flow Scanner` and `Popup`)
 - `Data Import` Only reset action if user hasn't manually selected one [issue #986](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/986) (contribution by [Ruben Halman](https://github.com/RubenHalman))
 - `Data Export` Fix query tab index numbering when adding new tabs after closing existing ones [issue #1059](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1059) (contribution by [mshivakumar2023-debug](https://github.com/mshivakumar2023-debug))

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -965,8 +965,7 @@ class AllDataBox extends React.PureComponent {
   componentDidMount() {
     if (this.state.activeSearchAspect === this.SearchAspectTypes.users) {
       this.ensureKnownUserContext();
-    }
-    else {
+    } else {
       this.ensureKnownBrowserContext();
     }
   }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -943,8 +943,13 @@ class AllDataBox extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.ensureKnownBrowserContext();
-    this.loadSobjects();
+    if (this.state.activeSearchAspect === this.SearchAspectTypes.users) {
+      this.ensureKnownUserContext();
+    }
+    else {
+      this.ensureKnownBrowserContext();
+      this.loadSobjects();
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -49,18 +49,20 @@ The creation of Connected Apps is soon to be deprecated (planned for Spring 26')
 
     >**Warning**
     >If you don't select the `web` scope, you might not be able to use the Login As Incognito.
-4. Configure Security settings:
+4. Flow Enablement
+   * Check the `Enable Authorization Code and Credentials Flow` and then check `Require user credentials in the POST body for Authorization Code and Credentials Flow`
+5. Configure Security settings:
    * **IMPORTANT: Deselect** (disable) `Require secret for Web Server Flow`.
    * Select (enable) `Require Proof Key for Code Exchange (PKCE) extension for Supported Authorization Flows`.
-5. Get Consumer Key and save it in the Options page
+6. Get Consumer Key and save it in the Options page
 
     <img alt="Option button" width="276" alt="image" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/14cc8aac-5ffc-4747-9da1-ba892231ace1">
 
-6. Enter the consumer key
+7. Enter the consumer key
 
     <img alt="Client Id" width="849" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/b1edfea1-5a56-4f42-8945-e452a7ab5cf5">
 
-7. Refresh page and generate new token
+8. Refresh page and generate new token
 
     <img width="275" alt="Generate Token" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/931df75d-42ac-4667-ab3f-35f6b6b65a66">
 


### PR DESCRIPTION
## Describe your changes
update componentDidMount in popup to load the proper context depending the default tab
/!\  this.loadSobjects(); must be removed at the end in the componentDidMount due to lazy loading of sobject definition managed in another PR

## Issue ticket number and link
[974](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/974)

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

