### PR TITLE
[feat] Flow Scanner: resolve FlowDefinition ID and support FlowRecord pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 ## Version 2.0
 
 - `Data Export` Fix unrecognized Salesforce Ids [issue #984](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/984)
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.0
 
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card. Fix `Flow Compare` button in the popup so it works from FlowRecord and FlowDefinition pages (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Metadata` Add 'Run Relevant Tests' option to metadata deploy Test Level picklist [feature 1286](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1286)
 - `Popup` Fix language flag icons for Catalan and Basque on the Users tab [issue #1196](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1196)
 - `Custom Shortcuts` Add "Global" toggle to share a shortcut across all orgs instead of keeping it specific to the current org [feature 191](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/191)
@@ -22,7 +23,6 @@
 ## Version 2.0
 
 - `Data Export` Fix unrecognized Salesforce Ids [issue #984](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/984)
-- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,13 @@
 
 ## Version 2.1
 
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card. Fix `Flow Compare` button in the popup so it works from FlowRecord and FlowDefinition pages (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
 
 ## Version 2.0
 
 - `Data Export` Fix unrecognized Salesforce Ids [issue #984](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/984)
-- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 ## Version 2.0
 
 - `Data Export` Fix unrecognized Salesforce Ids [issue #984](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/984)
+- `Flow Scanner` Resolve FlowDefinition ID (300xxx) when only that ID is available, using the active version (or latest as fallback). Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
 - `Popup` review cache management in "Preload SObjects before popup opens". If enabled, refresh of SObject definition is done every "SObjects List Cache" hours, else done in background when the popup is expanded

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -30,6 +30,15 @@ function getPrimaryAffectedElement(result) {
 }
 
 /**
+ * Sanitizes URL parameters by converting invalid values to null.
+ * @param {string|null} param - The URL parameter to sanitize.
+ * @returns {string|null} The sanitized parameter value.
+ */
+function sanitizeUrlParam(param) {
+  return (!param || param === "null" || param === "undefined") ? null : param;
+}
+
+/**
  * Generates a plan for purging old flow versions, determining which versions to keep and delete.
  * @param {Array} versions - Array of flow version objects.
  * @param {number} historySize - Number of old versions to keep (in addition to active version).
@@ -341,6 +350,7 @@ class FlowScanner {
         type = "ScreenFlow";
       }
       const showProcessType = type !== processType;
+      const versionNumber = versions.find(v => v.Id === this.flowId)?.VersionNumber ?? null;
 
       // Construct complete flow information object
       const result = {
@@ -352,6 +362,7 @@ class FlowScanner {
         type,
         status,
         displayStatus,
+        versionNumber,
         xmlData,
         triggerObjectLabel,
         triggerType,
@@ -1140,6 +1151,10 @@ function FlowInfoSection(props) {
                 id: "flow-status-badge"
               }, flow.displayStatus)
             ),
+            h("div", {className: "flow-detail-item flow-version-item"},
+              h("span", {className: "detail-label"}, "Version"),
+              h("span", {className: "detail-value", id: "flow-version-number"}, flow.versionNumber ?? "—")
+            ),
             h("div", {className: "flow-detail-item flow-type-item"},
               h("span", {className: "detail-label"}, "Type"),
               h("span", {className: "detail-value", id: "flow-type"}, flow.type)
@@ -1396,6 +1411,92 @@ function PurgeModal(props) {
 }
 
 /**
+ * Resolves flow IDs from URL parameters, handling cases where flowId is a FlowDefinition ID
+ * or where one of the IDs is missing.
+ * @param {string|null} flowDefId - The flow definition ID from URL params.
+ * @param {string|null} flowId - The flow version ID from URL params.
+ * @returns {Promise<{flowDefId: string, flowId: string}>} Resolved IDs.
+ */
+async function resolveFlowIds(flowDefId, flowId) {
+  let resolvedDefId = flowDefId;
+  let resolvedFlowId = flowId;
+
+  // Both present and correct types - no resolution needed
+  if (resolvedDefId?.startsWith("300") && resolvedFlowId?.startsWith("301")) {
+    return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+  }
+
+  // Handle flowId being a FlowDefinition ID (300xxx)
+  if (resolvedFlowId?.startsWith("300")) {
+    resolvedDefId = resolvedDefId || resolvedFlowId;
+    resolvedFlowId = null;
+  }
+
+  // Resolve missing IDs
+  if (!resolvedDefId && resolvedFlowId?.startsWith("301")) {
+    resolvedDefId = await getDefinitionIdFromFlowVersion(resolvedFlowId);
+  }
+  if (!resolvedFlowId && resolvedDefId?.startsWith("300")) {
+    resolvedFlowId = await getFlowVersionFromDefinition(resolvedDefId);
+  }
+
+  if (!resolvedDefId || !resolvedFlowId) {
+    throw new Error(`Unable to resolve flow IDs: flowDefId=${resolvedDefId}, flowId=${resolvedFlowId}`);
+  }
+
+  return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+}
+
+/**
+ * Gets the FlowDefinition ID from a Flow version ID.
+ * @param {string} flowVersionId - The Flow version ID (301xxx).
+ * @returns {Promise<string>} The FlowDefinition ID.
+ */
+async function getDefinitionIdFromFlowVersion(flowVersionId) {
+  const query = `SELECT DefinitionId FROM Flow WHERE Id='${flowVersionId}'`;
+  const response = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(query)}`
+  );
+
+  if (!response?.records?.[0]?.DefinitionId) {
+    throw new Error(`Could not resolve FlowDefinition for Flow version '${flowVersionId}'.`);
+  }
+
+  return response.records[0].DefinitionId;
+}
+
+/**
+ * Gets a Flow version ID from a FlowDefinition ID.
+ * Tries to get the active version first, falls back to latest version.
+ * @param {string} flowDefId - The FlowDefinition ID (300xxx).
+ * @returns {Promise<string>} The Flow version ID.
+ */
+async function getFlowVersionFromDefinition(flowDefId) {
+  // Try active version first
+  const activeQuery = `SELECT Id FROM Flow WHERE DefinitionId='${flowDefId}' AND Status='Active' LIMIT 1`;
+  const activeResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(activeQuery)}`
+  );
+
+  if (activeResponse?.records?.[0]?.Id) {
+    return activeResponse.records[0].Id;
+  }
+
+  // Fall back to latest version
+  console.warn(`No active Flow version found for FlowDefinition '${flowDefId}'. Falling back to latest version.`);
+  const latestQuery = `SELECT LatestVersionId FROM FlowDefinitionView WHERE DurableId='${flowDefId}'`;
+  const latestResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/query/?q=${encodeURIComponent(latestQuery)}`
+  );
+
+  if (!latestResponse?.records?.[0]?.LatestVersionId) {
+    throw new Error(`Could not resolve a Flow version for FlowDefinition '${flowDefId}'.`);
+  }
+
+  return latestResponse.records[0].LatestVersionId;
+}
+
+/**
  * The main React component for the Flow Scanner application.
  */
 class App extends React.Component {
@@ -1555,11 +1656,14 @@ class App extends React.Component {
       this.setState({error: null});
       const params = new URLSearchParams(window.location.search);
       const sfHost = params.get("host");
-      const flowDefId = params.get("flowDefId");
-      const flowId = params.get("flowId");
+      const flowDefId = sanitizeUrlParam(params.get("flowDefId"));
+      const flowId = sanitizeUrlParam(params.get("flowId"));
 
-      if (!sfHost || !flowDefId || !flowId) {
-        throw new Error(`Missing required parameters: host=${sfHost}, flowDefId=${flowDefId}, flowId=${flowId}`);
+      if (!sfHost) {
+        throw new Error("Missing required parameter: host");
+      }
+      if (!flowDefId && !flowId) {
+        throw new Error("Missing required parameters: at least one of flowDefId or flowId must be provided.");
       }
 
       window.initButton(sfHost, true);
@@ -1569,6 +1673,9 @@ class App extends React.Component {
       }
 
       await sfConn.getSession(sfHost);
+
+      // Resolve and normalize flow IDs
+      const {flowDefId: resolvedDefId, flowId: resolvedFlowId} = await resolveFlowIds(flowDefId, flowId);
 
       // Set org name from sfHost
       const orgName = sfHost.split(".")[0]?.toUpperCase() || "";
@@ -1584,7 +1691,7 @@ class App extends React.Component {
         });
       });
 
