### PR TITLE
centralize action controls and styles in AllDataSelection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Show All Data` Centralize action controls and styles in `AllDataSelection` with reusable `actionWrapper`, `actionLink`, `actionButton` helpers and a dedicated `sfir-all-data-actions` container to fix alignment and reduce duplicated JSX (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Metadata` Add 'Run Relevant Tests' option to metadata deploy Test Level picklist [feature 1286](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1286)
 - `Popup` Fix language flag icons for Catalan and Basque on the Users tab [issue #1196](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1196)
 - `Custom Shortcuts` Add "Global" toggle to share a shortcut across all orgs instead of keeping it specific to the current org [feature 191](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/191)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Show All Data` Centralize action controls and styles in `AllDataSelection` with reusable `actionWrapper`, `actionLink`, `actionButton` helpers and a dedicated `sfir-all-data-actions` container to fix alignment and reduce duplicated JSX (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
 

--- a/addon/popup.css
+++ b/addon/popup.css
@@ -111,6 +111,13 @@ input.api-input {
   width: 100%;
 }
 
+/* The action row wrappers are slightly wider than their button due to
+   horizontal padding; extend the pointer cursor to the wrappers so hovering
+   the row doesn't fall back to the default cursor at its edges. */
+.sfir-all-data-actions div {
+  cursor: pointer;
+}
+
 .all-data-input {
   font-size: var(--sfir-font-lg);
   font-family: inherit;

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4172,6 +4172,8 @@ class AllDataSelection extends React.PureComponent {
       eventMonitorHref,
     } = this.props;
     let {flowDefinitionId} = this.state;
+    const actionWrapperClass = "slds-col slds-size_1-of-1 slds-p-horizontal_xx-small slds-m-bottom_xx-small";
+    const actionControlClass = "page-button slds-button slds-button_neutral";
     // Show buttons for the available APIs.
     let buttons = selectedValue.sobject.availableApis
       ? Array.from(selectedValue.sobject.availableApis)
@@ -4379,128 +4381,158 @@ class AllDataSelection extends React.PureComponent {
           linkTarget,
         })
       ),
-      selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
-        ? h(
-          "a",
-          {
-            href: this.getDeployStatusUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          "Check Deploy Status"
-        )
-        : null,
-      selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
-        ? h(
-          "a",
-          {
-            href: this.getGeneratePackageUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          "Generate package.xml"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.redirectToFlowVersions(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Versions"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.getFlowScannerUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Scanner"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.getFlowCompareUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Compare"
-        )
-        : null,
       h(
-        "div", {},
-        buttons.map((button, index) =>
-          h(
-            "a",
-            {
-              key: button,
-              // If buttons for both APIs are shown, the keyboard shortcut should open the first button.
-              ref: index == 0 ? "showAllDataBtn" : null,
-              href: this.getAllDataUrl(button == "toolingApi"),
-              target: linkTarget,
-              className:
-                "slds-button slds-button_neutral slds-m-top_xx-small page-button slds-button slds-button_neutral slds-m-top_xx-small",
-            },
-            index == 0
-              ? h("span", {}, "Show ", h("u", {}, "a"), "ll data")
-              : "Show all data",
-            button == "regularApi"
-              ? ""
-              : button == "toolingApi"
-                ? " (Tooling API)"
-                : " (Not readable)"
+        "div",
+        {className: "sfir-all-data-actions"},
+        selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getDeployStatusUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Check Deploy Status"
+            )
           )
-        )
-      ),
-      isFieldsPresent
-        ? h(
-          "button",
-          {
-            ref: "showFieldApiNameBtn",
-            onClick: showApiName,
-            "data-target-link": linkTarget,
-            className:
-                "slds-button slds-button_neutral slds-m-top_xx-small page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          h("span", {}, "Show ", h("u", {}, "f"), "ields API names")
-        )
-        : null,
-      selectedValue.sobject.name.endsWith("__e")
-        ? h(
-          "div",
-          {className: "slds-button-group slds-m-top_xx-small", role: "group"},
-          h(
-            "a",
-            {
-              href: this.getSubscribeUrl(selectedValue.sobject.name),
-              target: linkTarget,
-              className: "slds-button slds-button_neutral page-button",
-            },
-            h("span", {}, h("u", {}), "Subscribe Event")
-          ),
-          h(
-            "a",
-            {
-              href: this.getGenerateEventUrl(selectedValue.sobject.name),
-              target: linkTarget,
-              className: "slds-button slds-button_neutral page-button",
-            },
-            h("span", {}, "Generate Event")
+          : null,
+        selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getGeneratePackageUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Generate package.xml"
+            )
           )
-        )
-        : null
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.redirectToFlowVersions(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Versions"
+            )
+          )
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getFlowScannerUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Scanner"
+            )
+          )
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getFlowCompareUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Compare"
+            )
+          )
+          : null,
+        h(
+          "div", {},
+          buttons.map((button, index) =>
+            h(
+              "div",
+              {className: actionWrapperClass, key: button},
+              h(
+                "a",
+                {
+                  // If buttons for both APIs are shown, the keyboard shortcut should open the first button.
+                  ...(index == 0 ? {ref: "showAllDataBtn"} : {}),
+                  href: this.getAllDataUrl(button == "toolingApi"),
+                  target: linkTarget,
+                  className: actionControlClass,
+                },
+                index == 0
+                  ? h("span", {}, "Show ", h("u", {}, "a"), "ll data")
+                  : "Show all data",
+                button == "regularApi"
+                  ? ""
+                  : button == "toolingApi"
+                    ? " (Tooling API)"
+                    : " (Not readable)"
+              )
+            )
+          )
+        ),
+        isFieldsPresent
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "button",
+              {
+                ref: "showFieldApiNameBtn",
+                onClick: showApiName,
+                "data-target-link": linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, "Show ", h("u", {}, "f"), "ields API names")
+            )
+          )
+          : null,
+        selectedValue.sobject.name.endsWith("__e")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getSubscribeUrl(selectedValue.sobject.name),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, h("u", {}), "Subscribe Event")
+            )
+          )
+          : null,
+        selectedValue.sobject.name.endsWith("__e")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getGenerateEventUrl(selectedValue.sobject.name),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, "Generate Event")
+            )
+          )
+          : null
+      )
     );
   }
 }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4505,30 +4505,32 @@ class AllDataSelection extends React.PureComponent {
         selectedValue.sobject.name.endsWith("__e")
           ? h(
             "div",
-            {className: actionWrapperClass},
+            {role: "group", "aria-label": "Event actions"},
             h(
-              "a",
-              {
-                href: this.getSubscribeUrl(selectedValue.sobject.name),
-                target: linkTarget,
-                className: actionControlClass,
-              },
-              h("span", {}, h("u", {}), "Subscribe Event")
-            )
-          )
-          : null,
-        selectedValue.sobject.name.endsWith("__e")
-          ? h(
-            "div",
-            {className: actionWrapperClass},
+              "div",
+              {className: actionWrapperClass},
+              h(
+                "a",
+                {
+                  href: this.getSubscribeUrl(selectedValue.sobject.name),
+                  target: linkTarget,
+                  className: actionControlClass,
+                },
+                h("span", {}, h("u", {}), "Subscribe Event")
+              )
+            ),
             h(
-              "a",
-              {
-                href: this.getGenerateEventUrl(selectedValue.sobject.name),
-                target: linkTarget,
-                className: actionControlClass,
-              },
-              h("span", {}, "Generate Event")
+              "div",
+              {className: actionWrapperClass},
+              h(
+                "a",
+                {
+                  href: this.getGenerateEventUrl(selectedValue.sobject.name),
+                  target: linkTarget,
+                  className: actionControlClass,
+                },
+                h("span", {}, "Generate Event")
+              )
             )
           )
           : null

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4057,6 +4057,8 @@ class AllDataSelection extends React.PureComponent {
       eventMonitorHref,
     } = this.props;
     let {flowDefinitionId} = this.state;
+    const actionWrapperClass = "slds-col slds-size_1-of-1 slds-p-horizontal_xx-small slds-m-bottom_xx-small";
+    const actionControlClass = "page-button slds-button slds-button_neutral";
     // Show buttons for the available APIs.
     let buttons = selectedValue.sobject.availableApis
       ? Array.from(selectedValue.sobject.availableApis)
@@ -4264,128 +4266,158 @@ class AllDataSelection extends React.PureComponent {
           linkTarget,
         })
       ),
-      selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
-        ? h(
-          "a",
-          {
-            href: this.getDeployStatusUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          "Check Deploy Status"
-        )
-        : null,
-      selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
-        ? h(
-          "a",
-          {
-            href: this.getGeneratePackageUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          "Generate package.xml"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.redirectToFlowVersions(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Versions"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.getFlowScannerUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Scanner"
-        )
-        : null,
-      flowDefinitionId
-        ? h(
-          "a",
-          {
-            href: this.getFlowCompareUrl(),
-            target: linkTarget,
-            className:
-                "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-          },
-          "Flow Compare"
-        )
-        : null,
       h(
-        "div", {},
-        buttons.map((button, index) =>
-          h(
-            "a",
-            {
-              key: button,
-              // If buttons for both APIs are shown, the keyboard shortcut should open the first button.
-              ref: index == 0 ? "showAllDataBtn" : null,
-              href: this.getAllDataUrl(button == "toolingApi"),
-              target: linkTarget,
-              className:
-                "slds-button slds-button_neutral slds-m-top_xx-small page-button slds-button slds-button_neutral slds-m-top_xx-small",
-            },
-            index == 0
-              ? h("span", {}, "Show ", h("u", {}, "a"), "ll data")
-              : "Show all data",
-            button == "regularApi"
-              ? ""
-              : button == "toolingApi"
-                ? " (Tooling API)"
-                : " (Not readable)"
+        "div",
+        {className: "sfir-all-data-actions"},
+        selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getDeployStatusUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Check Deploy Status"
+            )
           )
-        )
-      ),
-      isFieldsPresent
-        ? h(
-          "button",
-          {
-            ref: "showFieldApiNameBtn",
-            onClick: showApiName,
-            "data-target-link": linkTarget,
-            className:
-                "slds-button slds-button_neutral slds-m-top_xx-small page-button slds-button slds-button_neutral slds-m-top_xx-small",
-          },
-          h("span", {}, "Show ", h("u", {}, "f"), "ields API names")
-        )
-        : null,
-      selectedValue.sobject.name.endsWith("__e")
-        ? h(
-          "div",
-          {className: "slds-button-group slds-m-top_xx-small", role: "group"},
-          h(
-            "a",
-            {
-              href: this.getSubscribeUrl(selectedValue.sobject.name),
-              target: linkTarget,
-              className: "slds-button slds-button_neutral page-button",
-            },
-            h("span", {}, h("u", {}), "Subscribe Event")
-          ),
-          h(
-            "a",
-            {
-              href: this.getGenerateEventUrl(selectedValue.sobject.name),
-              target: linkTarget,
-              className: "slds-button slds-button_neutral page-button",
-            },
-            h("span", {}, "Generate Event")
+          : null,
+        selectedValue.recordId && selectedValue.recordId.startsWith("0Af")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getGeneratePackageUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Generate package.xml"
+            )
           )
-        )
-        : null
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.redirectToFlowVersions(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Versions"
+            )
+          )
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getFlowScannerUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Scanner"
+            )
+          )
+          : null,
+        flowDefinitionId
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getFlowCompareUrl(),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              "Flow Compare"
+            )
+          )
+          : null,
+        h(
+          "div", {},
+          buttons.map((button, index) =>
+            h(
+              "div",
+              {className: actionWrapperClass, key: button},
+              h(
+                "a",
+                {
+                  // If buttons for both APIs are shown, the keyboard shortcut should open the first button.
+                  ...(index == 0 ? {ref: "showAllDataBtn"} : {}),
+                  href: this.getAllDataUrl(button == "toolingApi"),
+                  target: linkTarget,
+                  className: actionControlClass,
+                },
+                index == 0
+                  ? h("span", {}, "Show ", h("u", {}, "a"), "ll data")
+                  : "Show all data",
+                button == "regularApi"
+                  ? ""
+                  : button == "toolingApi"
+                    ? " (Tooling API)"
+                    : " (Not readable)"
+              )
+            )
+          )
+        ),
+        isFieldsPresent
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "button",
+              {
+                ref: "showFieldApiNameBtn",
+                onClick: showApiName,
+                "data-target-link": linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, "Show ", h("u", {}, "f"), "ields API names")
+            )
+          )
+          : null,
+        selectedValue.sobject.name.endsWith("__e")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getSubscribeUrl(selectedValue.sobject.name),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, h("u", {}), "Subscribe Event")
+            )
+          )
+          : null,
+        selectedValue.sobject.name.endsWith("__e")
+          ? h(
+            "div",
+            {className: actionWrapperClass},
+            h(
+              "a",
+              {
+                href: this.getGenerateEventUrl(selectedValue.sobject.name),
+                target: linkTarget,
+                className: actionControlClass,
+              },
+              h("span", {}, "Generate Event")
+            )
+          )
+          : null
+      )
     );
   }
 }


### PR DESCRIPTION
PR to fix this alignment issue:
<img width="796" height="1221" alt="image" src="https://github.com/user-attachments/assets/e3718f50-1da7-4c5e-b8af-85e66c2695e8" />

## Describe your changes

- Introduce reusable action helpers (actionWrapper, actionLink, actionButton) with shared SLDS classes
- Replace repeated anchor/button markup with helpers for deploy status, package.xml, flow tools, and API action buttons
- Wrap actions in a dedicated container (sfir-all-data-actions)

Why: Reduces duplicated JSX, enforces consistent styling/attributes (e.g., target/data-target-link), and simplifies future maintenance of action buttons.

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)