### PR TITLE
fix: Correct typo in localStorage key for sorting metadata & 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@
 ## Version 2.1
 
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
-- `REST Explorer` Fix `requestTemplates` deserialization (was splitting on `//` and producing strings instead of objects); now JSON-parsed with a safe fallback to defaults
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 2.1
 
+- `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
+- `REST Explorer` Fix `requestTemplates` deserialization (was splitting on `//` and producing strings instead of objects); now JSON-parsed with a safe fallback to defaults
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/addon/background.js
+++ b/addon/background.js
@@ -78,7 +78,7 @@ chrome.commands?.onCommand.addListener((command) => {
         break;
     }
     chrome.tabs.create({
-      url: `https:///${sfHost}${link}`
+      url: `https://${sfHost}${link}`
     });
 
   } else if (command.startsWith("open-")){

--- a/addon/metadata-retrieve.js
+++ b/addon/metadata-retrieve.js
@@ -24,7 +24,7 @@ class Model {
     this.metadataObjects = [];
     this.metadataTypeMap = {}; // Map of xmlName to metadata object with suffix
     this.includeManagedPackage = localStorage.getItem("includeManagedMetadata") === "true";
-    this.sortMetadataBy = JSON.parse(localStorage.getItem("sortMevetadataBy")) || "fullName";
+    this.sortMetadataBy = JSON.parse(localStorage.getItem("sortMetadataBy")) || "fullName";
     this.packageXml;
     this.metadataFilter = "";
     this.deployRequestId;


### PR DESCRIPTION
# Describe your changes

**1. Metadata Retrieve Fix:**
`Metadata Retrieve` Fix the *Sort metadata by* user preference not persisting across sessions. The page was reading the preference from a misspelled localStorage key (`sortMevetadataBy`) while the Options page and every other reference in the file used the correct key (`sortMetadataBy`), so the read always failed and the value silently fell back to the default `"fullName"`.

**Fix:** read from the correct key `sortMetadataBy` in [addon/metadata-retrieve.js:27](addon/metadata-retrieve.js:27).

**Before:**
```js
this.sortMetadataBy = JSON.parse(localStorage.getItem("sortMevetadataBy")) || "fullName";
```

**After:**
```js
this.sortMetadataBy = JSON.parse(localStorage.getItem("sortMetadataBy")) || "fullName";
```

The Options-page setting at [addon/options.js:297](addon/options.js:297) writes to the correct key, so users who had previously set this preference will now actually have it applied.

**2. Triple-slash in keyboard shortcut URLs — background.js:81:**

url: `https:///${sfHost}${link}`   // three slashes
The link-setup / link-home / link-dev keyboard shortcuts open https:///yourorg.my.salesforce.com/.... Chrome usually rescues this, but it's an obvious typo. Fix: drop one slash.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [[CHANGES.md](http://CHANGES.md)](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [[how-to.md](http://how-to.md)](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)