-      this.flowScanner = new FlowScanner(sfHost, flowDefId, flowId);
+      this.flowScanner = new FlowScanner(sfHost, resolvedDefId, resolvedFlowId);
       await this.flowScanner.init();
 
       this.setState({isLoading: false, error: null});

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -10,7 +10,7 @@
 /* global React ReactDOM */
 import {getFlowScannerRules, normalizeSeverity, CORE_SEVERITY_TO_UI} from "./flow-scanner-rules.js";
 import {sfConn, apiVersion} from "./inspector.js";
-import {getLinkTarget, getUserInfo, isOptionEnabled, Constants, PromptTemplate, getFlowCompareUrl} from "./utils.js";
+import {getLinkTarget, getUserInfo, isOptionEnabled, Constants, PromptTemplate, getFlowCompareUrl, isValidFlowRecordId} from "./utils.js";
 import ConfirmModal from "./components/ConfirmModal.js";
 import {PageHeader} from "./components/PageHeader.js";
 
@@ -30,12 +30,16 @@ function getPrimaryAffectedElement(result) {
 }
 
 /**
- * Sanitizes URL parameters by converting invalid values to null.
+ * Sanitizes a Flow ID URL parameter, converting anything that isn't a
+ * well-formed Salesforce ID with an allowed key prefix to null. Prevents
+ * malformed or crafted values from reaching the SOQL queries in
+ * resolveFlowIds/FlowScanner.
  * @param {string|null} param - The URL parameter to sanitize.
+ * @param {string[]} allowedPrefixes - Key prefixes to accept (e.g. ["300", "301"])
  * @returns {string|null} The sanitized parameter value.
  */
