### PR TITLE
[fix] REST explorer performance issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Rest Explorer` fix a performance issue (edit entrypoint rerender completely the output even if no changes) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - Fix popup/detail record name field [issue #274](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/274) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - `Data Export` Fix Column order not respected when performing subqueries [#598](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/598)
 - `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title issues [#1107](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1107) & [#1108](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1108) (contribution by [akj](https://github.com/akj))

--- a/addon/rest-explore.js
+++ b/addon/rest-explore.js
@@ -92,6 +92,7 @@ class Model {
     this.exportProgress = {};
     this.queryName = "";
     this.apiResponse = null;
+    this.responseCounter = 0;
     this.canSendRequest = true;
     this.resultClass = "neutral";
     this.request = {endpoint: "", method: "get", body: "", headers: ""};
@@ -367,6 +368,7 @@ class Model {
             value: this.formatResponse(responseText, fallbackFormat),
             size: responseSize
           };
+          this.responseCounter++;
           return;
         }
       } else {
@@ -381,6 +383,7 @@ class Model {
       value: responseData ? this.formatResponse(responseData, format) : "NONE",
       size: responseSize
     };
+    this.responseCounter++;
 
     // Extract new API endpoints from successful JSON responses
     if (this.resultClass === "success" && responseData && typeof responseData === "object" && !Array.isArray(responseData)) {
@@ -499,6 +502,7 @@ class App extends React.Component {
   }
   resetRequest(model) {
     model.apiResponse = "";
+    model.responseCounter++;
     model.didUpdate();
   }
   onSelectQueryMethod(e) {
@@ -630,8 +634,11 @@ class App extends React.Component {
   }
   componentDidUpdate() {
     this.recalculateSize();
-    if (window.Prism) {
+    // Only run Prism when a new query result arrived - skip when just typing in endpoint/body.
+    const counter = this.props.model?.responseCounter ?? 0;
+    if (counter !== this._lastHighlightedCounter && this.props.model?.apiResponse && window.Prism) {
       window.Prism.highlightAll();
+      this._lastHighlightedCounter = counter;
     }
   }
   canSendRequest() {


### PR DESCRIPTION
# Describe your changes
After a first callout to Salesforce servers, the ouptut is rendered using Prims. When you want to edit the entrypoint for example after this first call using your keyboard, you can see some latency (because the output is rerendered).

- Add a response counter that is increment each time we do a "callout" action
- Use this new variable to detect if it has changed and we need to rerender the json output 

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
