### PR TITLE
[fix] recent items scroll + remove ListView from recent records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Popup` fix recent items scroll not working anymore in v2 (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - Fix popup/detail record name field [issue #274](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/274) (contribution by [Nicolas Greard](https://github.com/ngreardSF))
 - `Data Export` Fix Column order not respected when performing subqueries [#598](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/598)
 - `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title issues [#1107](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1107) & [#1108](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1108) (contribution by [akj](https://github.com/akj))

--- a/addon/options.js
+++ b/addon/options.js
@@ -142,6 +142,7 @@ class OptionsTabSelector extends React.Component {
               ]}
           },
           {option: Option, props: {type: "toggle", title: "Enable Dynamic Popup Height", key: "popupHeighDynamictMode", default: false, tooltip: "When enabled, the popup height will be dynamically adjusted based on the content."}},
+          {option: Option, props: {type: "toggle", title: "Show recently viewed records in popup", key: Constants.ENABLE_RECENTLY_VIEWED_RECORDS, default: true, tooltip: "When enabled, queries and displays recently viewed records when focusing the Object search field in the popup."}},
         ]
       },
       {

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4571,6 +4571,9 @@ class Autocomplete extends React.PureComponent {
   }
   handleFocus() {
     let {recentItems} = this.props;
+    if (!isSettingEnabled(Constants.ENABLE_RECENTLY_VIEWED_RECORDS, true)) {
+      return;
+    }
     sfConn
       .rest(
         `/services/data/v${apiVersion}/query/?q=SELECT+Id,Name,Type+FROM+RecentlyViewed+WHERE+Type!='ListView'+LIMIT+${RECENT_ITEMS_RENDERED_COUNT}`

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -7,6 +7,7 @@ import AlertBanner from "./components/AlertBanner.js";
 let p = parent;
 let hideButtonsOption = JSON.parse(localStorage.getItem("hideButtonsOption"));
 const isExtensionPage = document.location.ancestorOrigins?.[0].includes(getExtensionId());
+const RECENT_ITEMS_RENDERED_COUNT = 100;
 
 let h = React.createElement;
 if (typeof browser === "undefined") {
@@ -4572,9 +4573,7 @@ class Autocomplete extends React.PureComponent {
     let {recentItems} = this.props;
     sfConn
       .rest(
-        "/services/data/v"
-          + apiVersion
-          + "/query/?q=SELECT+Id,Name,Type+FROM+RecentlyViewed+LIMIT+100"
+        `/services/data/v${apiVersion}/query/?q=SELECT+Id,Name,Type+FROM+RecentlyViewed+WHERE+Type!='ListView'+LIMIT+${RECENT_ITEMS_RENDERED_COUNT}`
       )
       .then((res) => {
         let itemsIds = new Set();
@@ -4770,20 +4769,15 @@ class Autocomplete extends React.PureComponent {
       itemHeight,
       resultsMouseIsDown,
     } = this.state;
-    // For better performance only render the visible autocomplete items + at least one invisible item above and below (if they exist)
-    const RENDERED_ITEMS_COUNT = 11;
-    let firstIndex = 0;
+
     let autocompleteResults
       = recentItems.length > 0 ? recentItems : matchingResults;
     let lastIndex = autocompleteResults.length - 1;
     let firstRenderedIndex = Math.max(0, scrollTopIndex - 2);
     let lastRenderedIndex = Math.min(
       lastIndex,
-      firstRenderedIndex + RENDERED_ITEMS_COUNT
+      firstRenderedIndex + RECENT_ITEMS_RENDERED_COUNT
     );
-    let topSpace = (firstRenderedIndex - firstIndex) * itemHeight;
-    let bottomSpace = (lastIndex - lastRenderedIndex) * itemHeight;
-    let topSelected = (selectedIndex - firstIndex) * itemHeight;
 
     return h(
       "div",

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -24,6 +24,7 @@ export class Constants {
   // Options
   static PRELOAD_SOBJECTS_BEFORE_POPUP = "preloadSobjectsBeforePopup";
   static ENABLE_SOBJECTS_LIST_CACHE = "enableSobjectsListCache";
+  static ENABLE_RECENTLY_VIEWED_RECORDS = "enableRecentlyViewedRecords";
 }
 
 /**

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -374,6 +374,17 @@ You can configure which tab should be selected by default when opening the popup
 
 The selected tab will be remembered and used as the default when opening the popup.
 
+## Show recently viewed records in popup
+
+When you focus the Object search field in the popup, the extension queries and displays your recently viewed records for quick access. This is **enabled by default**. The option allows you to disable it if you prefer not to query or display recently viewed records:
+
+1. Open the options page
+2. Go to the "User Experience" tab
+3. Find the "Show recently viewed records in popup" toggle
+4. Disable it to skip the query and only show search results as you type
+
+When disabled, no API call is made to the RecentlyViewed object, which can reduce API usage and improve popup responsiveness.
+
 ## API Cache Configuration
 
 Salesforce Inspector Reloaded uses a caching system to reduce the number of API calls made to Salesforce, improving performance and reducing API usage. The extension caches API response data to optimize queries and avoid unnecessary API requests.


### PR DESCRIPTION
# Describe your changes
- display all recentitems to allow the browser scroll (remove the old logic as 100 items is not that much today in browsers)
- add filter to exclude listview in recentitems 

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [ x I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