-function sanitizeUrlParam(param) {
-  return (!param || param === "null" || param === "undefined") ? null : param;
+function sanitizeUrlParam(param, allowedPrefixes) {
+  return isValidFlowRecordId(param, allowedPrefixes) ? param : null;
 }
 
 /**
@@ -1447,8 +1451,12 @@ async function resolveFlowIds(flowDefId, flowId) {
   let resolvedDefId = flowDefId;
   let resolvedFlowId = flowId;
 
-  // Both present and correct types - no resolution needed
+  // Both present and correct types - verify they belong together before trusting them
   if (resolvedDefId?.startsWith("300") && resolvedFlowId?.startsWith("301")) {
+    const actualDefId = await getDefinitionIdFromFlowVersion(resolvedFlowId);
+    if (actualDefId !== resolvedDefId) {
+      throw new Error(`Flow version '${resolvedFlowId}' does not belong to FlowDefinition '${resolvedDefId}'.`);
+    }
     return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
   }
 
@@ -1682,8 +1690,9 @@ class App extends React.Component {
       this.setState({error: null});
       const params = new URLSearchParams(window.location.search);
       const sfHost = params.get("host");
-      const flowDefId = sanitizeUrlParam(params.get("flowDefId"));
-      const flowId = sanitizeUrlParam(params.get("flowId"));
+      const flowDefId = sanitizeUrlParam(params.get("flowDefId"), ["300"]);
+      // flowId may legitimately be a FlowDefinition ID (300); resolveFlowIds() re-derives it.
+      const flowId = sanitizeUrlParam(params.get("flowId"), ["300", "301"]);
 
       if (!sfHost) {
         throw new Error("Missing required parameter: host");

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -30,6 +30,15 @@ function getPrimaryAffectedElement(result) {
 }
 
 /**
+ * Sanitizes URL parameters by converting invalid values to null.
+ * @param {string|null} param - The URL parameter to sanitize.
+ * @returns {string|null} The sanitized parameter value.
+ */
+function sanitizeUrlParam(param) {
+  return (!param || param === "null" || param === "undefined") ? null : param;
+}
+
+/**
  * Generates a plan for purging old flow versions, determining which versions to keep and delete.
  * @param {Array} versions - Array of flow version objects.
  * @param {number} historySize - Number of old versions to keep (in addition to active version).
@@ -367,6 +376,7 @@ class FlowScanner {
         type = "ScreenFlow";
       }
       const showProcessType = type !== processType;
+      const versionNumber = versions.find(v => v.Id === this.flowId)?.VersionNumber ?? null;
 
       // Construct complete flow information object
       const result = {
@@ -378,6 +388,7 @@ class FlowScanner {
         type,
         status,
         displayStatus,
+        versionNumber,
         xmlData,
         triggerObjectLabel,
         triggerType,
@@ -1166,6 +1177,10 @@ function FlowInfoSection(props) {
                 id: "flow-status-badge"
               }, flow.displayStatus)
             ),
+            h("div", {className: "flow-detail-item flow-version-item"},
+              h("span", {className: "detail-label"}, "Version"),
+              h("span", {className: "detail-value", id: "flow-version-number"}, flow.versionNumber ?? "—")
+            ),
             h("div", {className: "flow-detail-item flow-type-item"},
               h("span", {className: "detail-label"}, "Type"),
               h("span", {className: "detail-value", id: "flow-type"}, flow.type)
@@ -1422,6 +1437,92 @@ function PurgeModal(props) {
 }
 
 /**
+ * Resolves flow IDs from URL parameters, handling cases where flowId is a FlowDefinition ID
+ * or where one of the IDs is missing.
+ * @param {string|null} flowDefId - The flow definition ID from URL params.
+ * @param {string|null} flowId - The flow version ID from URL params.
+ * @returns {Promise<{flowDefId: string, flowId: string}>} Resolved IDs.
+ */
+async function resolveFlowIds(flowDefId, flowId) {
+  let resolvedDefId = flowDefId;
+  let resolvedFlowId = flowId;
+
+  // Both present and correct types - no resolution needed
+  if (resolvedDefId?.startsWith("300") && resolvedFlowId?.startsWith("301")) {
+    return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+  }
+
+  // Handle flowId being a FlowDefinition ID (300xxx)
+  if (resolvedFlowId?.startsWith("300")) {
+    resolvedDefId = resolvedDefId || resolvedFlowId;
+    resolvedFlowId = null;
+  }
+
+  // Resolve missing IDs
+  if (!resolvedDefId && resolvedFlowId?.startsWith("301")) {
+    resolvedDefId = await getDefinitionIdFromFlowVersion(resolvedFlowId);
+  }
+  if (!resolvedFlowId && resolvedDefId?.startsWith("300")) {
+    resolvedFlowId = await getFlowVersionFromDefinition(resolvedDefId);
+  }
+
+  if (!resolvedDefId || !resolvedFlowId) {
+    throw new Error(`Unable to resolve flow IDs: flowDefId=${resolvedDefId}, flowId=${resolvedFlowId}`);
+  }
+
+  return {flowDefId: resolvedDefId, flowId: resolvedFlowId};
+}
+
+/**
+ * Gets the FlowDefinition ID from a Flow version ID.
+ * @param {string} flowVersionId - The Flow version ID (301xxx).
+ * @returns {Promise<string>} The FlowDefinition ID.
+ */
+async function getDefinitionIdFromFlowVersion(flowVersionId) {
+  const query = `SELECT DefinitionId FROM Flow WHERE Id='${flowVersionId}'`;
+  const response = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(query)}`
+  );
+
+  if (!response?.records?.[0]?.DefinitionId) {
+    throw new Error(`Could not resolve FlowDefinition for Flow version '${flowVersionId}'.`);
+  }
+
+  return response.records[0].DefinitionId;
+}
+
+/**
+ * Gets a Flow version ID from a FlowDefinition ID.
+ * Tries to get the active version first, falls back to latest version.
+ * @param {string} flowDefId - The FlowDefinition ID (300xxx).
+ * @returns {Promise<string>} The Flow version ID.
+ */
+async function getFlowVersionFromDefinition(flowDefId) {
+  // Try active version first
+  const activeQuery = `SELECT Id FROM Flow WHERE DefinitionId='${flowDefId}' AND Status='Active' LIMIT 1`;
+  const activeResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(activeQuery)}`
+  );
+
+  if (activeResponse?.records?.[0]?.Id) {
+    return activeResponse.records[0].Id;
+  }
+
+  // Fall back to latest version
+  console.warn(`No active Flow version found for FlowDefinition '${flowDefId}'. Falling back to latest version.`);
+  const latestQuery = `SELECT LatestVersionId FROM FlowDefinitionView WHERE DurableId='${flowDefId}'`;
+  const latestResponse = await sfConn.rest(
+    `/services/data/v${apiVersion}/query/?q=${encodeURIComponent(latestQuery)}`
+  );
+
+  if (!latestResponse?.records?.[0]?.LatestVersionId) {
+    throw new Error(`Could not resolve a Flow version for FlowDefinition '${flowDefId}'.`);
+  }
+
+  return latestResponse.records[0].LatestVersionId;
+}
+
+/**
  * The main React component for the Flow Scanner application.
  */
 class App extends React.Component {
@@ -1581,11 +1682,14 @@ class App extends React.Component {
       this.setState({error: null});
       const params = new URLSearchParams(window.location.search);
       const sfHost = params.get("host");
-      const flowDefId = params.get("flowDefId");
-      const flowId = params.get("flowId");
+      const flowDefId = sanitizeUrlParam(params.get("flowDefId"));
+      const flowId = sanitizeUrlParam(params.get("flowId"));
 
-      if (!sfHost || !flowDefId || !flowId) {
-        throw new Error(`Missing required parameters: host=${sfHost}, flowDefId=${flowDefId}, flowId=${flowId}`);
+      if (!sfHost) {
+        throw new Error("Missing required parameter: host");
+      }
+      if (!flowDefId && !flowId) {
+        throw new Error("Missing required parameters: at least one of flowDefId or flowId must be provided.");
       }
 
       window.initButton(sfHost, true);
@@ -1595,6 +1699,9 @@ class App extends React.Component {
       }
 
       await sfConn.getSession(sfHost);
+
+      // Resolve and normalize flow IDs
+      const {flowDefId: resolvedDefId, flowId: resolvedFlowId} = await resolveFlowIds(flowDefId, flowId);
 
       // Set org name from sfHost
       const orgName = sfHost.split(".")[0]?.toUpperCase() || "";
@@ -1610,7 +1717,7 @@ class App extends React.Component {
         });
       });
 
