### PR TITLE
Map column labels to API names and show field labels in column suggestions

### DIFF
--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -370,6 +370,15 @@ class Model {
     }());
   }
 
+  columnLabel(columnName) {
+    let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", this.importType).sobjectDescribe;
+    if (!sobjectDescribe) {
+      return undefined;
+    }
+    let field = sobjectDescribe.fields.find(sobjectField => sobjectField.name.toLowerCase() == columnName.toLowerCase());
+    return field && field.label != field.name ? field.label : undefined;
+  }
+
   importIdColumnValid() {
     return this.importAction == "create" || this.inputIdColumnIndex() > -1;
   }
@@ -1268,7 +1277,7 @@ class App extends React.Component {
             ),
             h("datalist", {id: "sobjectlist"}, model.sobjectList().map(data => h("option", {key: data.name, value: data.name}))),
             h("datalist", {id: "idlookuplist"}, model.idLookupList().map(data => h("option", {key: data, value: data}))),
-            h("datalist", {id: "columnlist"}, model.columnList().map(data => h("option", {key: data, value: data})))
+            h("datalist", {id: "columnlist"}, model.columnList().map(data => h("option", {key: data, value: data, label: model.columnLabel(data)})))
           ),
         ),
         h("div", {className: "conf-subsection columns-mapping"},

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -370,21 +370,6 @@ class Model {
     }());
   }
 
-  columnSuggestionList() {
-    let suggestions = this.columnList().map(value => ({value}));
-    let existingValues = new Set(suggestions.map(suggestion => suggestion.value.toLowerCase()));
-    let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", this.importType).sobjectDescribe;
-    if (sobjectDescribe) {
-      for (let field of sobjectDescribe.fields) {
-        if (field.label && existingValues.has(field.name.toLowerCase()) && !existingValues.has(field.label.toLowerCase())) {
-          suggestions.push({value: field.label, label: field.name});
-          existingValues.add(field.label.toLowerCase());
-        }
-      }
-    }
-    return suggestions;
-  }
-
   importIdColumnValid() {
     return this.importAction == "create" || this.inputIdColumnIndex() > -1;
   }
@@ -1283,7 +1268,7 @@ class App extends React.Component {
             ),
             h("datalist", {id: "sobjectlist"}, model.sobjectList().map(data => h("option", {key: data.name, value: data.name}))),
             h("datalist", {id: "idlookuplist"}, model.idLookupList().map(data => h("option", {key: data, value: data}))),
-            h("datalist", {id: "columnlist"}, model.columnSuggestionList().map(data => h("option", {key: data.value, value: data.value, label: data.label})))
+            h("datalist", {id: "columnlist"}, model.columnList().map(data => h("option", {key: data, value: data})))
           ),
         ),
         h("div", {className: "conf-subsection columns-mapping"},

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -654,14 +654,24 @@ class Model {
     if (!col) {
       return col;
     }
-    let columnName = col.split(".");
+    let trimmedCol = col.trim();
+    let columnName = trimmedCol.split(".");
     if (columnName.length == 2) {
       let externalIdColumn = this.columnList().find(s => s.toLowerCase().startsWith(columnName[0].toLowerCase()) && s.toLowerCase().endsWith(columnName[1].toLowerCase()));
       if (externalIdColumn) {
         return externalIdColumn;
       }
     }
-    return col.trim();
+
+    let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", this.importType).sobjectDescribe;
+    if (sobjectDescribe) {
+      let matchingField = sobjectDescribe.fields.find(field => field.label && field.label.toLowerCase() == trimmedCol.toLowerCase());
+      if (matchingField) {
+        return matchingField.name;
+      }
+    }
+
+    return trimmedCol;
   }
 
   refreshColumn() {

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -370,6 +370,21 @@ class Model {
     }());
   }
 
