### PR TITLE
[feat] Data Export: Add SObject List View Selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 ## Version 2.0
 
+- `Data Export` Add SObject List View Selector to populate queries from existing List Views (contribution by [Idan Damari](https://github.com/iDamari))
 - `Data Export` Fix unrecognized Salesforce Ids [issue #984](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/984)
 - `Data Import` Expose metadata updates through Tooling API (ie Bulk Deactivate Flows) [feature 1125](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1125)
 - Fix Lightning Navigation from Analytics / Tableau [issue #1121](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1121)
@@ -58,7 +59,7 @@
 - `Options` Fix export configuration file [issue #982](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/982) (issue by [Syamkumar Kanjiravelil Sasidharan](https://github.com/syamkumar-ks))
 - `Field Creator` Enable field creation for platform event objects [feature 954](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/954) (idea by [simagdo](https://github.com/simagdo))
 - Unfreeze User from User tab [feature #945](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/945) (contribution by [b-r-j](https://github.com/b-r-j))
-- `Users search`  now supports exclusion of inactive and portal users, supports customizable searchable fields and can be searched by profile name [feature 965](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/965) (contribution by [Thomas Malidin Delabriere](https://github.com/tmalidin33))
+- `Users search` now supports exclusion of inactive and portal users, supports customizable searchable fields and can be searched by profile name [feature 965](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/965) (contribution by [Thomas Malidin Delabriere](https://github.com/tmalidin33))
 - `Field Creator` UI improvement of the Options modal (contribution by [Kamil Gadawski](https://github.com/KamilGadawski))
 - `Field Creator` Permission dependency improvement [feature 931](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/931) (contribution by [DivyanshuBist](https://github.com/DivyanshuBist))
 - Enable custom banner text on Sandbox banner

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -42,6 +42,7 @@ class Model {
     this.queryTooling = false;
     this.prefHideRelations = localStorage.getItem("hideObjectNameColumnsDataExport") == "true"; // default to false
     this.prefPreventLineWrap = localStorage.getItem("preventLineWrapDataExport") !== "false"; // default to true (matches v1.27 behavior)
+    this.showListViewDropdown = localStorage.getItem("showListViewDropdown") !== "false"; // default to true
     this.autocompleteResults = {sobjectName: "", title: "\u00A0", results: []};
     this.autocompleteClick = null;
     this.isWorking = false;
@@ -56,6 +57,10 @@ class Model {
     this.selectedSavedEntry = null;
     this.expandAutocomplete = false;
     this.expandSavedOptions = false;
+    this.listViews = [];
+    this.listViewsBySobject = {};
+    this.listViewQueries = {};
+    this.lastFetchedListViewSobjectName = null;
     this.resultsFilter = "";
     this.displayPerformance = localStorage.getItem("displayQueryPerformance") !== "false"; // default to true
     this.performancePoints = [];
@@ -226,6 +231,55 @@ class Model {
   }
   clearHistory() {
     this.queryHistory.clear();
+  }
+  fetchListViews(sobjectName) {
+    this.listViews = [];
+    if (!sobjectName) {
+      return;
+    }
+    if (this.listViewsBySobject[sobjectName]) {
+      this.listViews = this.listViewsBySobject[sobjectName];
+      this.didUpdate();
+      return;
+    }
+    sfConn.rest("/services/data/v" + apiVersion + "/sobjects/" + sobjectName + "/listviews").then(res => {
+      if (res && res.listviews) {
+        this.listViews = res.listviews;
+        this.listViewsBySobject[sobjectName] = res.listviews;
+        this.didUpdate();
+      }
+    }).catch(err => {
+      console.error("Error fetching list views for " + sobjectName, err);
+    });
+  }
+
+  selectListViewEntry(listViewId) {
+    if (!this.lastFetchedListViewSobjectName || !listViewId) {
+      return;
+    }
+    
+    if (this.listViewQueries[listViewId]) {
+      this.queryInput.value = this.listViewQueries[listViewId];
+      this.updateCurrentTabQuery(this.queryInput.value);
+      this.queryAutocompleteHandler();
+      return;
+    }
+
+    this.spinFor(
+      sfConn.rest("/services/data/v" + apiVersion + "/sobjects/" + this.lastFetchedListViewSobjectName + "/listviews/" + listViewId + "/describe")
+        .then(res => {
+          if (res && res.query) {
+            this.listViewQueries[listViewId] = res.query;
+            this.queryInput.value = res.query;
+            this.updateCurrentTabQuery(this.queryInput.value);
+            this.queryAutocompleteHandler();
+          }
+        })
+        .catch(err => {
+          console.error("Error fetching list view query", err);
+          alert("Failed to fetch query for the selected list view.");
+        })
+    );
   }
   selectSavedEntry() {
     let delimiter = ":";
@@ -406,6 +460,11 @@ class Model {
 
     // If we are just after the "from" keyword, autocomplete the sobject name
     if (query.substring(0, selStart).match(/(^|\s)from\s*$/i)) {
+      if (vm.lastFetchedListViewSobjectName) {
+        vm.lastFetchedListViewSobjectName = null;
+        vm.listViews = [];
+        vm.didUpdate();
+      }
       let {globalStatus, globalDescribe} = vm.describeInfo.describeGlobal(useToolingApi);
       if (!globalDescribe) {
         switch (globalStatus) {
@@ -461,6 +520,11 @@ class Model {
         sobjectName = fromKeywordMatch[1];
         isAfterFrom = false;
       } else {
+        if (vm.lastFetchedListViewSobjectName) {
+          vm.lastFetchedListViewSobjectName = null;
+          vm.listViews = [];
+          vm.didUpdate();
+        }
         let title = findKeywordMatch || graphKeywordMatch ? "" : "\"from\" keyword not found";
         vm.autocompleteResults = {
           sobjectName: "",
@@ -483,6 +547,11 @@ class Model {
     vm.updateCurrentTabName(sobjectName);
     let {sobjectStatus, sobjectDescribe} = vm.describeInfo.describeSobject(useToolingApi, sobjectName);
     if (!sobjectDescribe) {
+      if (vm.lastFetchedListViewSobjectName) {
+        vm.lastFetchedListViewSobjectName = null;
+        vm.listViews = [];
+        vm.didUpdate();
+      }
       switch (sobjectStatus) {
         case "loading":
           vm.autocompleteResults = {
@@ -514,6 +583,10 @@ class Model {
           };
           return;
       }
+    }    
+    if (vm.showListViewDropdown && sobjectName && sobjectName !== vm.lastFetchedListViewSobjectName) {
+      vm.lastFetchedListViewSobjectName = sobjectName;
+      vm.fetchListViews(sobjectName);
     }
 
     /*
@@ -1353,6 +1426,7 @@ class App extends React.Component {
     this.onSelectHistoryEntry = this.onSelectHistoryEntry.bind(this);
     this.onSelectQueryTemplate = this.onSelectQueryTemplate.bind(this);
     this.onClearHistory = this.onClearHistory.bind(this);
+    this.onSelectListView = this.onSelectListView.bind(this);
     this.onSelectSavedEntry = this.onSelectSavedEntry.bind(this);
     this.onAddToHistory = this.onAddToHistory.bind(this);
     this.onRemoveFromHistory = this.onRemoveFromHistory.bind(this);
@@ -1442,6 +1516,11 @@ class App extends React.Component {
       model.clearHistory();
       model.didUpdate();
     }
+  }
+  onSelectListView(e) {
+    let {model} = this.props;
+    model.selectListViewEntry(e.target.value);
+    model.didUpdate();
   }
   onSelectSavedEntry(e) {
     let {model} = this.props;
@@ -1861,6 +1940,10 @@ class App extends React.Component {
                   h("button", {className: "slds-button slds-button_neutral", onClick: this.onClearHistory, title: "Clear Query History"}, "Clear")
                 ),
                 h("div", {className: "slds-button-group slds-m-left_small"},
+                  model.showListViewDropdown ? h("select", {value: "", onChange: this.onSelectListView, className: "query-history", title: "Select "+(model.lastFetchedListViewSobjectName?? "")+" List View"},
+                    h("option", {value: null, disabled: true, defaultValue: true, hidden: true}, "List Views"),
+                    model.listViews.map(v => h("option", {key: v.id, value: v.id}, v.label))
+                  ) : null,
                   h("select", {value: JSON.stringify(model.selectedSavedEntry), onChange: this.onSelectSavedEntry, className: "query-history"},
                     h("option", {value: JSON.stringify(null), disabled: true}, "Saved Queries"),
                     model.savedHistory.list.map(q => h("option", {key: JSON.stringify(q), value: JSON.stringify(q)}, q.query.substring(0, 300)))

--- a/addon/options.js
+++ b/addon/options.js
@@ -229,6 +229,7 @@ class OptionsTabSelector extends React.Component {
           {option: Option, props: {type: "toggle", title: "Show Local Time", key: "showLocalTime", default: false}},
           {option: Option, props: {type: "toggle", title: "Use SObject context on Data Export ", key: "useSObjectContextOnDataImpoltrink", default: true}},
           {option: Option, props: {type: "toggle", title: "Enable List View Export", key: "enableListViewExport", default: false, tooltip: "If enabled, Data Export link will be automatically populated with current ListView"}},
+          {option: Option, props: {type: "toggle", title: "Enable List View Selector", key: "showListViewDropdown", default: true, tooltip: "Adds a dropdown to the Data Export page to quickly load and apply queries from existing List Views for the current object."}},
           {option: MultiCheckboxButtonGroup,
             props: {title: "Show buttons",
               key: "hideExportButtonsOption",

--- a/docs/data-export.md
+++ b/docs/data-export.md
@@ -52,6 +52,13 @@ Example:
 
 <img width="895" alt="image" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/16490965-ec4f-42d7-a534-8f24febe1ee3">
 
+## Populating queries from List Views
+
+You can quickly load SOQL queries from existing Salesforce List Views.
+When an SObject is identified in your query (e.g., after typing `SELECT Id FROM Account`), a dropdown menu appears next to the "Saved Queries" button. Selecting a List View from this dropdown will automatically replace your current query with the SOQL filter associated with that List View.
+
+This feature can be enabled or disabled in **Options** -> **Data Export** tab by toggling **Enable List View Selector**.
+
 ## Customize Select all fields in a query shortcut
 
 If the default `Ctrl + space` shortcut is already used by another extension or app, you can customize it in `chrome://extensions/shortcuts` and choose the one you prefer.
@@ -76,7 +83,6 @@ To enable performance metrics for queries on the data export page, open the Opti
 then set "Display Query Execution Time" to enabled. Total time for the query to process and, when applicable, batch stats (Total Number of Batches, Min/Max/Avg Batch Time)
 are displayed.
 
-
 ## Hide object columns in query results
 
 After running a query in the "Data Export" page, you can hide columns in the query results. These columns represent the name of the objects included in your query. They are useful to automatically map the fields to the correct object in the "Data Import" page. The columns are hidden in the exported files (CSV or Excel) as well. You can set a default value, using the 'Hide Object Name Columns by default on Data Export' option ("Options" -> "Data Export" tab).
@@ -94,6 +100,7 @@ When quering EventLogFile, add the "LogFile" field in the query and click on the
 
 Since the extension offers more features, the number of button is increasing.
 Some of the users may don't need some of those, to make the UI lighter some of the buttons can be hidden:
+
 - Delete Records
 - Export Query
 - Agentforce icon
@@ -110,16 +117,16 @@ You can use Agentforce to generate SOQL queries directly from the Data Export pa
 > The standard Salesforce 'Prompt Template User' permission is required to use this feature.
 
 By default, the Agentforce button is hidden. To enable it:
+
 1. Go to Options -> Data Export
 2. Enable "Show Agentforce button"
 3. Optionally, you can customize the prompt template name that will be used for generating queries
 
 <img width="1443" alt="Agentforce SOQL builder" src="https://github.com/user-attachments/assets/deab54b8-df9a-4b74-ab81-b27aea5be800" />
 
-
 GenerateSOQL.genAiPromptTemplate meta content:
 
-``` xml
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">
     <activeVersionIdentifier>anEjRSM7QudV59rn+lQuKa5VlLkCpKFNWwKc0odntGw=_1</activeVersionIdentifier>


### PR DESCRIPTION
Adds a new dropdown to the Data Export page that allows users to quickly populate the query area using any existing Salesforce List View for the current SObject.

Key changes:
- List View Context: The selector dynamically appears when an SObject is detected in the query and automatically resets its state when the query is cleared or the SObject context changes.
- Enable List View Selector Toggle: I added a new configurable toggle in the Options page (under Data Export) so this feature can be enabled/disabled as needed.

This feature lets you import predefined fields and filters from List Views into the Data Export area for further editing and export.
<img width="521" height="213" alt="image" src="https://github.com/user-attachments/assets/d8f85c84-5304-4a1d-b326-114456cc3925" />


# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
