### PR TITLE
[fix] Data Import : issue with quoted words

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Data Import` Fix data import issue with quoted words [issue #748](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/748) (contribution by [Maral Zakarian](https://github.com/MaralZak)
 - `Data Export` Add context menu (Close All, Close Others) for query tabs (contribution by [Idan Damari](https://github.com/iDamari))
 - `Data Export` Fix Save Query Menu with SLDS Styling (contribution by [Idan Damari](https://github.com/iDamari))
 - Reduce API calls in popup by skipping unnecessary requests when not expanded [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437) (contribution by [Nicolas Greard](https://github.com/ngreardSF))

--- a/addon/csv-parse-test.js
+++ b/addon/csv-parse-test.js
@@ -10,7 +10,8 @@ export async function csvParseTest(test) {
   assertThrows({name: 'CSVParseError', message: 'Quote not closed', offsetStart: 4, offsetEnd: 5}, () => csvParse('"a","b\nc,d', ',')); // unclosed quote
   assertEquals([['aa', 'b"b'], ['c""c', 'dd"']], csvParse('aa,b"b\nc""c,dd"', ',')); // unquoted values may contain quotes, as long as they are not at the beginning of the value. These should not be unescaped.
   assertEquals([['a"a', 'bb'], ['c""c', 'dd']], csvParse('"a""a","bb"\n"c""""c","dd"', ',')); // quoted values may contain escaped quotes. These should be unescaped (by replacing each pair of quotes with a single quote).
-  assertThrows({name: 'CSVParseError', message: "unexpected token 'c'", offsetStart: 15, offsetEnd: 16}, () => csvParse('"a""a","bb"\n"c"c","dd"', ',')); // quoted values cannot contain unescaped quotes
+  assertEquals([['a"a', 'bb'], ['"c"c"', 'dd']], csvParse('"a""a","bb"\n"c"c","dd"', ',')); // quoted values with unescaped quotes are now treated leniently as unquoted fields to handle user data with quotes
+  assertEquals([['foo', 'bar'], ['foo', '"bar"text after quote']], csvParse('"foo","bar"\r\n"foo","bar"text after quote', ',')); // text after closing quote is handled gracefully (fixes issue with quotes in imported data)
   // Line breaks
   assertEquals([['a', 'b'], ['c', 'd']], csvParse('a,b\nc,d', ',')); // LF
   assertEquals([['a', 'b'], ['c', 'd']], csvParse('a,b\r\nc,d', ',')); // CRLF

--- a/addon/csv-parse.js
+++ b/addon/csv-parse.js
@@ -5,6 +5,7 @@ export function csvParse(csv, separator) {
   for (;;) { // for each value. Each iteration parses a cell value including following cell ceparator or line ceparator
     // parse cell value
     if (offset != csv.length && csv[offset] == "\"") { // quoted value
+      let quoteStart = offset;
       let next = csv.indexOf("\"", offset + 1);
       let text = "";
       for (;;) {
@@ -23,6 +24,31 @@ export function csvParse(csv, separator) {
         }
         text += "\"";
         next = csv.indexOf("\"", offset + 1);
+      }
+      // After closing quote, check if next character is separator, line break, or EOF
+      // If not, this might be malformed CSV (like "Hello"world). 
+      // We'll be lenient: treat the quote as part of an unquoted field and reparse from the start
+      if (offset < csv.length && csv[offset] != separator && csv[offset] != "\n" && csv[offset] != "\r") {
+        // There's content after the closing quote that's not a separator or line break
+        // This is malformed CSV, but we'll be lenient and treat it as an unquoted field
+        // Reset to the original quote position and parse as unquoted
+        offset = quoteStart;
+        // find the first EOF, separator, "\r" or "\n" from the quote position
+        let unquotedNext = csv.length;
+        let i = csv.indexOf(separator, offset);
+        if (i != -1 && i < unquotedNext) {
+          unquotedNext = i;
+        }
+        i = csv.indexOf("\n", offset);
+        if (i != -1 && i < unquotedNext) {
+          unquotedNext = i;
+        }
+        i = csv.indexOf("\r", offset);
+        if (i != -1 && i < unquotedNext) {
+          unquotedNext = i;
+        }
+        text = csv.substring(offset, unquotedNext);
+        offset = unquotedNext;
       }
       row.push(text);
     } else { // unquoted value

--- a/addon/csv-parse.js
+++ b/addon/csv-parse.js
@@ -26,7 +26,7 @@ export function csvParse(csv, separator) {
         next = csv.indexOf("\"", offset + 1);
       }
       // After closing quote, check if next character is separator, line break, or EOF
-      // If not, this might be malformed CSV (like "Hello"world). 
+      // If not, this might be malformed CSV (like "Hello"world).
       // We'll be lenient: treat the quote as part of an unquoted field and reparse from the start
       if (offset < csv.length && csv[offset] != separator && csv[offset] != "\n" && csv[offset] != "\r") {
         // There's content after the closing quote that's not a separator or line break

--- a/addon/data-import-test.js
+++ b/addon/data-import-test.js
@@ -320,9 +320,9 @@ export async function dataImportTest(test) {
   assertEquals({Queued: 0, Processing: 0, Succeeded: 0, Failed: 0}, vm.importCounts());
 
   vm.setData('"foo","bar"\r\n"foo","bar"text after quote');
-  assertEquals(true, vm.invalidInput());
-  assertEquals("Error: unexpected token 't'", vm.dataError);
-  assertEquals({Queued: 0, Processing: 0, Succeeded: 0, Failed: 0}, vm.importCounts());
+  assertEquals(false, vm.invalidInput());
+  assertEquals("", vm.dataError);
+  assertEquals({Queued: 1, Processing: 0, Succeeded: 0, Failed: 0}, vm.importCounts());
 
   vm.setData("a,b\r\nc,d\r\ne");
   assertEquals(true, vm.invalidInput());


### PR DESCRIPTION
## Describe your changes
Fixed the CSV parser to handle quotes. Updated csv-parse.js: After a closing quote, if the next character isn't a separator, line break, or EOF, the parser treats the entire field (including the quote) as unquoted. This handles cases like "Hello"world or "Hello" world.

## Issue ticket number and link
[issue #748](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/748)

## Checklist before requesting a review
- [X] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] Target branch is releaseCandidate and not master
- [X] I have performed a self-review of my code
- [X] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [X] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

