### PR TITLE
[fix]: Custom object setup links redirect to Object Manager root instead of specific object

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3907,14 +3907,6 @@ class AllDataSelection extends React.PureComponent {
       return this.getMetadataLink(durableId, "EventObjects");
     } else if (isCustomSetting) {
       return this.getMetadataLink(durableId, "CustomSettings");
-    } else if (sobjectName.endsWith("__c")) {
-      return (
-        "https://"
-        + this.props.sfHost
-        + "/lightning/setup/ObjectManager/"
-        + durableId
-        + "/Details/view"
-      );
     } else {
       return (
         "https://"
@@ -3933,14 +3925,6 @@ class AllDataSelection extends React.PureComponent {
       return this.getMetadataLink(durableId, "CustomMetadata");
     } else if (isCustomSetting) {
       return this.getMetadataLink(durableId, "CustomSettings");
-    } else if (sobjectName.endsWith("__c") || sobjectName.endsWith("__kav")) {
-      return (
-        "https://"
-        + this.props.sfHost
-        + "/lightning/setup/ObjectManager/"
-        + durableId
-        + "/FieldsAndRelationships/view"
-      );
     } else {
       return (
         "https://"
@@ -3981,24 +3965,14 @@ class AllDataSelection extends React.PureComponent {
       + "/ObjectAccess/view"
     );
   }
-  getRecordTypesLink(sfHost, sobjectName, durableId) {
-    if (sobjectName.endsWith("__c") || sobjectName.endsWith("__kav")) {
-      return (
-        "https://"
-        + sfHost
-        + "/lightning/setup/ObjectManager/"
-        + durableId
-        + "/RecordTypes/view"
-      );
-    } else {
-      return (
-        "https://"
-        + sfHost
-        + "/lightning/setup/ObjectManager/"
-        + sobjectName
-        + "/RecordTypes/view"
-      );
-    }
+  getRecordTypesLink(sfHost, sobjectName) {
+    return (
+      "https://"
+      + sfHost
+      + "/lightning/setup/ObjectManager/"
+      + sobjectName
+      + "/RecordTypes/view"
+    );
   }
   getObjectDocLink(sobject, api) {
     if (api === "toolingApi") {
@@ -4153,8 +4127,7 @@ class AllDataSelection extends React.PureComponent {
                           // TODO add check for record type support (such as custom metadata types and custom settings)
                           href: this.getRecordTypesLink(
                             sfHost,
-                            selectedValue.sobject.name,
-                            selectedValue.sobject.durableId
+                            selectedValue.sobject.name
                           ),
                           target: linkTarget,
                           onClick: handleLightningLinkClick,


### PR DESCRIPTION
Fixes the bug reported in beta where clicking Fields/Details/Record Types for a custom object navigates to the Object Manager root instead of the specific object.

## Root cause

The ObjectManager URLs for custom objects used `durableId` (from the Tooling API EntityDefinition query). If that query hasn't completed yet, `durableId` is `undefined`, producing a URL like `.../ObjectManager/undefined/FieldsAndRelationships/view`, which Salesforce redirects to the Object Manager root. Standard objects already used `sobjectName` directly and worked fine.

## Fix

Use `sobjectName` (e.g. `MyObject__c`) consistently in all ObjectManager URLs — it's always available immediately and works for both standard and custom objects.

## Affected functions
- `getObjectSetupLink`
- `getObjectFieldsSetupLink`
- `getRecordTypesLink`