### PR TITLE
[feat]: Add keyboard shortcut to open Show All Data for current record

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Show All Data` Add configurable keyboard shortcut to open Show All Data for the current record (`Alt+Shift+I` by default) [issue #917](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/917) (contribution by [Ruben Halman](https://github.com/RubenHalman))
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/addon/background.js
+++ b/addon/background.js
@@ -81,6 +81,33 @@ chrome.commands?.onCommand.addListener((command) => {
       url: `https:///${sfHost}${link}`
     });
 
+  } else if (command === "open-show-all-data") {
+    chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+      let tab = tabs[0];
+      if (!tab?.url) return;
+      let tabUrl = tab.url;
+      let currentDomain;
+      try { currentDomain = new URL(tabUrl).hostname; } catch { return; }
+      chrome.cookies.get({url: tabUrl, name: "sid", storeId: tab.cookieStoreId}, cookie => {
+        if (!cookie || currentDomain.endsWith(".mcas.ms")) {
+          openShowAllData(currentDomain, tabUrl);
+          return;
+        }
+        const [orgId] = cookie.value.split("!");
+        const orderedDomains = ["salesforce.com", "cloudforce.com", "salesforce.mil", "cloudforce.mil", "sfcrmproducts.cn", "force.com"];
+        let resolved = false;
+        orderedDomains.forEach(domain => {
+          chrome.cookies.getAll({name: "sid", domain, secure: true, storeId: tab.cookieStoreId}, cookies => {
+            if (resolved) return;
+            let sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!") && c.domain != "help.salesforce.com");
+            if (sessionCookie) {
+              resolved = true;
+              openShowAllData(sessionCookie.domain, tabUrl);
+            }
+          });
+        });
+      });
+    });
   } else if (command.startsWith("open-")){
     chrome.runtime.sendMessage({
       msg: "shortcut_pressed", command, sfHost
@@ -117,5 +144,29 @@ async function clearSobjectsListCache() {
   } catch (e) {
     console.error("Error clearing sobjectsList cache on update:", e);
   }
+}
+function openShowAllData(host, tabUrl) {
+  let url;
+  try { url = new URL(tabUrl); } catch { return; }
+  let sobject = null;
+  let sobjectMatch = url.pathname.match(/\/lightning\/[ro]\/([a-zA-Z0-9_]+)\/[a-zA-Z0-9]+/);
+  if (sobjectMatch) sobject = sobjectMatch[1];
+  let recordId = null;
+  if (url.pathname.includes("/builder_platform_interaction/flowBuilder.app")) {
+    let flowId = url.searchParams.get("flowId");
+    if (flowId?.startsWith("301")) recordId = flowId;
+  } else {
+    for (let p of url.pathname.split("/")) {
+      if (p.match(/^([a-zA-Z0-9]{3}|[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18})$/) && p.includes("0000")) {
+        recordId = p;
+        break;
+      }
+    }
+  }
+  let args = new URLSearchParams();
+  args.set("host", host);
+  if (sobject) args.set("objectType", sobject);
+  if (recordId) args.set("recordId", recordId);
+  chrome.tabs.create({url: chrome.runtime.getURL("inspect.html?" + args)});
 }
 chrome.runtime.setUninstallURL("https://forms.gle/y7LbTNsFqEqSrtyc6");

--- a/addon/manifest-firefox.json
+++ b/addon/manifest-firefox.json
@@ -86,5 +86,10 @@
     "flow-scanner.html"
   ],
   "incognito": "spanning",
-  "manifest_version": 2
+  "manifest_version": 2,
+  "commands": {
+    "open-show-all-data": {
+      "description": "Open Show All Data for current record"
+    }
+  }
 }

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -128,6 +128,13 @@
     "open-save-modifications": {
       "description": "Save modifications in Show All Data"
     },
