### PR TITLE
fix: Improve screen reader accessibility for core UI controls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0
 
-- `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title (contribution by [akj](https://github.com/akj))
+- `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title issues [#1107](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1107) & [#1108](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1108) (contribution by [akj](https://github.com/akj))
 - `Dependencies Explorer` (contribution by [Georgi Dobrishinov](https://github.com/dobrishinov))
 - `Flow Scanner` Extract Flow Scanner rules logic into shared module (fixes the Flow Scanner import flash on the Options page) contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - Introduce SObjectList cache to prevent request to Salesforce requests to be sent each time the popup opens [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title (contribution by [akj](https://github.com/akj))
 - `Dependencies Explorer` (contribution by [Georgi Dobrishinov](https://github.com/dobrishinov))
 - `Flow Scanner` Extract Flow Scanner rules logic into shared module (fixes the Flow Scanner import flash on the Options page) contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - Introduce SObjectList cache to prevent request to Salesforce requests to be sent each time the popup opens [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437)

--- a/addon/button.css
+++ b/addon/button.css
@@ -65,6 +65,14 @@
   #insext.insext-active .insext-popup {
     display: block;
   }
+  #insext button.insext-btn {
+    appearance: none;
+    -webkit-appearance: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+  }
   #insext .insext-btn {
     box-sizing: border-box;
     background: rgba(255, 255, 255, 0.9);

--- a/addon/button.js
+++ b/addon/button.js
@@ -19,10 +19,10 @@ if (document.querySelector("body.sfdcBody, body.ApexCSIPage, #auraLoadingBox, #s
 function initButton(sfHost, inInspector) {
   let rootEl = document.createElement("div");
   rootEl.id = "insext";
-  let btn = document.createElement("div");
+  let btn = document.createElement("button");
   let iFrameLocalStorage = {};
+  btn.type = "button";
   btn.className = "insext-btn";
-  btn.tabIndex = 0;
   btn.accessKey = "i";
   btn.title = "Show Salesforce details (Alt+I / Shift+Alt+I)";
   rootEl.appendChild(btn);
@@ -261,6 +261,7 @@ function initButton(sfHost, inInspector) {
 
     let popupSrc = chrome.runtime.getURL("popup.html?host=" + sfHost);
     let popupEl = document.createElement("iframe");
+    popupEl.title = "Salesforce Inspector Reloaded";
 
     function getOrientation(source) {
       return getKeyFromStorage(source, "popupArrowOrientation", "vertical");

--- a/addon/components/AlertBanner.js
+++ b/addon/components/AlertBanner.js
@@ -7,7 +7,7 @@ class AlertBanner extends React.PureComponent {
     let {type, iconName, iconTitle, bannerText, link, assistiveText, onClose} = this.props;
     return (
       h("div", {className: `slds-notify slds-notify_alert slds-theme_${type}`, role: "alert"},
-        h("span", {className: "slds-assistive-text"}, assistiveText | "Notification"),
+        h("span", {className: "slds-assistive-text"}, assistiveText || "Notification"),
         h("span", {className: `slds-icon_container slds-icon-utility-${iconName} slds-m-right_small slds-no-flex slds-align-top`, title: iconTitle},
           h("svg", {className: "slds-icon slds-icon_small", viewBox: "0 0 52 52"},
             h("use", {xlinkHref: `symbols.svg#${iconName}`})

--- a/addon/components/Tooltip.js
+++ b/addon/components/Tooltip.js
@@ -28,9 +28,12 @@ class Tooltip extends React.Component {
     this.setState({position: {x, y}, opacity: 1});
   }
 
-  onClick(e) {
-    e.preventDefault();
-    this.show();
+  onClick() {
+    if (this.state.isTooltipVisible) {
+      this.onHide();
+    } else {
+      this.show();
+    }
   }
 
   onHover() {
@@ -56,7 +59,7 @@ class Tooltip extends React.Component {
     }
 
     return h("span", {style: {marginLeft: "2px"}, id: this.iconKey},
-      h("a", {href: "#", onClick: this.onClick, onMouseEnter: this.onHover, onMouseLeave: this.onHide},
+      h("button", {type: "button", className: "slds-button slds-button_reset", onClick: this.onClick, onMouseEnter: this.onHover, onMouseLeave: this.onHide},
         h("span", {className: "slds-icon_container slds-icon-utility-info"},
           h("svg", {className: "slds-icon_xx-small slds-icon-text-default", viewBox: "0 0 40 40", style: {verticalAlign: "unset", margin: "3px"}},
             h("use", {xlinkHref: "symbols.svg#info", fill: "#9c9c9c"}),

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -239,8 +239,8 @@ class App extends React.PureComponent {
         type: config.type || "info",
         bannerText: config.bannerText || "Action completed",
         iconName: config.iconName || "info",
-        assistiveTest:
-          config.assistiveTest || config.bannerText || "Notification",
+        assistiveText:
+          config.assistiveText || config.bannerText || "Notification",
         link: config.link || null,
         onClose: config.onClose || this.hideToast,
         ...config, // Allow any additional AlertBanner props
@@ -416,7 +416,7 @@ class App extends React.PureComponent {
           bannerText: `Current Version: ${addonVersion}`,
           iconName: "notification",
           iconTitle: "Notification",
-          assistiveTest: "Version Update Notification",
+          assistiveText: "Version Update Notification",
           onClose: () => this.updateReleaseNotesViewed(addonVersion),
           link: {
             text: "See What's New",
@@ -433,7 +433,7 @@ class App extends React.PureComponent {
           h(AlertBanner, {type: bannerUrlAction.type,
             bannerText: bannerUrlAction.text,
             iconName: bannerUrlAction.icon,
-            assistiveTest: bannerUrlAction.text,
+            assistiveText: bannerUrlAction.text,
             onClose: null,
             link: {
               text: bannerUrlAction.title,
@@ -450,7 +450,7 @@ class App extends React.PureComponent {
             type: this.state.toastConfig.type,
             bannerText: this.state.toastConfig.bannerText,
             iconName: this.state.toastConfig.iconName,
-            assistiveTest: this.state.toastConfig.assistiveTest,
+            assistiveText: this.state.toastConfig.assistiveText,
             onClose: this.state.toastConfig.onClose,
             link: this.state.toastConfig.link,
             // Spread any additional props
@@ -461,7 +461,7 @@ class App extends React.PureComponent {
                     "type",
                     "bannerText",
                     "iconName",
-                    "assistiveTest",
+                    "assistiveText",
                     "onClose",
                     "link",
                   ].includes(key)
@@ -2822,7 +2822,7 @@ class UserDetails extends React.PureComponent {
         type: "success",
         bannerText: operation,
         iconName: "success",
-        assistiveTest: `${operation} completed successfully`,
+        assistiveText: `${operation} completed successfully`,
         link: link || {
           text: message || `${operation} completed successfully`,
         },
@@ -2837,7 +2837,7 @@ class UserDetails extends React.PureComponent {
         type: "error",
         bannerText: `${operation} Failed`,
         iconName: "error",
-        assistiveTest: `Failed to ${operation.toLowerCase()}`,
+        assistiveText: `Failed to ${operation.toLowerCase()}`,
         link: message ? {
           text: message,
         } : {


### PR DESCRIPTION
## Describe your changes

Fix several screen reader accessibility issues with core UI controls:

- **AlertBanner silent announcements**: `AlertBanner.js:10` used bitwise OR (`|`) instead of logical OR (`||`), causing assistive text to render as `0` instead of the fallback string. Additionally, all callers in `popup.js` passed `assistiveTest` (typo) instead of `assistiveText`, so the prop never reached the component.
- **Inspector button not announced as button**: The injected inspector button was a `<div>` with `tabIndex=0`. Converted to a native `<button>` element which provides built-in keyboard activation (Enter/Space) and correct screen reader role announcement. Added CSS reset to preserve existing visual appearance.
- **Popup iframe unnamed**: Screen readers announced the popup as "frame" with no description. Added `title="Salesforce Inspector Reloaded"` to the iframe element.
- **Tooltip trigger announced as link**: Tooltip info icons used `<a href="#">` which screen readers announced as a link despite performing an action. Converted to `<button>` with `slds-button_reset` class. Also fixed `onClick` to toggle visibility so tooltips can be dismissed via keyboard (previously `onClick` only called `show()` with no way to hide).

## Issue ticket number and link

#1107 
#1108 

## Checklist before requesting a review
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] Target branch is releaseCandidate and not master
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)