-      this.flowScanner = new FlowScanner(sfHost, flowDefId, flowId);
+      this.flowScanner = new FlowScanner(sfHost, resolvedDefId, resolvedFlowId);
       await this.flowScanner.init();
 
       this.setState({isLoading: false, error: null});

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4006,8 +4006,21 @@ class AllDataSelection extends React.PureComponent {
     );
   }
   getFlowScannerUrl() {
-    return `flow-scanner.html?host=${this.props.sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${this.props.selectedValue.recordId}`;
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
 
+    // FlowDefinition ID (300) - let flow-scanner resolve the version
+    if (recordId?.startsWith("300")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${recordId}`;
+    }
+
+    // FlowRecord (2aF) - use the resolved flowDefinitionId
+    if (recordId?.startsWith("2aF")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}`;
+    }
+
+    // Flow version ID (301) - include both definition and version IDs
+    return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
     return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);
@@ -4157,6 +4170,20 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+      } else if (recordId.startsWith("2aF")) {
+        sfConn
+          .rest(
+            "/services/data/v"
+              + apiVersion
+              + "/query/?q=SELECT+FlowDefinition+FROM+FlowRecord+WHERE+Id='"
+              + recordId
+              + "'"
+          )
+          .then((res) => {
+            if (res.records && res.records.length > 0) {
+              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+            }
+          });
       }
     }
   }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion, sessionError} from "./inspector.js";
