### PR TITLE
[feat] Options: Group options with section header

### DIFF
--- a/addon/options.js
+++ b/addon/options.js
@@ -197,6 +197,7 @@ class OptionsTabSelector extends React.Component {
         id: "data-export",
         tabTitle: "Data Export",
         content: [
+          {option: SectionHeader, props: {title: "General"}},
           {option: CSVSeparatorOption, props: {key: 1}},
           {option: Option, props: {type: "toggle", title: "Display Query Execution Time", key: "displayQueryPerformance", default: true}},
           {option: Option, props: {type: "toggle", title: "Show Local Time", key: "showLocalTime", default: false}},
@@ -649,6 +650,12 @@ class APIVersionOption extends React.Component {
         )
       )
     );
+  }
+}
+
+class SectionHeader extends React.Component {
+  render() {
+    return h("h3", {className: "slds-section-title--divider slds-m-top_medium slds-m-bottom_medium"}, this.props.title);
   }
 }
 


### PR DESCRIPTION
## Describe your changes
Component: Adds a new SectionHeader component with SLDS-compliant styling.
Organization: Split the options into distinct sections.

Usage:
```
content: [
...
{option: SectionHeader, props: {title: "TITLE_PLACEHOLDER"}}, 
...
]
```
<img width="513" height="440" alt="option-group-header" src="https://github.com/user-attachments/assets/96ada2ef-cd04-4667-99d8-8bc924125449" />

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional) 

