### PR TITLE
Resolve column labels to field API names in data import

### DIFF
--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -376,6 +376,17 @@ class Model {
     }());
   }
 
+  resolveColumnLabel(column) {
+    let sobjectName = this.importType;
+    let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", sobjectName).sobjectDescribe;
+    if (!sobjectDescribe) {
+      return column;
+    }
+    let trimmedColumn = column.trim();
+    let field = sobjectDescribe.fields.find(f => f.label && f.label.toLowerCase() == trimmedColumn.toLowerCase());
+    return field ? field.name : trimmedColumn;
+  }
+
   importIdColumnValid() {
     return this.importAction == "create" || this.inputIdColumnIndex() > -1;
   }
@@ -667,7 +678,7 @@ class Model {
         return externalIdColumn;
       }
     }
-    return col.trim();
+    return this.resolveColumnLabel(col);
   }
 
   refreshColumn() {


### PR DESCRIPTION
## Summary

This PR improves Data Import column mapping by resolving pasted Excel column headers from Salesforce field labels to field API names when possible.

The field suggestion list remains unchanged and continues to display API names only.

## Motivation

Most Excel files prepared for data import use user-facing Salesforce field labels as column headers, because those are the names users recognize from the Salesforce UI.

The Data Import tool, however, requires field API names. As a result, users often need to manually look up the corresponding API name for each column before running an import.

For example, an Excel file may contain a header like:

```text
Customer Segmentation
while the importer expects:

CustSegmentation__c
This change makes field mapping faster by automatically resolving matching field labels to their API names.
```

Description
This PR adds a small normalization step when guessing import columns.

After preserving the existing relationship/external-id guessing behavior, the importer now checks whether the pasted column header matches a field label on the selected object. If a case-insensitive label match is found, the header is resolved to the corresponding field API name.

Changes included:

Add resolveColumnLabel(column) to:

read the describe metadata for the selected import object,

trim the pasted column value,

find a field whose label matches the column header case-insensitively,

return the matching field name,

fall back to the trimmed original column value when no match is found.

Update guessColumn() to call resolveColumnLabel() after the existing relationship/external-id guessing logic.

Keep the existing field suggestion list unchanged so suggestions continue to display API names only.

Behavior
Before this change:

Customer Segmentation
would remain unchanged and could be treated as an unknown field.

After this change, if the selected object's describe metadata contains:

label: Customer Segmentation
name: CustSegmentation__c
then the pasted column header is normalized to:

CustSegmentation__c
Notes
This intentionally does not add field labels to the field mapping suggestion list.

The goal is to make pasted Excel headers easier to work with while preserving the existing API-name based suggestion and validation behavior.