### PR TITLE
[feat] Add Custom Permission access control for Data Export and Data …

### DIFF
--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion} from "./inspector.js";
-import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile, StorageHistory} from "./utils.js";
+import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile, StorageHistory, checkCustomPermission} from "./utils.js";
 /* global initButton */
 import {Enumerable, DescribeInfo, initScrollTable, s} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
@@ -82,6 +82,16 @@ class Model {
     // Initialize user info model - handles all user-related properties
     this.userInfoModel = new UserInfoModel(this.spinFor.bind(this));
 
+    // Custom Permission access control
+    this.hasReadPermission = null; // null = loading, true = allowed, false = blocked
+    this.readPermissionWarning = null;
+    this.readCustomPermissionName = localStorage.getItem(sfHost + Constants.READ_CUSTOM_PERMISSION);
+    if (this.readCustomPermissionName) {
+      this.spinFor(this._checkReadPermission());
+    } else {
+      this.hasReadPermission = true;
+    }
+
     let queryFromUrl = false;
     if (args.has("query")) {
       this.initialQuery = args.get("query");
@@ -102,6 +112,21 @@ class Model {
     this.queryTabs = [];
     this.activeTabIndex = 0;
     this.loadQueryTabs(queryFromUrl);
+  }
+
+  async _checkReadPermission() {
+    // Wait for userInfoModel to have userId
+    while (!this.userInfoModel.userId) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      if (this.userInfoModel.userError) {
+        this.hasReadPermission = false;
+        this.readPermissionWarning = "Unable to verify permissions: user info could not be loaded.";
+        return;
+      }
+    }
+    const result = await checkCustomPermission(this.sfHost, this.readCustomPermissionName, this.userInfoModel.userId);
+    this.hasReadPermission = result.hasPermission;
+    this.readPermissionWarning = result.warning;
   }
 
   updatedExportedData() {
@@ -840,6 +865,9 @@ class Model {
     return query.trim();
   }
   doExport() {
+    if (this.hasReadPermission === false) {
+      return;
+    }
     let vm = this; // eslint-disable-line consistent-this
     let exportedData = new RecordTable(vm);
     exportedData.isTooling = vm.queryTooling;
@@ -1745,16 +1773,20 @@ class App extends React.Component {
         model.queryAutocompleteHandler({ctrlSpace: true});
         model.didUpdate();
       } else if (e.data.command === "open-export-execute"){
-        model.doExport();
-        model.didUpdate();
+        if (model.hasReadPermission !== false) {
+          model.doExport();
+          model.didUpdate();
+        }
       }
     });
 
     addEventListener("keydown", e => {
       if ((e.ctrlKey && e.key == "Enter") || e.key == "F5") {
         e.preventDefault();
-        model.doExport();
-        model.didUpdate();
+        if (model.hasReadPermission !== false) {
+          model.doExport();
+          model.didUpdate();
+        }
       }
     });
 
@@ -1840,6 +1872,19 @@ class App extends React.Component {
         ...model.userInfoModel.getProps(),
         utilityItems
       }),
