### PR TITLE
fix: retrieve SF access token via show-access-token for e2e setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,7 @@ jobs:
         echo $SF_AUTH_URL > ./SFDX_AUTH_URL.txt
         sf org login sfdx-url -f ./SFDX_AUTH_URL.txt -a cicdorg -d
 
-        # Display the authenticated org and extract the access token and instance url
+        # Display the authenticated org and extract the instance url
         echo "Extracting authentication information..."
         ORG_INFO=$(sf org display --json -o cicdorg 2>/dev/null)
         SF_EXIT_CODE=$?
@@ -120,11 +120,16 @@ jobs:
           exit 1
         fi
         
-        ACCESS_TOKEN=$(echo "$ORG_INFO" | jq -r '.result.accessToken // empty' 2>/dev/null)
         INSTANCE_URL=$(echo "$ORG_INFO" | jq -r '.result.instanceUrl // empty' 2>/dev/null)
         
-        if [ -z "$ACCESS_TOKEN" ]; then
-          echo "Error: Could not extract access_token from auth response"
+        # The access token is redacted from "sf org display" since the CLI
+        # security update (~May 2026). Retrieve it from the dedicated command
+        # (--json/--no-prompt skip the interactive security confirmation).
+        TOKEN_INFO=$(sf org auth show-access-token --json -o cicdorg --no-prompt 2>/dev/null)
+        ACCESS_TOKEN=$(echo "$TOKEN_INFO" | jq -r '.result.accessToken // empty' 2>/dev/null)
+        
+        if [ -z "$ACCESS_TOKEN" ] || [ "${ACCESS_TOKEN#\[REDACTED\]}" != "$ACCESS_TOKEN" ]; then
+          echo "Error: Could not extract access token from 'sf org auth show-access-token'"
           exit 1
         fi
         

--- a/scripts/set-test-constants-from-org.js
+++ b/scripts/set-test-constants-from-org.js
@@ -5,7 +5,9 @@
  * Uses Salesforce CLI (sf) to get org info and run SOQL queries.
  *
  * Prerequisites:
- * - Salesforce CLI installed (sf)
+ * - Salesforce CLI installed (sf). Requires a version with
+ *   'sf org auth show-access-token' (the access token is redacted from
+ *   'sf org display' since the CLI security update, ~May 2026).
  * - Authenticated to a default org (sf org login web or sfdx force:auth:web:login)
  * - Flow RecordTrigger_InspectorTest deployed to the org
  * - At least one Account record in the org
@@ -46,6 +48,21 @@
     }
   }
 
+  function getAccessToken() {
+    // sf org display no longer returns the access token (redacted since the
+    // CLI security update, ~May 2026). The token must be fetched from the
+    // dedicated command; --json bypasses the interactive confirmation prompt.
+    const args = ["org", "auth", "show-access-token", "--json"];
+    if (TARGET_ORG) args.push("--target-org", TARGET_ORG);
+    const output = runSfCommand(args);
+    const data = JSON.parse(output);
+    const accessToken = data.result?.accessToken;
+    if (!accessToken || accessToken.startsWith("[REDACTED]")) {
+      throw new Error("Could not retrieve access token from 'sf org auth show-access-token'");
+    }
+    return accessToken;
+  }
+
   function getOrgInfo() {
     const args = ["org", "display", "--json"];
     if (TARGET_ORG) args.push("--target-org", TARGET_ORG);
@@ -56,13 +73,13 @@
       throw new Error("No org result in sf org display output");
     }
     const instanceUrl = result.instanceUrl;
-    const accessToken = result.accessToken;
     const apiVersion = result.apiVersion || "66.0";
 
-    if (!instanceUrl || !accessToken) {
-      throw new Error("Could not extract instanceUrl or accessToken from org display");
+    if (!instanceUrl) {
+      throw new Error("Could not extract instanceUrl from org display");
     }
 
+    const accessToken = getAccessToken();
     const host = new URL(instanceUrl).hostname;
     return {host, accessToken, apiVersion};
   }
@@ -188,10 +205,19 @@ export const TEST_CONSTANTS = {
       mockEnabled: false
     };
 
+    // Hide real access tokens (start with the org id prefix "00D") from the
+    // printed output to avoid leaking credentials in logs. A non-token value
+    // (e.g. a "[REDACTED] ..." placeholder) is shown as-is so it can help
+    // diagnose configuration issues.
+    const printableConstants = {
+      ...constants,
+      mockToken: constants.mockToken.startsWith("00D") ? "[MASKED] real token written to file, hidden from logs" : constants.mockToken
+    };
+
     console.log("\n" + "=".repeat(50));
     console.log("TEST_CONSTANTS:");
     console.log("=".repeat(50));
-    console.log(JSON.stringify(constants, null, 2));
+    console.log(JSON.stringify(printableConstants, null, 2));
     console.log("=".repeat(50));
 
     if (DRY_RUN) {

--- a/tests/HOW_TO_RUN_TESTS.md
+++ b/tests/HOW_TO_RUN_TESTS.md
@@ -82,6 +82,8 @@ npm run set-test-constants -- --target-org my-org-alias
 
 Prerequisites: Salesforce CLI (`sf`) installed, authenticated to an org, Flow `RecordTrigger_InspectorTest` deployed, and at least one Account record.
 
+> **Note:** Since the Salesforce CLI security update (~May 2026), `sf org display` redacts the access token (it returns `[REDACTED] Use 'sf org auth show-access-token' to view`). The script now fetches the token via `sf org auth show-access-token --json`, so make sure your CLI version supports that command. If you set `mockToken` manually (Option B) and see `401` errors, get a valid token with `sf org auth show-access-token --target-org <org>`.
+
 **Important:** Import `tests/account_test_data.csv` before running the script so Account names (e.g. "Test Account 1", "Test Account 2") match test expectations. The script sets both `accountRecordId` and `accountRecordName` from your org.
 
 **Option B: Manual configuration**


### PR DESCRIPTION
The Salesforce CLI security update (~May 2026) redacts the access token from `sf org display` (returns "[REDACTED] Use 'sf org auth show-access-token' to view"), which broke e2e test setup with 401s.

- set-test-constants script and e2e workflow now fetch the token via `sf org auth show-access-token --json` (CI keeps `::add-mask::`).
- Mask real tokens (00D prefix) in the script's printed output while still showing placeholder values to aid diagnosis.
- Document the CLI requirement in HOW_TO_RUN_TESTS.md.

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [ ] I used SLDS style and limit the usage of custom CSS
- [ ] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
