### PR TITLE
[feat] Add selective record deletion with checkboxes (fixes #1076)

### DIFF
--- a/addon/data-export.css
+++ b/addon/data-export.css
@@ -1,4 +1,30 @@
 
+/* Checkbox column for selective record deletion */
+.checkbox-cell {
+  width: 32px;
+  min-width: 32px !important;
+  max-width: 32px;
+  text-align: center;
+  padding: 0 4px !important;
+  background: #fff;
+}
+
+.checkbox-cell input[type="checkbox"] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: #0176d3;
+  vertical-align: middle;
+}
+
+tr.row-selected td {
+  background-color: #eaf5fe !important;
+}
+
+tr.row-selected:hover td {
+  background-color: #d8edfc !important;
+}
 
 .sf-link {
   background-color: rgb(6, 28, 63);

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -266,7 +266,8 @@ class Model {
     //In order to allow deletion, we should have at least 1 element and the Id field should have been included in the query
     return this.exportedData
           && (this.exportedData.countOfVisibleRecords === null /* no filtering has been done yet*/ || this.exportedData.countOfVisibleRecords > 0)
-          && this.exportedData.records.length < 20001 && !this.exportStatus.includes("Exporting") && this.exportedData?.table?.at(0)?.find(header => header.toLowerCase() === "id");
+          && this.exportedData.records.length < 20001 && !this.exportStatus.includes("Exporting") && this.exportedData?.table?.at(0)?.find(header => header.toLowerCase() === "id")
+          && this.exportedData.getSelectedVisibleCount() > 0;
   }
   copyAsExcel() {
     copyToClipboard(this.exportedData.csvSerialize("\t"));
@@ -283,7 +284,7 @@ class Model {
     downloadCsvFile(csvContent, filename);
   }
   deleteRecords(e) {
-    let data = this.exportedData.csvSerialize(this.separator);
+    let data = this.exportedData.csvSerializeSelected(this.separator);
     let encodedData = btoa(data);
 
     let args = new URLSearchParams();
@@ -842,6 +843,7 @@ class Model {
   doExport() {
     let vm = this; // eslint-disable-line consistent-this
     let exportedData = new RecordTable(vm);
+    exportedData.showCheckboxes = true;
     exportedData.isTooling = vm.queryTooling;
     exportedData.describeInfo = vm.describeInfo;
     exportedData.sfHost = vm.sfHost;
@@ -1287,16 +1289,19 @@ function RecordTable(vm) {
     records: [],
     table: [],
     rowVisibilities: [],
+    rowSelections: [],
     colVisibilities: [!vm.prefHideRelations],
     countOfVisibleRecords: null,
     isTooling: false,
     totalSize: -1,
     preventLineWrap: vm.prefPreventLineWrap,
+    showCheckboxes: false,
     addToTable(expRecords) {
       rt.records = rt.records.concat(expRecords);
       if (rt.table.length == 0 && expRecords.length > 0) {
         rt.table.push(header);
         rt.rowVisibilities.push(true);
+        rt.rowSelections.push(false); // header placeholder
       }
       let filter = vm.resultsFilter;
       for (let record of expRecords) {
@@ -1304,10 +1309,61 @@ function RecordTable(vm) {
         row[0] = record;
         rt.table.push(row);
         rt.rowVisibilities.push(isVisible(row, filter));
+        rt.rowSelections.push(false); // initially unselected
         discoverColumns(record, "", row);
       }
     },
     csvSerialize: separator => rt.getVisibleTable().map(row => row.map(cell => "\"" + cellToString(cell).split("\"").join("\"\"") + "\"").join(separator)).join("\r\n"),
+    csvSerializeSelected(separator) {
+      let rows = [];
+      for (let r = 0; r < rt.table.length; r++) {
+        if (r === 0 || (rt.rowVisibilities[r] && rt.rowSelections[r])) {
+          rows.push(rt.table[r]);
+        }
+      }
+      if (vm.prefHideRelations) {
+        rows = rt.filterColumns(rows, rt.colVisibilities);
+      }
+      return rows.map(row => row.map(cell => "\"" + cellToString(cell).split("\"").join("\"\"") + "\"").join(separator)).join("\r\n");
+    },
+    getSelectedVisibleCount() {
+      let count = 0;
+      for (let r = 1; r < rt.rowVisibilities.length; r++) {
+        if (rt.rowVisibilities[r] && rt.rowSelections[r]) count++;
+      }
+      return count;
+    },
+    isAllVisibleSelected() {
+      let visibleCount = 0;
+      let selectedCount = 0;
+      for (let r = 1; r < rt.rowVisibilities.length; r++) {
+        if (rt.rowVisibilities[r]) {
+          visibleCount++;
+          if (rt.rowSelections[r]) selectedCount++;
+        }
+      }
+      return visibleCount > 0 && selectedCount === visibleCount;
+    },
+    isSomeVisibleSelected() {
+      for (let r = 1; r < rt.rowVisibilities.length; r++) {
+        if (rt.rowVisibilities[r] && rt.rowSelections[r]) return true;
+      }
+      return false;
+    },
+    onToggleRowSelection(rowIdx) {
+      rt.rowSelections[rowIdx] = !rt.rowSelections[rowIdx];
+      vm.updatedExportedData();
+      vm.didUpdate();
+    },
+    onSelectAll(selected) {
+      for (let r = 1; r < rt.rowVisibilities.length; r++) {
+        if (rt.rowVisibilities[r]) {
+          rt.rowSelections[r] = selected;
+        }
+      }
+      vm.updatedExportedData();
+      vm.didUpdate();
+    },
     updateVisibility() {
       let filter = vm.resultsFilter;
       let countOfVisibleRecords = 0;
@@ -2074,7 +2130,16 @@ class App extends React.Component {
                   )
                 ),
                 isOptionEnabled("delete", this.state.hideButtonsOption)
-                  ? h("button", {className: "slds-button slds-button_destructive", disabled: !model.canDelete(), onClick: this.onDeleteRecords, title: "Open the 'Data Import' page with preloaded records to delete (< 20k records). 'Id' field needs to be queried"}, "Delete Records") : null,
+                  ? h("button", {
+                    className: "slds-button slds-button_destructive",
+                    disabled: !model.canDelete(),
+                    onClick: this.onDeleteRecords,
+                    title: model.exportedData && model.exportedData.getSelectedVisibleCount() === 0
+                      ? "Select records using checkboxes to enable deletion. 'Id' field needs to be queried (< 20k records)"
+                      : "Open the 'Data Import' page with preloaded records to delete (< 20k records). 'Id' field needs to be queried"
+                  }, model.exportedData && model.exportedData.getSelectedVisibleCount() > 0
+                    ? `Delete ${model.exportedData.getSelectedVisibleCount()} Record${model.exportedData.getSelectedVisibleCount() > 1 ? "s" : ""}`
+                    : "Delete Records") : null,
               ),
               model.exportedData && model.exportedData.table[0]?.length > 0 && !model.exportError ? h("div", {className: "slds-form-element"},
                 h("div", {className: "slds-form-element__control slds-input-has-icon slds-input-has-icon_left slds-m-left_small slds-button-group"},

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -602,6 +602,18 @@ export function initScrollTable(scroller) {
       table.className = "slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-is-relative";
       let cellsVisible = false;
 
+      // Event delegation for checkbox changes (avoids listener leaks during virtual scroll recycling)
+      if (data && data.showCheckboxes) {
+        table.addEventListener("change", e => {
+          if (e.target.classList.contains("row-select-checkbox")) {
+            let rowIdx = parseInt(e.target.getAttribute("data-row-index"));
+            if (data.onToggleRowSelection) data.onToggleRowSelection(rowIdx);
+          } else if (e.target.classList.contains("select-all-checkbox")) {
+            if (data.onSelectAll) data.onSelectAll(e.target.checked);
+          }
+        });
+      }
+
       // Ensure firstRowIdx never goes below headerRows
       firstRowIdx = Math.max(headerRows, firstRowIdx);
 
@@ -628,6 +640,24 @@ export function initScrollTable(scroller) {
           renderCell(data, cell, td);
           tr.appendChild(td);
         }
+        // Prepend "Select All" checkbox cell to header
+        if (data.showCheckboxes) {
+          let th = document.createElement("td");
+          th.className = "scrolltable-cell header checkbox-cell";
+          th.style.position = "sticky";
+          th.style.left = "0";
+          th.style.zIndex = "10";
+          let selectAllCb = document.createElement("input");
+          selectAllCb.type = "checkbox";
+          selectAllCb.className = "select-all-checkbox";
+          let allSelected = data.isAllVisibleSelected ? data.isAllVisibleSelected() : false;
+          let someSelected = data.isSomeVisibleSelected ? data.isSomeVisibleSelected() : false;
+          selectAllCb.checked = allSelected;
+          selectAllCb.indeterminate = someSelected && !allSelected;
+          selectAllCb.title = allSelected ? "Deselect all visible records" : "Select all visible records";
+          th.appendChild(selectAllCb);
+          tr.insertBefore(th, tr.firstChild);
+        }
         table.appendChild(tr);
       }
 
@@ -638,7 +668,11 @@ export function initScrollTable(scroller) {
         }
         let row = data.table[r];
         let tr = document.createElement("tr");
-        tr.className = "slds-line-height_reset";
+        let trClasses = "slds-line-height_reset";
+        if (data.showCheckboxes && data.rowSelections && data.rowSelections[r]) {
+          trClasses += " row-selected";
+        }
+        tr.className = trClasses;
         for (let c = firstColIdx; c < lastColIdx; c++) {
           if (colVisible[c] == 0) {
             continue;
@@ -657,6 +691,19 @@ export function initScrollTable(scroller) {
           td.style.height = rowHeights[r] + "px";
           renderCell(data, cell, td);
           tr.appendChild(td);
+          cellsVisible = true;
+        }
+        // Prepend row checkbox cell
+        if (data.showCheckboxes) {
+          let tdCheck = document.createElement("td");
+          tdCheck.className = "scrolltable-cell checkbox-cell";
+          let cb = document.createElement("input");
+          cb.type = "checkbox";
+          cb.className = "row-select-checkbox";
+          cb.checked = !!(data.rowSelections && data.rowSelections[r]);
+          cb.setAttribute("data-row-index", r);
+          tdCheck.appendChild(cb);
+          tr.insertBefore(tdCheck, tr.firstChild);
           cellsVisible = true;
         }
         table.appendChild(tr);
@@ -684,6 +731,10 @@ export function initScrollTable(scroller) {
           tr = tr.nextElementSibling;
         }
         let td = table.firstElementChild.firstElementChild;
+        // Skip the checkbox cell if present
+        if (data && data.showCheckboxes && td) {
+          td = td.nextElementSibling;
+        }
         for (let c = firstColIdx; c < lastColIdx; c++) {
           if (colVisible[c] == 0) {
             continue;

--- a/tests/e2e/data-export.spec.js
+++ b/tests/e2e/data-export.spec.js
@@ -59,16 +59,18 @@ test.describe("Data Export", () => {
 
     // Check Headers
     // The table is virtualized and uses <td> for headers in the first row, not <th>
+    // Column 0 is the checkbox cell (added for selective deletion)
+    // Column 1 is "_" (record reference), then the queried fields follow
     const headerCells = resultTable.locator("tr").first().locator("td");
-    await expect(headerCells.nth(1)).toHaveText("Id");
-    await expect(headerCells.nth(2)).toHaveText("Name");
-    await expect(headerCells.nth(3)).toHaveText("Type");
+    await expect(headerCells.nth(2)).toHaveText("Id");
+    await expect(headerCells.nth(3)).toHaveText("Name");
+    await expect(headerCells.nth(4)).toHaveText("Type");
 
     // Check Data
     // The data rows follow the header row
     const firstDataRow = resultTable.locator("tr").nth(1);
-    await expect(firstDataRow.locator("td").nth(1)).toHaveText(/^001/);
-    await expect(firstDataRow.locator("td").nth(2)).toContainText("Test Account 1");
+    await expect(firstDataRow.locator("td").nth(2)).toHaveText(/^001/);
+    await expect(firstDataRow.locator("td").nth(3)).toContainText("Test Account 1");
   });
 
   test("Autocomplete Suggestions", async ({page, context, extensionId}) => {
@@ -144,10 +146,10 @@ test.describe("Data Export", () => {
     const resultTable = page.locator("#result-area table");
     await expect(resultTable).toBeVisible();
 
-    //in the result table extract the first row and get the values of id
+    // Column 0 is checkbox, column 1 is "_", column 2 is "Id", column 3 is "Name"
     const firstRow = resultTable.locator("tr").nth(1);
-    const id = await firstRow.locator("td").nth(1).textContent();
-    const name = await firstRow.locator("td").nth(2).textContent();
+    const id = await firstRow.locator("td").nth(2).textContent();
+    const name = await firstRow.locator("td").nth(3).textContent();
 
     // Click Copy CSV
     await page.click("button:has-text('Copy (CSV)')");
@@ -159,6 +161,152 @@ test.describe("Data Export", () => {
 
     expect(clipboardContent).toContain('"Id","Name"');
     expect(clipboardContent).toContain('"' + id + '","' + name + '"');
+  });
+
+  test("Delete button disabled when no records selected", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    // Delete button should be disabled — no rows selected yet
+    const deleteBtn = page.locator("button:has-text('Delete Records')");
+    await expect(deleteBtn).toBeVisible();
+    await expect(deleteBtn).toBeDisabled();
+  });
+
+  test("Checkbox column renders after export", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    const resultTable = page.locator("#result-area table");
+    await expect(resultTable).toBeVisible();
+
+    // Header should have Select All checkbox
+    const selectAllCb = resultTable.locator("tr").first().locator(".select-all-checkbox");
+    await expect(selectAllCb).toBeVisible();
+    await expect(selectAllCb).not.toBeChecked();
+
+    // Each data row should have a row checkbox
+    const rowCheckboxes = resultTable.locator("tr:not(:first-child) .row-select-checkbox");
+    await expect(rowCheckboxes).toHaveCount(2);
+    for (const cb of await rowCheckboxes.all()) {
+      await expect(cb).not.toBeChecked();
+    }
+  });
+
+  test("Selecting a row enables delete button with count", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    const resultTable = page.locator("#result-area table");
+
+    // Select the first data row checkbox
+    const firstRowCb = resultTable.locator("tr:nth-child(2) .row-select-checkbox");
+    await firstRowCb.check();
+
+    // Delete button should now show count
+    await expect(page.locator("button:has-text('Delete 1 Record')")).toBeVisible();
+    await expect(page.locator("button:has-text('Delete 1 Record')")).toBeEnabled();
+
+    // Header checkbox should be indeterminate (some but not all selected)
+    const selectAllCb = resultTable.locator("tr").first().locator(".select-all-checkbox");
+    const isIndeterminate = await selectAllCb.evaluate(el => el.indeterminate);
+    expect(isIndeterminate).toBe(true);
+  });
+
+  test("Select All selects all rows and updates delete count", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    const resultTable = page.locator("#result-area table");
+    const selectAllCb = resultTable.locator("tr").first().locator(".select-all-checkbox");
+
+    // Click Select All
+    await selectAllCb.check();
+
+    // All row checkboxes should be checked
+    const rowCheckboxes = resultTable.locator("tr:not(:first-child) .row-select-checkbox");
+    for (const cb of await rowCheckboxes.all()) {
+      await expect(cb).toBeChecked();
+    }
+
+    // Delete button shows total count
+    await expect(page.locator("button:has-text('Delete 2 Records')")).toBeVisible();
+    await expect(page.locator("button:has-text('Delete 2 Records')")).toBeEnabled();
+
+    // Select All checkbox should be checked (not indeterminate)
+    await expect(selectAllCb).toBeChecked();
+    const isIndeterminate = await selectAllCb.evaluate(el => el.indeterminate);
+    expect(isIndeterminate).toBe(false);
+  });
+
+  test("Deselect All disables delete button", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    const resultTable = page.locator("#result-area table");
+    const selectAllCb = resultTable.locator("tr").first().locator(".select-all-checkbox");
+
+    // Select All then Deselect All
+    await selectAllCb.check();
+    await expect(page.locator("button:has-text('Delete 2 Records')")).toBeEnabled();
+
+    await selectAllCb.uncheck();
+
+    // Delete button should be back to disabled
+    await expect(page.locator("button:has-text('Delete Records')")).toBeDisabled();
+
+    // All row checkboxes should be unchecked
+    const rowCheckboxes = resultTable.locator("tr:not(:first-child) .row-select-checkbox");
+    for (const cb of await rowCheckboxes.all()) {
+      await expect(cb).not.toBeChecked();
+    }
+  });
+
+  test("Selected rows have highlighted background", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+    await queryInput.fill("SELECT Id, Name FROM Account WHERE Name like 'Test Account%'");
+    await page.click("button:has-text('Run Export')");
+    await expect(page.locator(".result-status")).toContainText("Exported 2 records", {timeout: 2000});
+
+    const resultTable = page.locator("#result-area table");
+
+    // Before selection: no row-selected class
+    const firstDataRow = resultTable.locator("tr:nth-child(2)");
+    await expect(firstDataRow).not.toHaveClass(/row-selected/);
+
+    // Select first row
+    await resultTable.locator("tr:nth-child(2) .row-select-checkbox").check();
+
+    // After selection: row-selected class present
+    await expect(firstDataRow).toHaveClass(/row-selected/);
   });
 
 });


### PR DESCRIPTION
## Summary

Fixes #1076 — allows users to select specific records for deletion instead of deleting all exported records at once.

- **Checkbox column** added as the first column in the Data Export results table
- **Select All** header checkbox with 3-state support (unchecked / indeterminate / checked)
- **Dynamic delete button** — shows `Delete N Record(s)` and is disabled until at least one row is selected
- **Only selected rows** are passed to the Data Import page for deletion (uses `csvSerializeSelected`)
- **Selected row highlight** — light blue background (`#eaf5fe`) on selected rows
- Virtual scroll safe — checkbox state lives in the model (`rowSelections[]`), not the DOM

## Files Changed

| File | Change |
|---|---|
| `addon/data-export.js` | `rowSelections[]` state, helper methods, updated `canDelete()` and `deleteRecords()` |
| `addon/data-load.js` | Checkbox column rendering (header + data rows), event delegation |
| `addon/data-export.css` | Checkbox column styles, selected row highlight |
| `tests/e2e/data-export.spec.js` | 6 new checkbox tests + updated existing column index assertions |

## Checklist

- [ ] Run a SOQL query with `Id` field included — checkbox column appears on the left
- [ ] No rows selected by default — Delete button is disabled
- [ ] Check one row — button shows `Delete 1 Record` and enables
- [ ] Check multiple rows — button shows correct count
- [ ] Click Select All — all visible rows selected
- [ ] Click Select All again — all rows deselected, button disabled
- [ ] With some rows selected, header checkbox shows indeterminate state
- [ ] Click Delete — only selected records appear in the Data Import page
- [ ] Apply a filter, select rows, remove filter — selections are preserved
- [ ] Query without `Id` field — Delete button stays hidden/disabled (existing behaviour)