+  columnSuggestionList() {
+    let suggestions = this.columnList().map(value => ({value}));
+    let existingValues = new Set(suggestions.map(suggestion => suggestion.value.toLowerCase()));
+    let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", this.importType).sobjectDescribe;
+    if (sobjectDescribe) {
+      for (let field of sobjectDescribe.fields) {
+        if (field.label && existingValues.has(field.name.toLowerCase()) && !existingValues.has(field.label.toLowerCase())) {
+          suggestions.push({value: field.label, label: field.name});
+          existingValues.add(field.label.toLowerCase());
+        }
+      }
+    }
+    return suggestions;
+  }
+
   importIdColumnValid() {
     return this.importAction == "create" || this.inputIdColumnIndex() > -1;
   }
@@ -1268,7 +1283,7 @@ class App extends React.Component {
             ),
             h("datalist", {id: "sobjectlist"}, model.sobjectList().map(data => h("option", {key: data.name, value: data.name}))),
             h("datalist", {id: "idlookuplist"}, model.idLookupList().map(data => h("option", {key: data, value: data}))),
-            h("datalist", {id: "columnlist"}, model.columnList().map(data => h("option", {key: data, value: data})))
+            h("datalist", {id: "columnlist"}, model.columnSuggestionList().map(data => h("option", {key: data.value, value: data.value, label: data.label})))
           ),
         ),
         h("div", {className: "conf-subsection columns-mapping"},
@@ -1359,7 +1374,7 @@ class ColumnMapper extends React.Component {
   }
   onColumnValueChange(e) {
     let {model, column} = this.props;
-    column.columnValue = e.target.value;
+    column.columnValue = model.guessColumn(e.target.value);
     model.didUpdate();
   }
   onColumnSkipClick(e) {

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -376,7 +376,7 @@ class Model {
       return undefined;
     }
     let field = sobjectDescribe.fields.find(sobjectField => sobjectField.name.toLowerCase() == columnName.toLowerCase());
-    return field && field.label != field.name ? field.label : undefined;
+    return field ? field.label : undefined;
   }
 
   importIdColumnValid() {


### PR DESCRIPTION
## Motivation

Improve the Data Import field-mapping experience when users paste or type Excel/CSV headers that use Salesforce field Labels instead of API Names.

Example:

- Excel header: `Customer Segmentation`
- Salesforce API Name: `CustSegmentation__c`

The import UI should be able to resolve the Label to the API Name while still keeping the mapping value as the API Name.

## Summary

- Trim column header input before guessing field mappings.
- Preserve existing dotted external-id mapping behavior, such as `Relationship.ExternalId`.
- Add case-insensitive field Label matching in `guessColumn()` so a pasted or fully typed Salesforce field Label maps back to the field API Name.
- Add `label` attributes to field-mapping `<option>` entries while keeping `value` as the API Name.
  - Example rendered intent:
    ```html
    <option value="CustSegmentation__c" label="Customer Segmentation"></option>
    ```
- Normalize edited mapping values through `guessColumn()` so manually entered Labels can be converted to API Names.

## Implementation Details

- Added `columnLabel(columnName)` to look up the Salesforce field Label from the current sObject describe metadata.
- Updated the field mapping datalist to render API Name options with their corresponding Label metadata.
- Updated `guessColumn()` to:
  - trim the input,
  - run existing external-id matching against the trimmed value,
  - match `field.label` case-insensitively,
  - return the API Name when a Label match is found,
  - otherwise return the trimmed input.
- Updated `ColumnMapper.onColumnValueChange()` to apply `model.guessColumn(e.target.value)` when users edit a mapping field.

## Notes

The datalist option `value` remains the API Name, so selecting a suggestion still fills the API Name into the mapping input. The `label` attribute is used only to expose the human-readable Salesforce field Label in the browser suggestion UI.

## Testing

- Ran syntax validation:
  ```bash
  node --check addon/data-import.js
<img width="1898" height="555" alt="image" src="https://github.com/user-attachments/assets/7a7ee981-422f-4215-8713-eeba2b0ef7ee" />
