### PR TITLE
fix: Ensure underscores visible in custom field names at all zoom levels

### DIFF
--- a/addon/data-load.css
+++ b/addon/data-load.css
@@ -36,12 +36,14 @@
   white-space: pre;
   box-sizing: border-box;
   position: relative;
+  line-height: 1.5;
 }
 
 .scrolltable-cell.header {
   font-weight: 700;
   background-color: #FAFAF9;
   border-top: none;
+  overflow: visible;
   padding-top: 7px;
   padding-bottom: 7px;
 }
@@ -72,6 +74,7 @@
   font-weight: 700;
   background-color: #FAFAF9;
   border-top: none;
+  overflow: visible;
   padding-top: 7px;
   padding-bottom: 7px;
 }


### PR DESCRIPTION
## Summary
- Fixes underscores in custom field names disappearing at certain browser zoom levels in the Data Export table
- Adds explicit `overflow: visible` to header cells and increases `line-height` on all table cells

## Root Cause
At certain zoom levels, sub-pixel rendering causes the bottom border of table cells to clip underscore characters (which sit at the text baseline). The fix ensures cells have enough vertical space and explicitly prevent overflow clipping.

## Test Plan
- [ ] Open Data Export and run a query with custom fields containing underscores (e.g., `Custom_Field__c`)
- [ ] Zoom browser in and out (75%, 90%, 100%, 110%, 125%) — underscores should remain visible at all zoom levels
- [ ] Verify table layout still looks correct with the increased line-height
- [ ] Check both header row and data rows

Closes #1110