### PR TITLE
[feat] Data Export: Add context menu for managing open tabs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 2.0
 
+- `Data Export` Add context menu (Close All, Close Others) for query tabs (contribution by [Idan Damari](https://github.com/iDamari))
+- `Data Export` Fix Save Query Menu with SLDS Styling (contribution by [Idan Damari](https://github.com/iDamari))
 - Reduce API calls in popup by skipping unnecessary requests when not expanded [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - Add API Statistics page to track and monitor REST and SOAP API calls (enable via `Enable API Stats Debug Mode` in Options > API tab) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - `User Experience` Add dynamic popup height and option to enable / disable setting (contribution by [Nicolas Greard](https://github.com/ngreardSF))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1739,7 +1739,7 @@ class App extends React.Component {
       contextMenu: {
         x: e.clientX,
         y: e.clientY,
-        index: index
+        index
       }
     });
   }
@@ -2208,7 +2208,7 @@ class App extends React.Component {
           ),
           h("li", {className: "slds-dropdown__item", role: "presentation"},
             h("a", {href: "#", role: "menuitem", tabIndex: "-1", onClick: (e) => { e.preventDefault(); this.onRemoveOtherTabs(); }},
-              h("span", {className: "slds-truncate", title: "Close Other"}, "Close Other")
+              h("span", {className: "slds-truncate", title: "Close Others"}, "Close Others")
             )
           ),
           h("li", {className: "slds-dropdown__item", role: "presentation"},

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1930,17 +1930,7 @@ class App extends React.Component {
                   ),
                   h("input", {placeholder: "Query Label", type: "save", value: model.queryName, onInput: this.onSetQueryName}),
                   h("button", {className: "slds-button slds-button_neutral", onClick: this.onAddToHistory, title: "Add query to saved history"}, "Save Query"),
-                  h("button", {className: model.expandSavedOptions ? "slds-button slds-button_neutral toggle contract" : "slds-button slds-button_neutral toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"})),
-                  h("div", {className: "slds-dropdown-trigger slds-dropdown-trigger_click " + (model.expandSavedOptions ? "slds-is-open" : "slds-is-closed")},
-                    h("div", {className: "slds-dropdown slds-dropdown_right"},
-                      h("div", {className: "slds-dropdown__item"},
-                        h("a", {href: "#", onClick: this.onRemoveFromHistory, title: "Remove query from saved history"}, "Remove Saved Query")
-                      ),
-                      h("div", {className: "slds-dropdown__item"},
-                        h("a", {href: "#", onClick: this.onClearSavedHistory, title: "Clear saved history"}, "Clear Saved Queries")
-                      )
-                    )
-                  )
+                  h("button", {className: model.expandSavedOptions ? "slds-button slds-button_neutral toggle contract" : "slds-button slds-button_neutral toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"}))
                 ),
               ),
               h("div", {className: "slds-grid slds-grid_align-spread"},

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1126,6 +1126,34 @@ class Model {
     }
   }
 
+  removeOtherQueryTabs(index) {
+    if (this.queryTabs.length > 1) {
+      const tabToKeep = this.queryTabs[index];
+      this.queryTabs = [tabToKeep];
+      this.activeTabIndex = 0;
+      this.setActiveTab(this.activeTabIndex);
+      this.saveQueryTabs();
+      this.didUpdate();
+    }
+  }
+
+  removeRightQueryTabs(index) {
+    if (this.queryTabs.length > index + 1) {
+      this.queryTabs.splice(index + 1);
+      if (this.activeTabIndex > index) {
+        this.activeTabIndex = index;
+      }
+      this.setActiveTab(this.activeTabIndex);
+      this.saveQueryTabs();
+      this.didUpdate();
+    }
+  }
+
+  removeAllQueryTabs() {
+    this.queryTabs = [];
+    this.addQueryTab();
+  }
+
   setActiveTab(index) {
     this.activeTabIndex = index;
     // Update the query input value to match the current tab's query
@@ -1409,6 +1437,9 @@ class App extends React.Component {
     this.filterColumns = []; // Initialize as an empty array
     this.onAddTab = this.onAddTab.bind(this);
     this.onRemoveTab = this.onRemoveTab.bind(this);
+    this.onRemoveOtherTabs = this.onRemoveOtherTabs.bind(this);
+    this.onRemoveRightTabs = this.onRemoveRightTabs.bind(this);
+    this.onRemoveAllTabs = this.onRemoveAllTabs.bind(this);
     this.onTabClick = this.onTabClick.bind(this);
     this.onQueryInput = this.onQueryInput.bind(this);
     this.onTabNameEdit = this.onTabNameEdit.bind(this);
@@ -1418,6 +1449,9 @@ class App extends React.Component {
     this.onTabDrop = this.onTabDrop.bind(this);
     this.onTabDragLeave = this.onTabDragLeave.bind(this);
     this.onTabDragEnd = this.onTabDragEnd.bind(this);
+    this.onTabContextMenu = this.onTabContextMenu.bind(this);
+    this.onOverlayContextMenu = this.onOverlayContextMenu.bind(this);
+    this.onCloseContextMenu = this.onCloseContextMenu.bind(this);
 
     // Tab editing state
     this.state = {
@@ -1425,7 +1459,8 @@ class App extends React.Component {
       editingTabIndex: -1,
       editingTabName: "",
       draggedTabIndex: -1,
-      dropTargetIndex: -1
+      dropTargetIndex: -1,
+      contextMenu: null
     };
   }
   onQueryAllChange(e) {
@@ -1602,6 +1637,29 @@ class App extends React.Component {
     let {model} = this.props;
     model.removeQueryTab(index);
   }
+
+  onRemoveOtherTabs() {
+    let {model} = this.props;
+    if (this.state.contextMenu) {
+      model.removeOtherQueryTabs(this.state.contextMenu.index);
+    }
+    this.onCloseContextMenu();
+  }
+
+  onRemoveRightTabs() {
+    let {model} = this.props;
+    if (this.state.contextMenu) {
+      model.removeRightQueryTabs(this.state.contextMenu.index);
+    }
+    this.onCloseContextMenu();
+  }
+
+  onRemoveAllTabs() {
+    let {model} = this.props;
+    model.removeAllQueryTabs();
+    this.onCloseContextMenu();
+  }
+
   onTabClick(e, index) {
     e.preventDefault();
     let {model} = this.props;
@@ -1673,6 +1731,44 @@ class App extends React.Component {
     // Reset drag state when drag operation ends
     this.setState({draggedTabIndex: -1, dropTargetIndex: -1});
   }
+
+  onTabContextMenu(e, index) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({
+      contextMenu: {
+        x: e.clientX,
+        y: e.clientY,
+        index: index
+      }
+    });
+  }
+
+  onOverlayContextMenu(e) {
+    e.preventDefault();
+    e.target.style.visibility = "hidden";
+    let target = document.elementFromPoint(e.clientX, e.clientY);
+    e.target.style.visibility = "visible";
+
+    if (target) {
+      let event = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: e.clientX,
+        clientY: e.clientY
+      });
+      if (!target.dispatchEvent(event)) {
+        return;
+      }
+    }
+    this.onCloseContextMenu();
+  }
+
+  onCloseContextMenu() {
+    this.setState({contextMenu: null});
+  }
+
   componentDidMount() {
     let {model} = this.props;
     let queryInput = this.refs.query;
@@ -1834,7 +1930,17 @@ class App extends React.Component {
                   ),
                   h("input", {placeholder: "Query Label", type: "save", value: model.queryName, onInput: this.onSetQueryName}),
                   h("button", {className: "slds-button slds-button_neutral", onClick: this.onAddToHistory, title: "Add query to saved history"}, "Save Query"),
-                  h("button", {className: model.expandSavedOptions ? "slds-button slds-button_neutral toggle contract" : "slds-button slds-button_neutral toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"}))
+                  h("button", {className: model.expandSavedOptions ? "slds-button slds-button_neutral toggle contract" : "slds-button slds-button_neutral toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"})),
+                  h("div", {className: "slds-dropdown-trigger slds-dropdown-trigger_click " + (model.expandSavedOptions ? "slds-is-open" : "slds-is-closed")},
+                    h("div", {className: "slds-dropdown slds-dropdown_right"},
+                      h("div", {className: "slds-dropdown__item"},
+                        h("a", {href: "#", onClick: this.onRemoveFromHistory, title: "Remove query from saved history"}, "Remove Saved Query")
+                      ),
+                      h("div", {className: "slds-dropdown__item"},
+                        h("a", {href: "#", onClick: this.onClearSavedHistory, title: "Clear saved history"}, "Clear Saved Queries")
+                      )
+                    )
+                  )
                 ),
               ),
               h("div", {className: "slds-grid slds-grid_align-spread"},
@@ -1891,7 +1997,8 @@ class App extends React.Component {
                 onDragOver: e => this.onTabDragOver(e, index),
                 onDragLeave: e => this.onTabDragLeave(e),
                 onDrop: e => this.onTabDrop(e, index),
-                onDragEnd: e => this.onTabDragEnd(e)
+                onDragEnd: e => this.onTabDragEnd(e),
+                onContextMenu: e => this.onTabContextMenu(e, index)
               },
               this.state.editingTabIndex === index
                 ? h("input", {
@@ -2091,7 +2198,41 @@ class App extends React.Component {
               style: {flex: "1 1 0", minHeight: 0, maxHeight: "100%", overflowY: "auto"}
             }
             )
-          ))
+          )
+        ),
+        this.state.contextMenu && h("div", {
+          className: "context-menu-overlay",
+          style: {position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 1000},
+          onClick: this.onCloseContextMenu,
+          onContextMenu: this.onOverlayContextMenu
+        }),
+        this.state.contextMenu && h("div", {
+          className: "slds-dropdown slds-dropdown_left slds-dropdown_small",
+          style: {position: "fixed", top: this.state.contextMenu.y, left: this.state.contextMenu.x, zIndex: 3000}
+        },
+        h("ul", {className: "slds-dropdown__list", role: "menu"},
+          h("li", {className: "slds-dropdown__item", role: "presentation"},
+            h("a", {href: "#", role: "menuitem", tabIndex: "-1", onClick: (e) => { e.preventDefault(); this.onRemoveTab(e, this.state.contextMenu.index); this.onCloseContextMenu(); }},
+              h("span", {className: "slds-truncate", title: "Close"}, "Close")
+            )
+          ),
+          h("li", {className: "slds-dropdown__item", role: "presentation"},
+            h("a", {href: "#", role: "menuitem", tabIndex: "-1", onClick: (e) => { e.preventDefault(); this.onRemoveOtherTabs(); }},
+              h("span", {className: "slds-truncate", title: "Close Other"}, "Close Other")
+            )
+          ),
+          h("li", {className: "slds-dropdown__item", role: "presentation"},
+            h("a", {href: "#", role: "menuitem", tabIndex: "-1", onClick: (e) => { e.preventDefault(); this.onRemoveRightTabs(); }},
+              h("span", {className: "slds-truncate", title: "Close to the Right"}, "Close to the Right")
+            )
+          ),
+          h("li", {className: "slds-dropdown__item", role: "presentation"},
+            h("a", {href: "#", role: "menuitem", tabIndex: "-1", onClick: (e) => { e.preventDefault(); this.onRemoveAllTabs(); }},
+              h("span", {className: "slds-truncate", title: "Close All"}, "Close All")
+            )
+          )
+        )
+        )
       )
     );
   }

