### PR TITLE
[feat]: Show All Data: Add refresh button and persist filter in URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 
 ## Version 2.1
 
-- `Show All Data` Add **Refresh** button to re-fetch the latest field values from Salesforce for the currently displayed record without reloading the full page
-- `Show All Data` Persist the filter value in the URL so it survives page refreshes
+- `Show All Data` Add **Refresh** button to re-fetch the latest field values and persist the filter value in the URL [feature 1201](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1201)
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 2.1
 
+- `Show All Data` Add **Refresh** button to re-fetch the latest field values from Salesforce for the currently displayed record without reloading the full page
+- `Show All Data` Persist the filter value in the URL so it survives page refreshes
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -529,6 +529,19 @@ Structure your response clearly with appropriate headings.`;
     this.childRows = new ChildRowList(this);
     this.startLoading();
   }
+  refreshData() {
+    // Re-fetch the latest field values from Salesforce for the currently displayed record.
+    // We keep the existing fieldRows/childRows (and therefore the active row filter, column
+    // filters and sort order), so the user's filter is still obeyed after the refresh.
+    if (this.recordId) {
+      this.recordName = null; // Recompute the record heading in case the Name changed.
+      this.clearRecordData();
+      this.setRecordData(sfConn.rest("/services/data/v" + apiVersion + "/" + (this.useToolingApi ? "tooling/" : "") + "sobjects/" + this.sobjectName + "/" + this.recordId));
+    } else {
+      // No specific record is loaded, so there are no values to refresh; reload the object metadata instead.
+      this.reloadTables();
+    }
+  }
 
   exportTable() {
     // Get the current active tab to determine which table to export
@@ -1642,6 +1655,7 @@ class App extends React.Component {
     this.onDoDelete = this.onDoDelete.bind(this);
     this.onDoCreate = this.onDoCreate.bind(this);
     this.onDoSave = this.onDoSave.bind(this);
+    this.onRefresh = this.onRefresh.bind(this);
     this.onCancelEdit = this.onCancelEdit.bind(this);
     this.onUpdateTableBorderSettings = this.onUpdateTableBorderSettings.bind(this);
     this.handleClick = this.handleClick.bind(this);
@@ -1730,6 +1744,12 @@ class App extends React.Component {
     model.doSave();
     model.didUpdate();
     e.currentTarget.disabled = false;
+  }
+  onRefresh(e) {
+    e.preventDefault();
+    let {model} = this.props;
+    model.refreshData();
+    model.didUpdate();
   }
   onCancelEdit() {
     let {model} = this.props;
@@ -1855,6 +1875,12 @@ class App extends React.Component {
       h("div", {className: "slds-builder-header__utilities-item slds-p-top_x-small slds-p-horizontal_x-small sfir-border-none"},
         h("div", {className: "slds-media__body"},
           h("span", {className: "slds-button-group object-actions"},
+            model.editMode == null && model.objectName() ? h("button", {
+              title: "Refresh the data shown in the table with the latest field values from Salesforce",
+              className: "slds-button slds-button_neutral",
+              disabled: model.spinnerCount != 0,
+              onClick: this.onRefresh
+            }, "Refresh") : null,
             model.editMode == null && model.recordData && (model.useTab == "all" || model.useTab == "fields") ? h("button", {
               title: "Inline edit the values of this record",
               className: "slds-button slds-button_neutral",

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -1671,14 +1671,26 @@ class App extends React.Component {
   onRowsFilterInput(e) {
     let {model} = this.props;
     model.rowsFilter = e.target.value;
+    this.persistFilterInUrl(model.rowsFilter);
     model.didUpdate();
   }
   onClearAndFocusFilter(e) {
     e.preventDefault();
     let {model} = this.props;
     model.rowsFilter = "";
+    this.persistFilterInUrl(model.rowsFilter);
     this.refs.rowsFilter.focus();
     model.didUpdate();
+  }
+  // Persist the filter value in the URL so it survives page refreshes.
+  persistFilterInUrl(value) {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (value) {
+      urlParams.set("filter", value);
+    } else {
+      urlParams.delete("filter");
+    }
+    window.history.replaceState(null, "", "?" + urlParams.toString());
   }
   onShowObjectMetadata(e) {
     e.preventDefault();
@@ -2636,6 +2648,7 @@ class DetailsBox extends React.Component {
     model.sobjectName = args.get("objectType");
     model.useToolingApi = args.has("useToolingApi");
     model.recordId = args.get("recordId");
+    model.rowsFilter = args.get("filter") || "";
     model.startLoading();
     model.reactCallback = cb => {
       ReactDOM.render(h(App, {model}), root, cb);

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -534,9 +534,13 @@ Structure your response clearly with appropriate headings.`;
     // We keep the existing fieldRows/childRows (and therefore the active row filter, column
     // filters and sort order), so the user's filter is still obeyed after the refresh.
     if (this.recordId) {
-      this.recordName = null; // Recompute the record heading in case the Name changed.
-      this.clearRecordData();
-      this.setRecordData(sfConn.rest("/services/data/v" + apiVersion + "/" + (this.useToolingApi ? "tooling/" : "") + "sobjects/" + this.sobjectName + "/" + this.recordId));
+      let recordDataPromise = sfConn.rest("/services/data/v" + apiVersion + "/" + (this.useToolingApi ? "tooling/" : "") + "sobjects/" + this.sobjectName + "/" + this.recordId)
+        .then(res => {
+          this.recordName = null; // Recompute the record heading in case the Name changed.
+          this.clearRecordData();
+          return res;
+        });
+      this.setRecordData(recordDataPromise);
     } else {
       // No specific record is loaded, so there are no values to refresh; reload the object metadata instead.
       this.reloadTables();


### PR DESCRIPTION
# Describe your changes

Improvements to the user experience on the 'Show All Data' `inspect.js` page. These are changes I've wanted to implement for myself for years, and then I saw that someone else had requested the same thing in an issue recently, so that inspired me to find time and actually make the changes. 
- `Show All Data` Persist the filter value in the URL so it survives page refreshes
- `Show All Data` Add **Refresh** button to re-fetch the latest field values from Salesforce for the currently displayed record without reloading the full page

## Issue ticket number and link
Resolves #1201

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
