### PR TITLE
[fix]: Org Limits names and values can wrap and be hidden

### DIFF
--- a/addon/limits.css
+++ b/addon/limits.css
@@ -11,12 +11,12 @@ figcaption {
   font-weight: bold;
   display: table-caption;
   caption-side: bottom;
-  height: 55px;
-  font-size: 1.2em;
+  line-height: 1.2;
+  font-size: 1.1em;
 }
 figcaption > div {
   font-weight: normal;
-  font-size: 0.8em;
+  font-size: 0.9em;
   margin-top: 2px;
 }
 .gauge {


### PR DESCRIPTION
Fixes #1183

## Changes

- Removed fixed `height: 55px` from `figcaption` — replaced with `line-height: 1.2` so content grows naturally
- Reduced `figcaption` font-size from `1.2em` to `1.1em` — keeps long names to 2 lines
- Increased `figcaption > div` font-size from `0.8em` to `0.9em` — compensates so limit values stay approximately the same visual size

Long names like "Hourly Published Standard Volume Platform Events" and values >1M no longer overflow into adjacent gauges.