--- a/docs/data-export.md
+++ b/docs/data-export.md
@@ -22,13 +22,18 @@ The Data Export page now supports multiple query tabs, allowing you to work on s
 - **Drag & Drop Reordering**: Click and drag tabs to reorder them according to your preference. The tab positions are automatically saved.
 - **Handling Duplicate Names**: If you open a new tab for an SObject that already has a tab, or if you manually create tabs with duplicate names, a number will be appended to keep them unique (e.g., "Account (1)", "Account (2)").
 - **Preserved Context**: Each tab remembers its own query and the results from the last time it was run. When you switch between tabs, the query and its results are instantly restored.
+- **Context Menu Actions**: **Right-click** on any tab to access the context menu with quick actions:
+  - **Close tab**: Close the selected tab
+  - **Close other tabs**: Close all tabs except the selected one
+  - **Close tabs to the right**: Close all tabs to the right of the selected tab
+  - **Close all tabs**: Close all tabs (creates a new empty tab if all are closed)
 
 ### How to Use
 
 - **Create a new tab**: Click the `+` button in the tab bar
 - **Edit tab names**: Double-click on any tab name, type your custom name, and press Enter
 - **Reorder tabs**: Click and drag any tab to move it to your preferred position
-- **Close tabs**: Click the `×` button on any tab (except when only one tab remains)
+- **Close tabs**: Click the `×` button on any tab (except when only one tab remains), or right-click to access more closing options via the context menu
 
 All tab names and positions are automatically saved and will persist between browser sessions.
 


### PR DESCRIPTION
## Describe your changes
Adds a UI enhancement enabling a right-click context menu on tabs for efficient tab management.

The context menu supports:
- Close tab
- Close other tabs
- Close tabs to the right
- Close all tabs

This improves usability when working with many open tabs and aligns behavior with common browser and IDE tab management.

<img width="461" height="269" alt="tab-context-menu" src="https://github.com/user-attachments/assets/107b8abb-9547-468e-8a8d-08b5009879a3" />

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)