+    "open-show-all-data": {
+      "description": "Open Show All Data for current record",
+      "suggested_key": {
+        "default": "Ctrl+Shift+I",
+        "mac": "Command+Shift+I"
+      }
+    },
     "link-setup": {
       "description": "Open Setup"
     },

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -129,11 +129,7 @@
       "description": "Save modifications in Show All Data"
     },
     "open-show-all-data": {
-      "description": "Open Show All Data for current record",
-      "suggested_key": {
-        "default": "Ctrl+Shift+I",
-        "mac": "Command+Shift+I"
-      }
+      "description": "Open Show All Data for current record"
     },
     "link-setup": {
       "description": "Open Setup"

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -129,7 +129,10 @@
       "description": "Save modifications in Show All Data"
     },
     "open-show-all-data": {
-      "description": "Open Show All Data for current record"
+      "description": "Open Show All Data for current record",
+      "suggested_key": {
+        "default": "Alt+Shift+I"
+      }
     },
     "link-setup": {
       "description": "Open Setup"

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -36,7 +36,7 @@ if (typeof browser === "undefined") {
     if (request.msg === "shortcut_pressed") {
       if (request.command === "open-popup") {
         parent.postMessage({insextOpenPopup: true}, "*");
-      } else {
+      } else if (request.command !== "open-show-all-data") {
         parent.postMessage({command: request.command}, "*");
       }
     } else if (request.message === "tokenUpdated" && request.sfHost) {
@@ -138,6 +138,7 @@ class App extends React.PureComponent {
     };
     this.onContextUrlMessage = this.onContextUrlMessage.bind(this);
     this.onShortcutKey = this.onShortcutKey.bind(this);
+    this.onShowAllDataShortcut = this.onShowAllDataShortcut.bind(this);
     this.onChangeApi = this.onChangeApi.bind(this);
     this.onContextRecordChange = this.onContextRecordChange.bind(this);
     this.updateReleaseNotesViewed = this.updateReleaseNotesViewed.bind(this);
@@ -325,12 +326,31 @@ class App extends React.PureComponent {
     let {sfHost} = this.props;
     addEventListener("message", this.onContextUrlMessage);
     addEventListener("keydown", this.onShortcutKey);
+    chrome.runtime.onMessage.addListener(this.onShowAllDataShortcut);
     parent.postMessage({insextLoaded: true}, "*");
     setOrgInfo(this.props.sfHost);
   }
   componentWillUnmount() {
     removeEventListener("message", this.onContextUrlMessage);
     removeEventListener("keydown", this.onShortcutKey);
+    chrome.runtime.onMessage.removeListener(this.onShowAllDataShortcut);
+  }
+  onShowAllDataShortcut(request) {
+    if (request.msg === "shortcut_pressed" && request.command === "open-show-all-data") {
+      let {sfHost} = this.props;
+      let {contextUrl} = this.state;
+      let recordId = contextUrl && getRecordId(contextUrl);
+      let sobject = contextUrl && getSobject(contextUrl);
+      let args = new URLSearchParams();
+      args.set("host", sfHost);
+      if (sobject) {
+        args.set("objectType", sobject);
+      }
+      if (recordId) {
+        args.set("recordId", recordId);
+      }
+      window.open(chrome.runtime.getURL("inspect.html?" + args), "_blank");
+    }
   }
   isMac() {
     return navigator.userAgentData?.platform.toLowerCase().indexOf("mac") > -1 || navigator.userAgent.toLowerCase().indexOf("mac") > -1;

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -36,7 +36,7 @@ if (typeof browser === "undefined") {
     if (request.msg === "shortcut_pressed") {
       if (request.command === "open-popup") {
         parent.postMessage({insextOpenPopup: true}, "*");
-      } else if (request.command !== "open-show-all-data") {
+      } else {
         parent.postMessage({command: request.command}, "*");
       }
     } else if (request.message === "tokenUpdated" && request.sfHost) {
@@ -138,7 +138,6 @@ class App extends React.PureComponent {
     };
     this.onContextUrlMessage = this.onContextUrlMessage.bind(this);
     this.onShortcutKey = this.onShortcutKey.bind(this);
-    this.onShowAllDataShortcut = this.onShowAllDataShortcut.bind(this);
     this.onChangeApi = this.onChangeApi.bind(this);
     this.onContextRecordChange = this.onContextRecordChange.bind(this);
     this.updateReleaseNotesViewed = this.updateReleaseNotesViewed.bind(this);
@@ -326,31 +325,12 @@ class App extends React.PureComponent {
     let {sfHost} = this.props;
     addEventListener("message", this.onContextUrlMessage);
     addEventListener("keydown", this.onShortcutKey);
-    chrome.runtime.onMessage.addListener(this.onShowAllDataShortcut);
     parent.postMessage({insextLoaded: true}, "*");
     setOrgInfo(this.props.sfHost);
   }
   componentWillUnmount() {
     removeEventListener("message", this.onContextUrlMessage);
     removeEventListener("keydown", this.onShortcutKey);
-    chrome.runtime.onMessage.removeListener(this.onShowAllDataShortcut);
-  }
-  onShowAllDataShortcut(request) {
-    if (request.msg === "shortcut_pressed" && request.command === "open-show-all-data") {
-      let {sfHost} = this.props;
-      let {contextUrl} = this.state;
-      let recordId = contextUrl && getRecordId(contextUrl);
-      let sobject = contextUrl && getSobject(contextUrl);
-      let args = new URLSearchParams();
-      args.set("host", sfHost);
-      if (sobject) {
-        args.set("objectType", sobject);
-      }
-      if (recordId) {
-        args.set("recordId", recordId);
-      }
-      window.open(chrome.runtime.getURL("inspect.html?" + args), "_blank");
-    }
   }
   isMac() {
     return navigator.userAgentData?.platform.toLowerCase().indexOf("mac") > -1 || navigator.userAgent.toLowerCase().indexOf("mac") > -1;

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -328,10 +328,6 @@ Navigate to your browser shortcut menu and choose dedicated shortcuts for the pa
 
 <img width="660" alt="Use Chrome Shortcuts" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/382aea2d-5278-4dfe-89e6-6dcec4c724c9">
 
-### Open Show All Data for current record
-
-Press `Alt+Shift+I` (default) to instantly open the Show All Data page for the record you're currently viewing, without having to open the popup first. You can remap this shortcut in your browser's extension shortcut settings.
-
 ### Default shortcuts
 
 If you want to open popup keyboard shortcuts, you can use the 'ctrl' (windows) or 'command' (mac) key with the corresponding key.
@@ -342,6 +338,8 @@ Example:
 * Org <ins>L</ins>imits : l
 * <ins>D</ins>ownload Metadata : d
 * E<ins>x</ins>plore API : x
+
+You can also assign a shortcut to open **Show All Data** directly for the current record (default: `Alt+Shift+I`), skipping the popup entirely.
 
 ## Highlight PROD with a top border
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -324,8 +324,13 @@ Navigate to your browser shortcut menu and choose dedicated shortcuts for the pa
 
 * Chrome: [chrome://extensions/shortcut](chrome://extensions/shortcut)
 * Edge: [edge://extensions/shortcuts](edge://extensions/shortcuts)
+* Firefox: Open the Add-ons Manager (`Cmd+Shift+A` on Mac / `Ctrl+Shift+A` on Windows), click the gear icon, then select "Manage Extension Shortcuts"
 
 <img width="660" alt="Use Chrome Shortcuts" src="https://github.com/tprouvot/Salesforce-Inspector-reloaded/assets/35368290/382aea2d-5278-4dfe-89e6-6dcec4c724c9">
+
+### Open Show All Data for current record
+
+Press `Alt+Shift+I` (default) to instantly open the Show All Data page for the record you're currently viewing, without having to open the popup first. You can remap this shortcut in your browser's extension shortcut settings.
 
 ### Default shortcuts
 


### PR DESCRIPTION
Fixes #917

## Summary

- Adds `open-show-all-data` command to `manifest.json` (Chrome/Edge) and `manifest-firefox.json` (Firefox) so it appears in extension shortcut settings
- Default shortcut: `Ctrl+Shift+I` on Windows/Linux, `Cmd+Shift+I` on Mac (configurable by the user)
- Handled in `popup.js` using the existing `getRecordId`/`getSobject` context — no logic duplicated into `button.js`
- Opens `inspect.html` for the current record directly, including objectType when available

## How it works

When the shortcut fires, `background.js` sends `shortcut_pressed` with `command: "open-show-all-data"`. The `App` component in `popup.js` listens for this via `chrome.runtime.onMessage` and opens the inspect page using the already-known `contextUrl` state — the same URL the popup uses to detect the current record.

## Testing

- On a Salesforce record page, press `Cmd+Shift+I` (Mac) or `Ctrl+Shift+I` (Windows/Linux)
- Show All Data opens in a new tab for the current record

## Checklist
- [x] I have read and understand the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and I discussed it with maintainer
 - [x] I used SLDS style and limit the usage of custom CSS
 - [x] I have performed a self-review of my code
 - [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
 - [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
 - [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)