### PR TITLE
[fix]: SOQL autocomplete broken when last SELECT field starts with 'from'

### DIFF
--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -448,7 +448,7 @@ class Model {
     let sobjectName, isAfterFrom;
     // Find out what sobject we are querying, by using the word after the "from" keyword.
     // Assuming no subqueries in the select clause, we should find the correct sobjectName. There should be only one "from" keyword, and strings (which may contain the word "from") are only allowed after the real "from" keyword.
-    let fromKeywordMatch = /(^|\s)from\s+([a-z0-9_]*)/i.exec(query);
+    let fromKeywordMatch = [...query.matchAll(/(^|\s)from\s+([a-z0-9_]*)/gi)].pop();
     let findKeywordMatch = /(^|\s)find\s+([a-z0-9_]*)/i.exec(query);
     let graphKeywordMatch = /(^|\s)uiapi\s+([a-z0-9_]*)/i.exec(query);
     if (fromKeywordMatch) {


### PR DESCRIPTION
Fixes #557

## Root cause

The regex `/(^|\s)from\s+([a-z0-9_]*)/i` used `.exec()` which returns the **first** match. When a field named `from` (or `FromAddress`, `FromName`, etc.) is the last field in SELECT, the first match captures the field name + the real `FROM` keyword as the object name (e.g. `FROM` instead of `EmailMessage`).

## Fix

Use `.matchAll()` and take the **last** match — the real `FROM` keyword always comes after the SELECT fields, so the last occurrence is always correct.

```js
// Before
let fromKeywordMatch = /(^|\s)from\s+([a-z0-9_]*)/i.exec(query);

// After
let fromKeywordMatch = [...query.matchAll(/(^|\s)from\s+([a-z0-9_]*)/gi)].pop();
```