-import {getLinkTarget, isOptionEnabled, isSettingEnabled, getLatestApiVersionFromOrg, setOrgInfo, getPKCEParameters, getBrowserType, getExtensionId, getClientId, getRedirectUri, Constants, copyToClipboard, DataCache, getFlowCompareUrl, isRecordId, getSobjectsList} from "./utils.js";
+import {getLinkTarget, isOptionEnabled, isSettingEnabled, getLatestApiVersionFromOrg, setOrgInfo, getPKCEParameters, getBrowserType, getExtensionId, getClientId, getRedirectUri, Constants, copyToClipboard, DataCache, getFlowCompareUrl, isRecordId, isValidFlowRecordId, getSobjectsList} from "./utils.js";
 import {setupLinks} from "./links.js";
 import AlertBanner from "./components/AlertBanner.js";
 
@@ -4178,7 +4178,7 @@ class AllDataSelection extends React.PureComponent {
       });
   }
   setFlowDefinitionId(recordId) {
-    if (recordId && !this.state.flowDefinitionId) {
+    if (recordId && !this.state.flowDefinitionId && isValidFlowRecordId(recordId, ["300", "301", "2aF"])) {
       if (recordId.startsWith("301")) {
         this.setState({flowVersionId: recordId});
         sfConn

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3822,8 +3822,21 @@ class AllDataSelection extends React.PureComponent {
     );
   }
   getFlowScannerUrl() {
-    return `flow-scanner.html?host=${this.props.sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${this.props.selectedValue.recordId}`;
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
 
+    // FlowDefinition ID (300) - let flow-scanner resolve the version
+    if (recordId?.startsWith("300")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${recordId}`;
+    }
+
+    // FlowRecord (2aF) - use the resolved flowDefinitionId
+    if (recordId?.startsWith("2aF")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}`;
+    }
+
+    // Flow version ID (301) - include both definition and version IDs
+    return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
     return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);
@@ -3970,6 +3983,20 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+      } else if (recordId.startsWith("2aF")) {
+        sfConn
+          .rest(
+            "/services/data/v"
+              + apiVersion
+              + "/query/?q=SELECT+FlowDefinition+FROM+FlowRecord+WHERE+Id='"
+              + recordId
+              + "'"
+          )
+          .then((res) => {
+            if (res.records && res.records.length > 0) {
+              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+            }
+          });
       }
     }
   }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3950,6 +3950,7 @@ class AllDataSelection extends React.PureComponent {
     super(props);
     this.state = {
       flowDefinitionId: null,
+      flowVersionId: null,
     };
   }
   clickAllDataBtn() {
@@ -4023,7 +4024,10 @@ class AllDataSelection extends React.PureComponent {
     return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
-    return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
+    const flowVersionId = recordId?.startsWith("301") ? recordId : this.state.flowVersionId;
+    return getFlowCompareUrl(sfHost, flowVersionId);
   }
   /**
    * Optimistically generate lightning setup uri for the provided object api name.
@@ -4151,9 +4155,32 @@ class AllDataSelection extends React.PureComponent {
   getGenerateEventUrl(name) {
     return this.props.eventMonitorHref + "&channel=" + name + "&generate=1";
   }
+  resolveFlowVersionId(flowDefinitionId) {
+    if (!flowDefinitionId || this.state.flowVersionId) {
+      return;
+    }
+    const activeQuery = "SELECT+Id+FROM+Flow+WHERE+DefinitionId='" + flowDefinitionId + "'+AND+Status='Active'+LIMIT+1";
+    sfConn
+      .rest("/services/data/v" + apiVersion + "/tooling/query/?q=" + activeQuery)
+      .then((res) => {
+        if (res.records && res.records.length > 0) {
+          this.setState({flowVersionId: res.records[0].Id});
+          return;
+        }
+        const latestQuery = "SELECT+Id+FROM+Flow+WHERE+DefinitionId='" + flowDefinitionId + "'+ORDER+BY+VersionNumber+DESC+LIMIT+1";
+        sfConn
+          .rest("/services/data/v" + apiVersion + "/tooling/query/?q=" + latestQuery)
+          .then((latestRes) => {
+            if (latestRes.records && latestRes.records.length > 0) {
+              this.setState({flowVersionId: latestRes.records[0].Id});
+            }
+          });
+      });
+  }
   setFlowDefinitionId(recordId) {
     if (recordId && !this.state.flowDefinitionId) {
       if (recordId.startsWith("301")) {
+        this.setState({flowVersionId: recordId});
         sfConn
           .rest(
             "/services/data/v"
@@ -4170,6 +4197,7 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+        this.resolveFlowVersionId(recordId);
       } else if (recordId.startsWith("2aF")) {
         sfConn
           .rest(
@@ -4181,7 +4209,9 @@ class AllDataSelection extends React.PureComponent {
           )
           .then((res) => {
             if (res.records && res.records.length > 0) {
-              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+              const defId = res.records[0].FlowDefinition;
+              this.setState({flowDefinitionId: defId});
+              this.resolveFlowVersionId(defId);
             }
           });
       }
@@ -4198,7 +4228,7 @@ class AllDataSelection extends React.PureComponent {
       isFieldsPresent,
       eventMonitorHref,
     } = this.props;
-    let {flowDefinitionId} = this.state;
+    let {flowDefinitionId, flowVersionId} = this.state;
     // Show buttons for the available APIs.
     let buttons = selectedValue.sobject.availableApis
       ? Array.from(selectedValue.sobject.availableApis)
@@ -4454,7 +4484,7 @@ class AllDataSelection extends React.PureComponent {
           "Flow Scanner"
         )
         : null,
-      flowDefinitionId
+      flowVersionId
         ? h(
           "a",
           {

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3891,8 +3891,21 @@ class AllDataSelection extends React.PureComponent {
     );
   }
   getFlowScannerUrl() {
-    return `flow-scanner.html?host=${this.props.sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${this.props.selectedValue.recordId}`;
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
 
+    // FlowDefinition ID (300) - let flow-scanner resolve the version
+    if (recordId?.startsWith("300")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${recordId}`;
+    }
+
+    // FlowRecord (2aF) - use the resolved flowDefinitionId
+    if (recordId?.startsWith("2aF")) {
+      return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}`;
+    }
+
+    // Flow version ID (301) - include both definition and version IDs
+    return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
     return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);
@@ -4042,6 +4055,20 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+      } else if (recordId.startsWith("2aF")) {
+        sfConn
+          .rest(
+            "/services/data/v"
+              + apiVersion
+              + "/query/?q=SELECT+FlowDefinition+FROM+FlowRecord+WHERE+Id='"
+              + recordId
+              + "'"
+          )
+          .then((res) => {
+            if (res.records && res.records.length > 0) {
+              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+            }
+          });
       }
     }
   }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3835,6 +3835,7 @@ class AllDataSelection extends React.PureComponent {
     super(props);
     this.state = {
       flowDefinitionId: null,
+      flowVersionId: null,
     };
   }
   clickAllDataBtn() {
@@ -3908,7 +3909,10 @@ class AllDataSelection extends React.PureComponent {
     return `flow-scanner.html?host=${sfHost}&flowDefId=${this.state.flowDefinitionId}&flowId=${recordId}`;
   }
   getFlowCompareUrl() {
-    return getFlowCompareUrl(this.props.sfHost, this.props.selectedValue.recordId);
+    const {sfHost, selectedValue} = this.props;
+    const recordId = selectedValue.recordId;
+    const flowVersionId = recordId?.startsWith("301") ? recordId : this.state.flowVersionId;
+    return getFlowCompareUrl(sfHost, flowVersionId);
   }
   /**
    * Optimistically generate lightning setup uri for the provided object api name.
@@ -4036,9 +4040,32 @@ class AllDataSelection extends React.PureComponent {
   getGenerateEventUrl(name) {
     return this.props.eventMonitorHref + "&channel=" + name + "&generate=1";
   }
+  resolveFlowVersionId(flowDefinitionId) {
+    if (!flowDefinitionId || this.state.flowVersionId) {
+      return;
+    }
+    const activeQuery = "SELECT+Id+FROM+Flow+WHERE+DefinitionId='" + flowDefinitionId + "'+AND+Status='Active'+LIMIT+1";
+    sfConn
+      .rest("/services/data/v" + apiVersion + "/tooling/query/?q=" + activeQuery)
+      .then((res) => {
+        if (res.records && res.records.length > 0) {
+          this.setState({flowVersionId: res.records[0].Id});
+          return;
+        }
+        const latestQuery = "SELECT+Id+FROM+Flow+WHERE+DefinitionId='" + flowDefinitionId + "'+ORDER+BY+VersionNumber+DESC+LIMIT+1";
+        sfConn
+          .rest("/services/data/v" + apiVersion + "/tooling/query/?q=" + latestQuery)
+          .then((latestRes) => {
+            if (latestRes.records && latestRes.records.length > 0) {
+              this.setState({flowVersionId: latestRes.records[0].Id});
+            }
+          });
+      });
+  }
   setFlowDefinitionId(recordId) {
     if (recordId && !this.state.flowDefinitionId) {
       if (recordId.startsWith("301")) {
+        this.setState({flowVersionId: recordId});
         sfConn
           .rest(
             "/services/data/v"
@@ -4055,6 +4082,7 @@ class AllDataSelection extends React.PureComponent {
           });
       } else if (recordId.startsWith("300")) {
         this.setState({flowDefinitionId: recordId});
+        this.resolveFlowVersionId(recordId);
       } else if (recordId.startsWith("2aF")) {
         sfConn
           .rest(
@@ -4066,7 +4094,9 @@ class AllDataSelection extends React.PureComponent {
           )
           .then((res) => {
             if (res.records && res.records.length > 0) {
-              this.setState({flowDefinitionId: res.records[0].FlowDefinition});
+              const defId = res.records[0].FlowDefinition;
+              this.setState({flowDefinitionId: defId});
+              this.resolveFlowVersionId(defId);
             }
           });
       }
@@ -4083,7 +4113,7 @@ class AllDataSelection extends React.PureComponent {
       isFieldsPresent,
       eventMonitorHref,
     } = this.props;
-    let {flowDefinitionId} = this.state;
+    let {flowDefinitionId, flowVersionId} = this.state;
     // Show buttons for the available APIs.
     let buttons = selectedValue.sobject.availableApis
       ? Array.from(selectedValue.sobject.availableApis)
@@ -4339,7 +4369,7 @@ class AllDataSelection extends React.PureComponent {
           "Flow Scanner"
         )
         : null,
-      flowDefinitionId
+      flowVersionId
         ? h(
           "a",
           {

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1257,6 +1257,20 @@ export function isRecordId(recordId) {
 }
 
 /**
+ * Strictly validates a Flow-related Salesforce ID: exactly 15 or 18
+ * alphanumeric characters and one of the allowed key prefixes. Used before
+ * interpolating an ID into a SOQL query.
+ * @param {string} recordId - The string to validate
+ * @param {string[]} allowedPrefixes - Key prefixes to accept (e.g. ["300", "301", "2aF"])
+ * @returns {boolean} True if the string is a valid ID with an allowed prefix
+ */
+export function isValidFlowRecordId(recordId, allowedPrefixes) {
+  return typeof recordId === "string"
+       && /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(recordId)
+       && allowedPrefixes.some(prefix => recordId.startsWith(prefix));
+}
+
+/**
  * Generates a package.xml string from grouped metadata components
  * @param {Map|Object} groupedComponents - Map or Object where keys are metadata types and values are Set or Array of member names
  * @param {Object} [options] - Optional configuration

--- a/tests/e2e/test-mock.js
+++ b/tests/e2e/test-mock.js
@@ -350,6 +350,22 @@ export async function routeMock(route, host) {
         return true;
       }
 
+      // Flow Scanner - resolve FlowDefinition ID from a Flow version ID (SELECT DefinitionId FROM Flow WHERE Id=...)
+      if (path.includes("/tooling/query") && query.includes("select definitionid from flow")) {
+        await fulfillSuccess(route, {
+          records: [{DefinitionId: TEST_CONSTANTS.flowDefId}]
+        });
+        return true;
+      }
+
+      // Flow Scanner - resolve active Flow version ID from a FlowDefinition ID (SELECT Id FROM Flow WHERE DefinitionId=... AND Status='Active')
+      if (path.includes("/tooling/query") && query.includes("select id from flow") && query.includes("status='active'")) {
+        await fulfillSuccess(route, {
+          records: [{Id: TEST_CONSTANTS.flowId}]
+        });
+        return true;
+      }
+
       // Mock Flow versions query (flow-scanner: SELECT Id, VersionNumber, Status FROM Flow)
       if (path.includes("/tooling/") && query.includes("from flow") && query.includes("versionnumber") && !query.includes("definition")) {
         await fulfillSuccess(route, {


### PR DESCRIPTION
# Describe your changes

Resolve FlowDefinition ID (300xxx) to the active Flow version (or latest as fallback) when only a definition ID is available. Support opening Flow Scanner from FlowRecord pages (`/lightning/r/FlowRecord/...`). Display the analyzed flow version number in the Flow Information card.

**Details:**
- Added `sanitizeUrlParam()` to normalize `"null"`/`"undefined"` URL param strings to `null`
- Added `resolveFlowIds()` to handle all ID resolution scenarios (300→301, missing IDs, mixed inputs)
- Added `getDefinitionIdFromFlowVersion()` — looks up FlowDefinition from a Flow version via Tooling API
- Added `getFlowVersionFromDefinition()` — looks up active (or latest fallback) Flow version from a FlowDefinition
- Added `versionNumber` field displayed in the Flow Information card
- Relaxed URL parameter validation: `host` is required; at least one of `flowDefId` or `flowId` is sufficient
- Updated `getFlowScannerUrl()` in popup.js to generate correct URLs for FlowDefinition (300xxx), FlowRecord (2aF...), and Flow version (301xxx) IDs
- Added FlowRecord ID handler in popup.js to resolve the associated FlowDefinition ID via REST API

## Issue ticket number and link

Closes #1127

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)