### PR TITLE
fix: debounce debug log preview filter to keep focus while typing

### DIFF
--- a/addon/debug-log.js
+++ b/addon/debug-log.js
@@ -744,6 +744,7 @@ Please structure your response in a clear, organized manner using these sections
     // Process filter change asynchronously to avoid blocking UI
     setTimeout(() => {
       if (applyId !== this.previewFilterApplySeq) return;
+      if (this.previewFilterInput !== filterText) return; // newer input is pending debounce
       try {
         this.previewFilter = filterText;
         // Reset search when filter changes

--- a/addon/debug-log.js
+++ b/addon/debug-log.js
@@ -22,6 +22,9 @@ class Model {
     this.previewLog = null; // {id, body, fileName}
     this.previewSearch = {term: "", liveTerm: "", index: 0, count: 0, _timer: 0};
     this.previewFilter = ""; // grep-like filter for log lines
+    this.previewFilterInput = ""; // live input value kept separate to avoid focus loss while typing
+    this.previewFilterTimerId = 0;
+    this.previewFilterApplySeq = 0;
     this.filterTemplates = [
       {label: "No filter", value: ""},
       {label: "USER_DEBUG", value: "USER_DEBUG"},
@@ -640,6 +643,9 @@ Please structure your response in a clear, organized manner using these sections
   }
 
   async preview(id) {
+    this.clearPreviewFilterTimer();
+    this.previewFilterApplySeq++;
+    this.previewFilterProcessing = false;
     this.previewLoading = true;
     this.previewLog = {id, body: "", fileName: `${id}.log`}; // Show modal immediately with loading state
     this.didUpdate();
@@ -650,6 +656,7 @@ Please structure your response in a clear, organized manner using these sections
       this.previewLog = {id, body: cachedBody, fileName: `${id}.log`};
       this.previewSearch = {term: "", liveTerm: "", index: 0, count: 0, _timer: 0};
       this.previewFilter = ""; // Reset filter when opening new log
+      this.previewFilterInput = "";
       this.previewLoading = false;
       window.addEventListener("keydown", this._onPreviewKeyDown, true);
       setTimeout(() => {
@@ -666,6 +673,7 @@ Please structure your response in a clear, organized manner using these sections
       this.previewLog = {id, body: text, fileName: `${id}.log`};
       this.previewSearch = {term: "", liveTerm: "", index: 0, count: 0, _timer: 0};
       this.previewFilter = ""; // Reset filter when opening new log
+      this.previewFilterInput = "";
       window.addEventListener("keydown", this._onPreviewKeyDown, true);
       setTimeout(() => {
         const inp = document.querySelector(".sfir-preview-search-input");
@@ -682,10 +690,14 @@ Please structure your response in a clear, organized manner using these sections
   }
 
   closePreview() {
+    this.clearPreviewFilterTimer();
+    this.previewFilterApplySeq++;
+    this.previewFilterProcessing = false;
     this.previewLog = null;
     // Reset search state completely when closing preview
     this.previewSearch = {term: "", liveTerm: "", index: 0, count: 0, _timer: 0};
     this.previewFilter = "";
+    this.previewFilterInput = "";
     // Clear cached processed body
     this._cachedProcessedBody = null;
     this._cachedFilteredBody = null;
@@ -696,10 +708,34 @@ Please structure your response in a clear, organized manner using these sections
     this.didUpdate();
   }
 
+  clearPreviewFilterTimer() {
+    if (this.previewFilterTimerId) {
+      clearTimeout(this.previewFilterTimerId);
+      this.previewFilterTimerId = 0;
+    }
+  }
+
+  schedulePreviewFilter(filterText) {
+    this.previewFilterInput = filterText;
+    this.clearPreviewFilterTimer();
+    this.didUpdate();
+    this.previewFilterTimerId = setTimeout(() => {
+      this.previewFilterTimerId = 0;
+      this.applyPreviewFilter(this.previewFilterInput);
+    }, 200);
+  }
+
   applyPreviewFilter(filterText) {
+    this.clearPreviewFilterTimer();
+    this.previewFilterInput = filterText;
+    if (this.previewFilter === filterText && !this.previewFilterProcessing) {
+      this.didUpdate();
+      return;
+    }
+
+    const applyId = ++this.previewFilterApplySeq;
     // Show loading state immediately
     this.previewFilterProcessing = true;
-    this.previewFilter = filterText;
     // Clear cache when filter changes
     this._cachedProcessedBody = null;
     this._cachedFilteredBody = null;
@@ -707,7 +743,9 @@ Please structure your response in a clear, organized manner using these sections
 
     // Process filter change asynchronously to avoid blocking UI
     setTimeout(() => {
+      if (applyId !== this.previewFilterApplySeq) return;
       try {
+        this.previewFilter = filterText;
         // Reset search when filter changes
         this.previewSearch = {term: "", liveTerm: "", index: 0, count: 0, _timer: 0};
         this.previewFilterProcessing = false;
@@ -1803,9 +1841,9 @@ function PreviewModal({model, hideButtonsOption}) {
             h("select", {
               id: "sfir-log-filter-template",
               className: "slds-select",
-              value: model.previewFilter,
+              value: model.previewFilterInput,
               onChange: (e) => model.applyPreviewFilter(e.target.value),
-              disabled: isLoading || isFilterProcessing
+              disabled: isLoading
             },
             ...model.filterTemplates.map(t => h("option", {key: t.value, value: t.value}, t.label))
             )
@@ -1822,9 +1860,9 @@ function PreviewModal({model, hideButtonsOption}) {
             type: "text",
             className: "slds-input",
             placeholder: "e.g., USER_DEBUG|EXCEPTION_THROWN",
-            value: model.previewFilter,
-            onChange: (e) => model.applyPreviewFilter(e.target.value),
-            disabled: isLoading || isFilterProcessing
+            value: model.previewFilterInput,
+            onChange: (e) => model.schedulePreviewFilter(e.target.value),
+            disabled: isLoading
           })
         )
       )

--- a/tests/e2e/debug-log.spec.js
+++ b/tests/e2e/debug-log.spec.js
@@ -1,0 +1,88 @@
+import {test, expect} from "./fixtures";
+import {TEST_CONSTANTS, injectSessionData, fulfillSuccess} from "./test-helpers";
+
+test.describe("Debug Log Viewer", () => {
+  const {mockHost, mockToken, apiVersion} = TEST_CONSTANTS;
+
+  test.beforeEach(async ({context}) => {
+    await injectSessionData(context, {
+      host: mockHost,
+      token: mockToken,
+      version: apiVersion
+    });
+
+    await context.route("**/*", async route => {
+      const url = route.request().url();
+      if (!url.includes(mockHost)) {
+        await route.continue();
+        return;
+      }
+
+      if (url.includes("/tooling/sobjects/ApexLog/07L000000000001AAA/Body")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/plain",
+          body: [
+            "12:00:00.0|USER_DEBUG|First message",
+            "12:00:00.1|FATAL_ERROR|Something failed",
+            "12:00:00.2|USER_DEBUG|Second message"
+          ].join("\n")
+        });
+        return;
+      }
+
+      const decodedUrl = decodeURIComponent(url);
+      if (decodedUrl.includes("SELECT COUNT() FROM ApexLog")) {
+        await fulfillSuccess(route, {totalSize: 1, records: []});
+        return;
+      }
+
+      if (decodedUrl.includes("SELECT LogUserId, LogUser.Name")) {
+        await fulfillSuccess(route, {
+          records: [{
+            LogUserId: "005000000000001AAA",
+            LogUser: {Name: "Test User", Profile: {Name: "System Administrator"}}
+          }]
+        });
+        return;
+      }
+
+      if (decodedUrl.includes("FROM ApexLog")) {
+        await fulfillSuccess(route, {
+          records: [{
+            Id: "07L000000000001AAA",
+            Operation: "EXECUTION_STARTED",
+            Request: "API",
+            Status: "Success",
+            StartTime: "2026-08-21T12:00:00.000Z",
+            LogUserId: "005000000000001AAA",
+            Application: "Unknown",
+            Location: "Unknown",
+            LogLength: 128
+          }]
+        });
+        return;
+      }
+
+      await fulfillSuccess(route, {records: []});
+    });
+  });
+
+  test("keeps focus while applying a debounced preview filter", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/debug-log.html?host=${mockHost}`);
+
+    await page.getByRole("button", {name: "Preview"}).click();
+    const filterInput = page.locator("#sfir-log-filter-custom");
+    await expect(filterInput).toBeVisible();
+
+    await filterInput.pressSequentially("USER_DEBUG", {delay: 30});
+    await expect(filterInput).toHaveValue("USER_DEBUG");
+    await expect(filterInput).toBeFocused();
+
+    const preview = page.locator(".sfir-preview-code-block");
+    await expect(preview).toContainText("First message");
+    await expect(preview).toContainText("Second message");
+    await expect(preview).not.toContainText("Something failed");
+    await expect(filterInput).toBeFocused();
+  });
+});


### PR DESCRIPTION
﻿## Summary
- keeps the Debug Log Viewer custom filter input focused while typing
- debounces preview filter application instead of reprocessing the preview on every keystroke
- keeps the live input value separate from the applied filter and cancels stale queued updates

## How it works
When the user types in the custom filter box, the textbox value updates immediately, but the expensive preview filtering is only applied after a short debounce. The filter input is no longer disabled during preview filter processing, so focus is not dropped mid-typing.

## Test Plan
- [ ] Open Logs Viewer (beta)
- [ ] Open any log preview
- [ ] Type continuously in the Custom Filter field
- [ ] Verify the input keeps focus and the cursor does not jump out while typing
- [ ] Verify the selected filter template still updates the preview correctly
- [ ] Close and reopen a preview to confirm the filter resets cleanly

Closes #1063