+
+      model.hasReadPermission === false
+        ? h("div", {className: "slds-notify slds-notify_alert slds-alert_warning slds-m-horizontal_medium slds-m-top_xx-large", role: "alert"},
+          h("span", {className: "slds-assistive-text"}, "warning"),
+          h("h2", {}, "You do not have the required Custom Permission (", model.readCustomPermissionName, ") to export data.")
+        )
+        : null,
+      model.readPermissionWarning && model.hasReadPermission === true
+        ? h("div", {className: "slds-notify slds-notify_alert slds-alert_warning slds-m-horizontal_medium slds-m-top_xx-large", role: "alert"},
+          h("span", {className: "slds-assistive-text"}, "warning"),
+          h("h2", {}, model.readPermissionWarning)
+        )
+        : null,
 
       h("div", {className: "slds-m-top_xx-large sfir-page-container"},
         h("div", {className: "slds-card slds-m-around_medium"},
@@ -1990,7 +2035,7 @@ class App extends React.Component {
                 h("span", {className: "slds-m-left_xx-small"}, model.autocompleteResults.title),
                 h("ul", {className: "slds-button-group-row flex-right"},
                   h("li", {className: "slds-button-group-item"},
-                    h("button", {tabIndex: 1, disabled: model.isWorking, onClick: this.onExport, title: "Ctrl+Enter / F5", className: "slds-button slds-button_brand"}, "Run Export")
+                    h("button", {tabIndex: 1, disabled: model.isWorking || model.hasReadPermission === false || model.hasReadPermission === null, onClick: this.onExport, title: "Ctrl+Enter / F5", className: "slds-button slds-button_brand"}, "Run Export")
                   ),
                   h("li", {className: "slds-button-group-item"},
                     isOptionEnabled("export-query", this.state.hideButtonsOption) ? h("button", {tabIndex: 2, onClick: this.onCopyQuery, title: "Copy query url", className: "slds-button slds-button_neutral copy-id"}, "Export Query") : null

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -4,7 +4,7 @@ import {sfConn, apiVersion} from "./inspector.js";
 import {csvParse} from "./csv-parse.js";
 import {DescribeInfo, initScrollTable} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, copyToClipboard, getSobjectsList, Constants, applyProductionStyling} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, copyToClipboard, getSobjectsList, Constants, applyProductionStyling, checkCustomPermission} from "./utils.js";
 
 const allApis = [
   {value: "Enterprise", label: "Enterprise (default)"},
@@ -79,6 +79,16 @@ class Model {
     // Initialize user info model - handles all user-related properties
     this.userInfoModel = new UserInfoModel(this.spinFor.bind(this));
 
+    // Custom Permission access control
+    this.hasWritePermission = null; // null = loading, true = allowed, false = blocked
+    this.writePermissionWarning = null;
+    this.writeCustomPermissionName = localStorage.getItem(sfHost + Constants.WRITE_CUSTOM_PERMISSION);
+    if (this.writeCustomPermissionName) {
+      this.spinFor(this._checkWritePermission());
+    } else {
+      this.hasWritePermission = true;
+    }
+
     let apiTypeParam = args.get("apitype");
     this.apiType = this.importType.endsWith("__mdt") ? "Metadata" : apiTypeParam ? apiTypeParam : "Enterprise";
 
@@ -92,6 +102,21 @@ class Model {
       this.skipAllUnknownFields();
       console.log(this.importData);
     }
+  }
+
+  async _checkWritePermission() {
+    // Wait for userInfoModel to have userId
+    while (!this.userInfoModel.userId) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      if (this.userInfoModel.userError) {
+        this.hasWritePermission = false;
+        this.writePermissionWarning = "Unable to verify permissions: user info could not be loaded.";
+        return;
+      }
+    }
+    const result = await checkCustomPermission(this.sfHost, this.writeCustomPermissionName, this.userInfoModel.userId);
+    this.hasWritePermission = result.hasPermission;
+    this.writePermissionWarning = result.warning;
   }
 
   // set available actions based on api type, and set the first one as the default
@@ -557,6 +582,9 @@ class Model {
   }
 
   doImport() {
+    if (this.hasWritePermission === false) {
+      return;
+    }
     let importedRecords = this.importData.counts.Queued + this.importData.counts.Processing;
     let skippedRecords = this.importAction != "undelete" ? this.importData.counts.Succeeded + this.importData.counts.Failed : 0;
     let actionVerb = this.getActionVerb(this.importAction);
@@ -1190,6 +1218,19 @@ class App extends React.Component {
         ...model.userInfoModel.getProps(),
         utilityItems
       }),
+      model.hasWritePermission === false
+        ? h("div", {className: "slds-notify slds-notify_alert slds-alert_warning slds-m-horizontal_medium slds-m-top_xx-large", role: "alert"},
+          h("span", {className: "slds-assistive-text"}, "warning"),
+          h("h2", {}, "You do not have the required Custom Permission (", model.writeCustomPermissionName, ") to import data.")
+        )
+        : null,
+      model.writePermissionWarning && model.hasWritePermission === true
+        ? h("div", {className: "slds-notify slds-notify_alert slds-alert_warning slds-m-horizontal_medium slds-m-top_xx-large", role: "alert"},
+          h("span", {className: "slds-assistive-text"}, "warning"),
+          h("h2", {}, model.writePermissionWarning)
+        )
+        : null,
+
       h("div", {className: "slds-m-top_xx-large sfir-page-container"},
         h("div", {className: "slds-m-around_medium"},
           h("div", {className: "slds-grid slds-gutters"},
@@ -1322,7 +1363,7 @@ class App extends React.Component {
         h("div", {className: "slds-card slds-m-horizontal_medium slds-p-around_small"},
           h("div", {className: "slds-grid slds-grid_align-spread slds-grid_vertical-align-center"},
             h("div", {className: "slds-col"},
-              h("button", {onClick: this.onDoImportClick, disabled: model.invalidInput() || model.isWorking() || model.importCounts().Queued == 0, className: "slds-button slds-button_brand"}, "Run " + model.importActionName),
+              h("button", {onClick: this.onDoImportClick, disabled: model.invalidInput() || model.isWorking() || model.importCounts().Queued == 0 || model.hasWritePermission === false || model.hasWritePermission === null, className: "slds-button slds-button_brand"}, "Run " + model.importActionName),
               h("button", {disabled: !model.isWorking(), onClick: this.onToggleProcessingClick, className: model.isWorking() && !model.isProcessingQueue ? "slds-button slds-button_neutral" : "slds-button slds-button_neutral"}, model.isWorking() && !model.isProcessingQueue ? "Resume Queued" : "Cancel Queued"),
               h("button", {disabled: !model.importCounts().Failed > 0, onClick: this.onRetryFailedClick, className: "slds-button slds-button_neutral"}, "Retry Failed"),
               h("div", {className: "slds-button-group"},

--- a/addon/options.js
+++ b/addon/options.js
@@ -160,6 +160,8 @@ class OptionsTabSelector extends React.Component {
                 }
               }}},
           {option: Option, props: {type: "text", title: "Rest Header", placeholder: "Rest Header", key: "createUpdateRestCalloutHeaders", inputSize: "6"}},
+          {option: Option, props: {type: "text", title: "Read Custom Permission", placeholder: "e.g. Inspector_Read_Access", key: this.sfHost + Constants.READ_CUSTOM_PERMISSION, inputSize: "5", tooltip: "API name of a Custom Permission. If set, only users with this permission can use Data Export. Leave blank to allow all users."}},
+          {option: Option, props: {type: "text", title: "Write Custom Permission", placeholder: "e.g. Inspector_Write_Access", key: this.sfHost + Constants.WRITE_CUSTOM_PERMISSION, inputSize: "5", tooltip: "API name of a Custom Permission. If set, only users with this permission can use Data Import. Leave blank to allow all users."}},
           {option: Option, props: {type: "toggle", title: "Enable API Stats Debug Mode", key: Constants.API_DEBUG_STATISTICS_MODE, default: false, tooltip: "When enabled, tracks API call statistics (REST and SOAP) to help monitor API usage. Statistics can be viewed on the API Debug Statistics page."}},
           {option: Option, props: {type: "toggle", title: "Preload SObjects before popup opens", key: Constants.PRELOAD_SOBJECTS_BEFORE_POPUP, default: true, tooltip: "When enabled, loads the SObjects list from cache before the popup is opened for faster context detection. Disable to reduce initial load time and only load when the Objects tab is accessed."}},
         ]

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -27,6 +27,9 @@ export class Constants {
   static PRELOAD_SOBJECTS_BEFORE_POPUP = "preloadSobjectsBeforePopup";
   static ENABLE_SOBJECTS_LIST_CACHE = "enableSobjectsListCache";
   static ENABLE_RECENTLY_VIEWED_RECORDS = "enableRecentlyViewedRecords";
+  // Custom Permission Access Control
+  static READ_CUSTOM_PERMISSION = "_readCustomPermission";
+  static WRITE_CUSTOM_PERMISSION = "_writeCustomPermission";
 }
 
 /**
@@ -337,6 +340,7 @@ export async function getUserInfo() {
     const res = await sfConn.soap(sfConn.wsdl(apiVersion, "Partner"), "getUserInfo", {});
     return {
       success: true,
+      userId: res.userId,
       userInfo: res.userFullName + " / " + res.userName + " / " + res.organizationName,
       userFullName: res.userFullName,
       userInitials: res.userFullName.split(" ").map(n => n[0]).join(""),
@@ -348,6 +352,7 @@ export async function getUserInfo() {
     console.error("Error fetching user info:", error);
     return {
       success: false,
+      userId: null,
       userInfo: "Error loading user info",
       userFullName: "Unknown User",
       userInitials: "?",
@@ -380,6 +385,7 @@ export async function getUserInfo() {
 export class UserInfoModel {
   constructor(spinForCallback) {
     // Initialize with loading state
+    this.userId = null;
     this.userInfo = "...";
     this.userFullName = "";
     this.userInitials = "";
@@ -399,6 +405,7 @@ export class UserInfoModel {
     const result = await getUserInfo();
 
     // Update all properties from result
+    this.userId = result.userId;
     this.userInfo = result.userInfo;
     this.userFullName = result.userFullName;
     this.userInitials = result.userInitials;
@@ -419,6 +426,71 @@ export class UserInfoModel {
       userError: this.userError,
       userErrorDescription: this.userErrorDescription
     };
+  }
+}
+
+/**
+ * Check if the current user has a specific Custom Permission.
+ * Uses sessionStorage to cache the result per browser session.
+ * @param {string} sfHost - Salesforce host
+ * @param {string} permissionApiName - DeveloperName of the Custom Permission
+ * @param {string} userId - Current user's Salesforce Id
+ * @returns {Promise<{hasPermission: boolean, warning: string|null}>}
+ */
+export async function checkCustomPermission(sfHost, permissionApiName, userId) {
+  if (!permissionApiName || !permissionApiName.trim()) {
+    return {hasPermission: true, warning: null};
+  }
+  permissionApiName = permissionApiName.trim();
+
+  // Check sessionStorage cache
+  const cacheKey = sfHost + "_customPerm_" + permissionApiName;
+  const cached = sessionStorage.getItem(cacheKey);
+  if (cached) {
+    try {
+      return JSON.parse(cached);
+    } catch (e) {
+      // Ignore invalid cache
+    }
+  }
+
+  try {
+    // Query 1: Resolve Custom Permission API name to Id
+    const permResult = await sfConn.rest(
+      "/services/data/v" + apiVersion + "/query/?q="
+      + encodeURIComponent("SELECT Id FROM CustomPermission WHERE DeveloperName = '" + permissionApiName + "'")
+    );
+
+    if (!permResult.records || permResult.records.length === 0) {
+      // Custom Permission not found — fail open with warning
+      const result = {hasPermission: true, warning: "Custom Permission '" + permissionApiName + "' was not found in this org. Please verify the API name in Settings."};
+      sessionStorage.setItem(cacheKey, JSON.stringify(result));
+      return result;
+    }
+
+    const customPermissionId = permResult.records[0].Id;
+
+    // Query 2: Check if user has access (single-level nesting)
+    const accessResult = await sfConn.rest(
+      "/services/data/v" + apiVersion + "/query/?q="
+      + encodeURIComponent(
+        "SELECT Id FROM SetupEntityAccess "
+        + "WHERE SetupEntityId = '" + customPermissionId + "' "
+        + "AND SetupEntityType = 'CustomPermission' "
+        + "AND ParentId IN ("
+        + "SELECT PermissionSetId FROM PermissionSetAssignment WHERE AssigneeId = '" + userId + "'"
+        + ") LIMIT 1"
+      )
+    );
+
+    const hasPermission = accessResult.records && accessResult.records.length > 0;
+    const result = {hasPermission, warning: null};
+    sessionStorage.setItem(cacheKey, JSON.stringify(result));
+    return result;
+  } catch (error) {
+    console.error("Error checking custom permission:", error);
+    // Fail closed on API errors — block the operation
+    return {hasPermission: false, warning: "Failed to verify Custom Permission: " + error.message};
   }
 }
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -66,6 +66,42 @@ The creation of Connected Apps is soon to be deprecated (planned for Spring 26')
 
     <img width="275" alt="Generate Token" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/931df75d-42ac-4667-ab3f-35f6b6b65a66">
 
+## Restrict Data Export / Import with Custom Permissions
+
+---
+
+You can restrict who can use the Data Export (read) and Data Import (write) features by leveraging Salesforce Custom Permissions. This is useful when you need to grant API access for other integrations but want to prevent certain users from mass-exporting or modifying records via the extension.
+
+### Setup
+
+1. **Create Custom Permissions** in Salesforce Setup:
+    - Navigate to **Setup > Custom Permissions > New**
+    - Create one for read access (e.g. `Inspector_Read_Access`) and/or one for write access (e.g. `Inspector_Write_Access`)
+
+2. **Assign the Custom Permissions** to the appropriate users via Permission Sets, Permission Set Groups, or Profiles.
+
+3. **Configure the extension**:
+    - Open the extension **Options** page (gear icon)
+    - Go to the **API** tab
+    - Enter the Custom Permission API name (DeveloperName) in:
+        - **Read Custom Permission** — controls access to Data Export
+        - **Write Custom Permission** — controls access to Data Import
+
+### Behavior
+
+| Scenario | Result |
+|----------|--------|
+| Setting is blank (default) | No restriction — all users can use the feature |
+| Custom Permission exists and user has it | User can use the feature normally |
+| Custom Permission exists and user lacks it | Feature is blocked — button disabled, warning banner shown |
+| Custom Permission API name doesn't exist in the org | Warning banner shown, but feature is **not blocked** (fail open) |
+
+### Notes
+
+- The permission check result is cached per browser session (sessionStorage) to minimize API calls. Close and reopen the tab to pick up permission changes.
+- The check covers Profiles, Permission Sets, and Permission Set Groups.
+- Each org can have different Custom Permission names configured (settings are org-specific).
+
 ## Migrate saved queries from legacy extension to Salesforce Inspector Reloaded
 
 1. Open data export page on legacy extension


### PR DESCRIPTION
…Import

Introduce access-control settings governed by Salesforce Custom Permissions. Admins can configure a Read and/or Write Custom Permission API name in Settings > API tab to restrict who can use Data Export and Data Import.

Details:

- Added Constants.READ_CUSTOM_PERMISSION and WRITE_CUSTOM_PERMISSION keys
- Added checkCustomPermission() in utils.js with sessionStorage caching
- Extended getUserInfo() and UserInfoModel to expose userId
- Added Read/Write Custom Permission text inputs to Options > API tab
- Data Export: permission check in Model constructor, disabled Run Export button, guarded keyboard shortcuts (Ctrl+Enter/F5) and message handler, AlertBanner for denied/warning states
- Data Import: permission check in Model constructor, disabled Run Import button, AlertBanner for denied/warning states
- If Custom Permission does not exist in org, fail open with warning banner
- Permission check cached per browser session (sessionStorage) to minimize API calls
- Updated docs/how-to.md with setup and configuration instructions

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [ ] I used SLDS style and limit the usage of custom CSS
- [ ] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
