### PR TITLE
Issue/Flow Scanner: resolve FlowDefinition ID and support FlowRecord pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -30,6 +30,15 @@ function getPrimaryAffectedElement(result) {
 }
 
 /**
+ * Sanitizes URL parameters by converting invalid values to null.
+ * @param {string|null} param - The URL parameter to sanitize.
+ * @returns {string|null} The sanitized parameter value.
+ */
+function sanitizeUrlParam(param) {
+  return (!param || param === "null" || param === "undefined") ? null : param;
+}
+
+/**
  * Generates a plan for purging old flow versions, determining which versions to keep and delete.
  * @param {Array} versions - Array of flow version objects.
  * @param {number} historySize - Number of old versions to keep (in addition to active version).
@@ -341,6 +350,7 @@ class FlowScanner {
         type = "ScreenFlow";
       }
       const showProcessType = type !== processType;
+      const versionNumber = versions.find(v => v.Id === this.flowId)?.VersionNumber ?? null;
 
       // Construct complete flow information object
       const result = {
@@ -352,6 +362,7 @@ class FlowScanner {
         type,
         status,
         displayStatus,
+        versionNumber,
         xmlData,
         triggerObjectLabel,
         triggerType,
@@ -1140,6 +1151,10 @@ function FlowInfoSection(props) {
                 id: "flow-status-badge"
               }, flow.displayStatus)
             ),
+            h("div", {className: "flow-detail-item flow-version-item"},
+              h("span", {className: "detail-label"}, "Version"),
+              h("span", {className: "detail-value", id: "flow-version-number"}, flow.versionNumber ?? "—")
+            ),
             h("div", {className: "flow-detail-item flow-type-item"},
               h("span", {className: "detail-label"}, "Type"),
               h("span", {className: "detail-value", id: "flow-type"}, flow.type)
@@ -1396,6 +1411,92 @@ function PurgeModal(props) {
 }
 
 /**
+ * Resolves flow IDs from URL parameters, handling cases where flowId is a FlowDefinition ID
+ * or where one of the IDs is missing.
+ * @param {string|null} flowDefId - The flow definition ID from URL params.
+ * @param {string|null} flowId - The flow version ID from URL params.
+ * @returns {Promise<{flowDefId: string, flowId: string}>} Resolved IDs.
+ */
+async function resolveFlowIds(flowDefId, flowId) {
+  let resolvedDefId = flowDefId;
+  let resolvedFlowId = flowId;
+
+  // Both present and correct types - no resolution needed
+  if (resolvedDefId?.startsWith("300") && resolvedFlowId?.startsWith("301")) {
+    return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+  }
+
+  // Handle flowId being a FlowDefinition ID (300xxx)
+  if (resolvedFlowId?.startsWith("300")) {
+    resolvedDefId = resolvedDefId || resolvedFlowId;
+    resolvedFlowId = null;
+  }
+
+  // Resolve missing IDs
+  if (!resolvedDefId && resolvedFlowId?.startsWith("301")) {
+    resolvedDefId = await getDefinitionIdFromFlowVersion(resolvedFlowId);
+  }
+  if (!resolvedFlowId && resolvedDefId?.startsWith("300")) {
+    resolvedFlowId = await getFlowVersionFromDefinition(resolvedDefId);
+  }
+
+  if (!resolvedDefId || !resolvedFlowId) {
+    throw new Error(`Unable to resolve flow IDs: flowDefId=${resolvedDefId}, flowId=${resolvedFlowId}`);
+  }
+
+  return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+}
+
+/**
+ * Gets the FlowDefinition ID from a Flow version ID.
+ * @param {string} flowVersionId - The Flow version ID (301xxx).
+ * @returns {Promise<string>} The FlowDefinition ID.
+ */
+async function getDefinitionIdFromFlowVersion(flowVersionId) {
+  const query = `SELECT DefinitionId FROM Flow WHERE Id='${flowVersionId}'`;
+  const response = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(query)}`
+  );
+
+  if (!response?.records?.[0]?.DefinitionId) {
+    throw new Error(`Could not resolve FlowDefinition for Flow version '${flowVersionId}'.`);
+  }
+
+  return response.records[0].DefinitionId;
+}
+
+/**
+ * Gets a Flow version ID from a FlowDefinition ID.
+ * Tries to get the active version first, falls back to latest version.
+ * @param {string} flowDefId - The FlowDefinition ID (300xxx).
+ * @returns {Promise<string>} The Flow version ID.
+ */
+async function getFlowVersionFromDefinition(flowDefId) {
+  // Try active version first
+  const activeQuery = `SELECT Id FROM Flow WHERE DefinitionId='${flowDefId}' AND Status='Active' LIMIT 1`;
+  const activeResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(activeQuery)}`
+  );
+
+  if (activeResponse?.records?.[0]?.Id) {
+    return activeResponse.records[0].Id;
+  }
+
+  // Fall back to latest version
+  console.warn(`No active Flow version found for FlowDefinition '${flowDefId}'. Falling back to latest version.`);
+  const latestQuery = `SELECT LatestVersionId FROM FlowDefinitionView WHERE DurableId='${flowDefId}'`;
+  const latestResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/query/?q=${encodeURIComponent(latestQuery)}`
+  );
+
+  if (!latestResponse?.records?.[0]?.LatestVersionId) {
+    throw new Error(`Could not resolve a Flow version for FlowDefinition '${flowDefId}'.`);
+  }
+
+  return latestResponse.records[0].LatestVersionId;
+}
+
+/**
  * The main React component for the Flow Scanner application.
  */
 class App extends React.Component {
@@ -1555,11 +1656,14 @@ class App extends React.Component {
       this.setState({error: null});
       const params = new URLSearchParams(window.location.search);
       const sfHost = params.get("host");
-      const flowDefId = params.get("flowDefId");
-      const flowId = params.get("flowId");
+      const flowDefId = sanitizeUrlParam(params.get("flowDefId"));
+      const flowId = sanitizeUrlParam(params.get("flowId"));
 
-      if (!sfHost || !flowDefId || !flowId) {
-        throw new Error(`Missing required parameters: host=${sfHost}, flowDefId=${flowDefId}, flowId=${flowId}`);
+      if (!sfHost) {
+        throw new Error("Missing required parameter: host");
+      }
+      if (!flowDefId && !flowId) {
+        throw new Error("Missing required parameters: at least one of flowDefId or flowId must be provided.");
       }
 
       window.initButton(sfHost, true);
@@ -1569,6 +1673,9 @@ class App extends React.Component {
       }
 
       await sfConn.getSession(sfHost);
+
+      // Resolve and normalize flow IDs
+      const {flowDefId: resolvedDefId, flowId: resolvedFlowId} = await resolveFlowIds(flowDefId, flowId);
 
       // Set org name from sfHost
       const orgName = sfHost.split(".")[0]?.toUpperCase() || "";
@@ -1584,7 +1691,7 @@ class App extends React.Component {
         });
       });
 
-      this.flowScanner = new FlowScanner(sfHost, flowDefId, flowId);
+      this.flowScanner = new FlowScanner(sfHost, resolvedDefId, resolvedFlowId);
       await this.flowScanner.init();
 
       this.setState({isLoading: false, error: null});

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3822,8 +3822,16 @@ class AllDataSelection extends React.PureComponent {
     );
   }
   getFlowScannerUrl() {
-    return `flow-scanner.html?host=${this.props.sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${this.props.selectedValue.recordId}`;
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
 
+    // FlowDefinition ID (300xxx) - let flow-scanner resolve the version
+    if (recordId?.startsWith("300")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${recordId}`;
+    }
+
+    // Flow version ID - include both definition and version IDs
+    return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
     return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3825,12 +3825,17 @@ class AllDataSelection extends React.PureComponent {
     const {sfHost, selectedValue} = this.props;
     const recordId = selectedValue.recordId;
 
-    // FlowDefinition ID (300xxx) - let flow-scanner resolve the version
+    // FlowDefinition ID (300) - let flow-scanner resolve the version
     if (recordId?.startsWith("300")) {
       return `flow-scanner.html?host=${sfHost}&flowDefId=${recordId}`;
     }
 
-    // Flow version ID - include both definition and version IDs
+    // FlowRecord (2aF) - use the resolved flowDefinitionId
+    if (recordId?.startsWith("2aF")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}`;
+    }
+
+    // Flow version ID (301) - include both definition and version IDs
     return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
@@ -3978,6 +3983,20 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+      } else if (recordId.startsWith("2aF")) {
+        sfConn
+          .rest(
+            "/services/data/v"
+              + apiVersion
+              + "/query/?q=SELECT+FlowDefinition+FROM+FlowRecord+WHERE+Id='"
+              + recordId
+              + "'"
+          )
+          .then((res) => {
+            if (res.records && res.records.length > 0) {
+              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+            }
+          });
       }
     }
   }


### PR DESCRIPTION
# Describe your changes
  - Handle cases where only a FlowDefinition ID (300xxx) is passed to the Flow Scanner instead of a Flow version ID (301xxx), by resolving the active version
  (falling back to latest)
  - Support opening Flow Scanner from FlowRecord pages (/lightning/r/FlowRecord/2aFxxx/view) by querying the FlowDefinition field
  - Display the analyzed flow version number in the Flow Information card
  - Sanitize URL parameters to handle null/undefined string values
## Issue ticket number and link

## Checklist before requesting a review

- [X] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [X] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [X] I used SLDS style and limit the usage of custom CSS
- [X] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [X] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
