### PR TITLE
fix: Prevent keyboard shortcuts from executing outside Salesforce

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -64,6 +64,9 @@ chrome.action.onClicked.addListener(() => {
   });
 });
 chrome.commands?.onCommand.addListener((command) => {
+  if (!sfHost) {
+    return;
+  }
   if (command.startsWith("link-")){
     let link;
     switch (command){


### PR DESCRIPTION
## Summary
- Adds a guard in the `chrome.commands.onCommand` listener to skip execution when `sfHost` is not set
- This prevents extension shortcuts from firing on non-Salesforce pages, avoiding conflicts with other websites and extensions

## How it works
The `sfHost` variable is only populated when the user visits a Salesforce org page and the extension establishes a session. If no Salesforce page has been visited in the current browser session, shortcuts are silently ignored.

## Test Plan
- [ ] Configure a keyboard shortcut for Data Export in `chrome://extensions/shortcuts`
- [ ] Press the shortcut on a non-Salesforce page (e.g., google.com) — nothing should happen
- [ ] Navigate to a Salesforce org, then press the shortcut — it should work normally
- [ ] Verify shortcuts still work after navigating away from Salesforce (sfHost persists in session)

Closes #948