### PR TITLE
[fix] Data Export: Clear Saved Query Menu SLDS Styling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Data Export` Fix Save Query Menu with SLDS Styling (contribution by [Idan Damari](https://github.com/iDamari))
 - Reduce API calls in popup by skipping unnecessary requests when not expanded [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - Add API Statistics page to track and monitor REST and SOAP API calls (enable via `Enable API Stats Debug Mode` in Options > API tab) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - `User Experience` Add dynamic popup height and option to enable / disable setting (contribution by [Nicolas Greard](https://github.com/ngreardSF))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1823,10 +1823,6 @@ class App extends React.Component {
                   ),
                   h("button", {className: "slds-button slds-button_neutral", onClick: this.onClearHistory, title: "Clear Query History"}, "Clear")
                 ),
-                h("div", {className: "pop-menu saveOptions", hidden: !model.expandSavedOptions},
-                  h("a", {href: "#", onClick: this.onRemoveFromHistory, title: "Remove query from saved history"}, "Remove Saved Query"),
-                  h("a", {href: "#", onClick: this.onClearSavedHistory, title: "Clear saved history"}, "Clear Saved Queries")
-                ),
                 h("div", {className: "slds-button-group slds-m-left_small"},
                   h("select", {value: JSON.stringify(model.selectedSavedEntry), onChange: this.onSelectSavedEntry, className: "query-history"},
                     h("option", {value: JSON.stringify(null), disabled: true}, "Saved Queries"),
@@ -1835,6 +1831,16 @@ class App extends React.Component {
                   h("input", {placeholder: "Query Label", type: "save", value: model.queryName, onInput: this.onSetQueryName}),
                   h("button", {className: "slds-button slds-button_neutral", onClick: this.onAddToHistory, title: "Add query to saved history"}, "Save Query"),
                   h("button", {className: model.expandSavedOptions ? "slds-button slds-button_neutral toggle contract" : "slds-button slds-button_neutral toggle expand", title: "Show More Options", onClick: this.onToggleSavedOptions}, h("div", {className: "button-toggle-icon"}))
+                ),
+                h("div", {className: "slds-dropdown-trigger slds-dropdown-trigger_click " + (model.expandSavedOptions ? "slds-is-open" : "slds-is-closed")},
+                  h("div", {className: "slds-dropdown slds-dropdown_right"},
+                    h("div", {className: "slds-dropdown__item"},
+                      h("a", {href: "#", onClick: this.onRemoveFromHistory, title: "Remove query from saved history"}, "Remove Saved Query")
+                    ),
+                    h("div", {className: "slds-dropdown__item"},
+                      h("a", {href: "#", onClick: this.onClearSavedHistory, title: "Clear saved history"}, "Clear Saved Queries")
+                    )
+                  )
                 ),
               ),
               h("div", {className: "slds-grid slds-grid_align-spread"},


### PR DESCRIPTION
## Describe your changes
Removes the legacy "clear saved query" options and replaces them with an SLDS compliant dropdown menu.

Old menu:
<img width="482" height="75" alt="old-clear-saved-query-menu" src="https://github.com/user-attachments/assets/84fc82c4-ca71-4f92-9a24-07b8ac640946" />

New menu:
<img width="482" height="148" alt="new-clear-saved-query-menu" src="https://github.com/user-attachments/assets/d70ac080-7f19-43c9-99a5-ed98ab7f12a9" />

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

