### PR TITLE
feat: [Data Export] Add keyboard shortcuts to focus Filters and Inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` Add keyboard shortcuts (/ and Ctrl/Cmd+Shift+F (customizable)) to focus the search/result filter feature [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Add keyboard shortcuts (/ and Ctrl/Cmd+Shift+F) to focus the result filter [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Show All Data` Add **Refresh** button to re-fetch the latest field values and persist the filter value in the URL [feature 1201](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1201)
 - `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
+- `Data Export` Add keyboard shortcuts to focus result filter (/ and Ctrl/Cmd+Shift+F) [#1222](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1222) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1
 
-- `Accessibility` Add keyboard shortcuts (`/` or customizable `Ctrl/Cmd+Shift+F`) to focus search and filter inputs across Data Export, Data Import, Popup, Show all data, Logs Viewer, Field Creator, Download Metadata, Event Monitor, Dependencies Explorer, and REST Explorer [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+- `Accessibility` Add keyboard shortcuts (`/` or customizable `Ctrl/Cmd+Shift+F`) to focus search and filter inputs [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Disabled the Copy/Download buttons when the query output has no results [#1258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1258) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,12 @@
 
 ## Version 2.1
 
+- `Data Export` Add keyboard shortcuts (/ and Ctrl/Cmd+Shift+F) to focus the result filter [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Show All Data` Add **Refresh** button to re-fetch the latest field values and persist the filter value in the URL [feature 1201](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1201)
 - `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
-- `Data Export` Add keyboard shortcuts to focus result filter (/ and Ctrl/Cmd+Shift+F) [#1222](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1222) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1
 
-- `Data Export` Add keyboard shortcuts (/ and Ctrl/Cmd+Shift+F (customizable)) to focus the search/result filter feature [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+- `Accessibility` Add keyboard shortcuts (`/` or customizable `Ctrl/Cmd+Shift+F`) to focus search and filter inputs across Data Export, Data Import, Popup, Show all data, Logs Viewer, Field Creator, Download Metadata, Event Monitor, Dependencies Explorer, and REST Explorer [feature #811](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/811) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Disabled the Copy/Download buttons when the query output has no results [#1258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1258) (contribution by [Prem Kumar](https://github.com/prem-k-r))
@@ -27,7 +27,7 @@
 - `Data Export` Fix Column order not respected when performing subqueries [#598](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/598)
 - `Accessibility` Improve screen reader support: fix AlertBanner silent announcements, convert inspector button and tooltip trigger to semantic elements, add popup iframe title issues [#1107](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1107) & [#1108](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1108) (contribution by [akj](https://github.com/akj))
 - `Dependencies Explorer` (contribution by [Georgi Dobrishinov](https://github.com/dobrishinov))
-- `Flow Scanner` Extract Flow Scanner rules logic into shared module (fixes the Flow Scanner import flash on the Options page) contribution by [Camille Guillory](https://github.com/CamilleGuillory))
+- `Flow Scanner` Extract Flow Scanner rules logic into shared module (fixes the Flow Scanner import flash on the Options page) (contribution by [Camille Guillory](https://github.com/CamilleGuillory))
 - Introduce SObjectList cache to prevent request to Salesforce requests to be sent each time the popup opens [issue #437](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/437)
 - `Popup` Support record ID detection in Lightning Setup URLs with address parameter [feature 1099](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1099)
 - `Data Export` Fix Incorrect SOSL Query stamping when selected from Saved Queries [issue #1075](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1075) (contribution by [Divyanshu Bist](https://github.com/DivyanshuBist)
@@ -242,7 +242,7 @@
 - Add "Enable Logs" button in the User tab [feature 245](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/245) (contribution by [Antoine Leleu](https://github.com/AntoineLeleu-Salesforce))
 - Add default connected app setting and improve access token renew flow. Note: Due to the simplified redirect url, this is a BREAKING CHANGE for users who have created their own connected app: those users MUST update their connected app Callback URL to the new value before they can use this version of the extension (contribution by [Mehdi Cherfaoui](https://github.com/mehdicherf))
 - Allow users to define REST callout headers on showAllData page. The need is to prevent the auto assignation of Accounts, Cases and Leads. [feature 198](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/198) (issue by [SfdxDieter](https://github.com/SfdxDieter))
-- Fix flow scrollability] checkbox on non dev environments [issue 258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/258) (by [Samuel Krissi](https://github.com/samuelkrissi))
+- Fix flow scrollability checkbox on non dev environments [issue 258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/258) (by [Samuel Krissi](https://github.com/samuelkrissi))
 - Fix 'Record Type not displayed' in popup [issue 255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/255)
 - Add "Options" page to manage local storage variables directly from the UX. Allow to reposition the popup button [feature 145](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/145) (contribution by [Pietro Martino](https://github.com/pietromartino))
 - Bugfix Delete button does not check for 'toolingApi' parameter [issue 254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/254) (contribution by [Oscar Gomez Balaguer](https://github.com/ogomezba))

--- a/addon/background.js
+++ b/addon/background.js
@@ -64,9 +64,6 @@ chrome.action.onClicked.addListener(() => {
   });
 });
 chrome.commands?.onCommand.addListener((command) => {
-  if (!sfHost) {
-    return;
-  }
   if (command.startsWith("link-")){
     let link;
     switch (command){

--- a/addon/background.js
+++ b/addon/background.js
@@ -64,6 +64,9 @@ chrome.action.onClicked.addListener(() => {
   });
 });
 chrome.commands?.onCommand.addListener((command) => {
+  if (!sfHost) {
+    return;
+  }
   if (command.startsWith("link-")){
     let link;
     switch (command){

--- a/addon/background.js
+++ b/addon/background.js
@@ -85,6 +85,8 @@ chrome.commands?.onCommand.addListener((command) => {
     chrome.runtime.sendMessage({
       msg: "shortcut_pressed", command, sfHost
     });
+  } else if (command === "focus-search") {
+    chrome.runtime.sendMessage({ command: "focus-search" });
   } else {
     chrome.tabs.create({
       url: `chrome-extension://${chrome.i18n.getMessage("@@extension_id")}/${command}.html?host=${sfHost}`

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -16,6 +16,24 @@ function createQueryHistory(storageKey, max) {
   });
 }
 
+function isEditableElement(element) {
+  if (!element || element.nodeType !== 1) {
+    return false;
+  }
+  const tagName = element.tagName;
+  return tagName == "INPUT"
+    || tagName == "TEXTAREA"
+    || tagName == "SELECT"
+    || element.isContentEditable
+    || element.closest("[contenteditable]") != null;
+}
+
+function isVisibleElement(element) {
+  return element
+    && element.getClientRects().length > 0
+    && getComputedStyle(element).visibility != "hidden";
+}
+
 class Model {
   static QUERY_TAB_PREFIX = "Query";
 
@@ -1371,6 +1389,7 @@ class App extends React.Component {
     this.onCopyAsJson = this.onCopyAsJson.bind(this);
     this.onDeleteRecords = this.onDeleteRecords.bind(this);
     this.onResultsFilterInput = this.onResultsFilterInput.bind(this);
+    this.onFilterShortcutKeyDown = this.onFilterShortcutKeyDown.bind(this);
     this.onSetQueryName = this.onSetQueryName.bind(this);
     this.onStopExport = this.onStopExport.bind(this);
     this.state = {hideButtonsOption: JSON.parse(localStorage.getItem("hideExportButtonsOption")), isDropdownOpen: false};// Tracks whether the dropdown is open
@@ -1556,6 +1575,30 @@ class App extends React.Component {
       this.setState({isDropdownOpen: false});
     }
     model.didUpdate();
+  }
+  onFilterShortcutKeyDown(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    const filterInput = this.refs.resultsFilter;
+    if (!isVisibleElement(filterInput) || document.activeElement == filterInput) {
+      return;
+    }
+
+    const isExplicitShortcut = (e.ctrlKey || e.metaKey)
+      && e.shiftKey
+      && !e.altKey
+      && (e.key || "").toLowerCase() == "f";
+    const isSlashShortcut = e.key == "/"
+      && !e.ctrlKey
+      && !e.altKey
+      && !e.metaKey
+      && !isEditableElement(e.target);
+
+    if (isExplicitShortcut || isSlashShortcut) {
+      e.preventDefault();
+      filterInput.focus();
+    }
   }
   onSetQueryName(e) {
     let {model} = this.props;
@@ -1757,6 +1800,7 @@ class App extends React.Component {
         model.didUpdate();
       }
     });
+    addEventListener("keydown", this.onFilterShortcutKeyDown);
 
     this.scrollTable = initScrollTable(this.refs.scroller);
     model.resultTableCallback = this.scrollTable.dataChange;
@@ -1780,6 +1824,9 @@ class App extends React.Component {
     }
     addEventListener("resize", resize);
     resize();
+  }
+  componentWillUnmount() {
+    removeEventListener("keydown", this.onFilterShortcutKeyDown);
   }
   componentDidUpdate() {
     this.recalculateSize();
@@ -2079,7 +2126,9 @@ class App extends React.Component {
               model.exportedData && model.exportedData.table[0]?.length > 0 && !model.exportError ? h("div", {className: "slds-form-element"},
                 h("div", {className: "slds-form-element__control slds-input-has-icon slds-input-has-icon_left slds-m-left_small slds-button-group"},
                   h("input", {
+                    ref: "resultsFilter",
                     className: "slds-input slds-button slds-m-around_none",
+                    "aria-label": "Filter Result",
                     placeholder: model.filterColumns?.length > 0
                       ? `Filter by (${model.filterColumns.length})`
                       : "Filter",

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion} from "./inspector.js";
-import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile, StorageHistory} from "./utils.js";
+import {getLinkTarget, nullToEmptyString, isOptionEnabled, PromptTemplate, Constants, UserInfoModel, createSpinForMethod, copyToClipboard, downloadCsvFile, StorageHistory, SearchFocusManager} from "./utils.js";
 /* global initButton */
 import {Enumerable, DescribeInfo, initScrollTable, s} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
@@ -1780,6 +1780,22 @@ class App extends React.Component {
     }
     addEventListener("resize", resize);
     resize();
+
+    this.searchFocusManager = new SearchFocusManager(() => this.refs.resultsFilter);
+    this.searchFocusManager.register();
+    if (chrome.commands && chrome.commands.getAll) {
+      chrome.commands.getAll((commands) => {
+        const focusCmd = commands.find(c => c.name === "focus-search");
+        if (focusCmd && focusCmd.shortcut) {
+          this.setState({ focusShortcut: focusCmd.shortcut });
+        }
+      });
+    }
+  }
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
   componentDidUpdate() {
     this.recalculateSize();
@@ -2079,7 +2095,11 @@ class App extends React.Component {
               model.exportedData && model.exportedData.table[0]?.length > 0 && !model.exportError ? h("div", {className: "slds-form-element"},
                 h("div", {className: "slds-form-element__control slds-input-has-icon slds-input-has-icon_left slds-m-left_small slds-button-group"},
                   h("input", {
+                    ref: "resultsFilter",
                     className: "slds-input slds-button slds-m-around_none",
+                    title: this.state.focusShortcut 
+                      ? `Filter export results (/ or ${this.state.focusShortcut})` 
+                      : "Filter export results (/)",
                     placeholder: model.filterColumns?.length > 0
                       ? `Filter by (${model.filterColumns.length})`
                       : "Filter",

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -21,17 +21,17 @@ function isEditableElement(element) {
     return false;
   }
   const tagName = element.tagName;
-  return tagName == "INPUT"
-    || tagName == "TEXTAREA"
-    || tagName == "SELECT"
+  return tagName === "INPUT"
+    || tagName === "TEXTAREA"
+    || tagName === "SELECT"
     || element.isContentEditable
-    || element.closest("[contenteditable]") != null;
+    || element.closest("[contenteditable]") !== null;
 }
 
 function isVisibleElement(element) {
   return element
     && element.getClientRects().length > 0
-    && getComputedStyle(element).visibility != "hidden";
+    && getComputedStyle(element).visibility !== "hidden";
 }
 
 class Model {
@@ -1581,15 +1581,15 @@ class App extends React.Component {
       return;
     }
     const filterInput = this.refs.resultsFilter;
-    if (!isVisibleElement(filterInput) || document.activeElement == filterInput) {
+    if (!isVisibleElement(filterInput) || document.activeElement === filterInput) {
       return;
     }
 
     const isExplicitShortcut = (e.ctrlKey || e.metaKey)
       && e.shiftKey
       && !e.altKey
-      && (e.key || "").toLowerCase() == "f";
-    const isSlashShortcut = e.key == "/"
+      && (e.key || "").toLowerCase() === "f";
+    const isSlashShortcut = e.key === "/"
       && !e.ctrlKey
       && !e.altKey
       && !e.metaKey
@@ -1842,6 +1842,11 @@ class App extends React.Component {
   render() {
     let {model} = this.props;
     const perf = model.perfStatus();
+
+    const isMac = navigator.userAgentData?.platform === "macOS" || /Mac/.test(navigator.platform);
+    const filterShortcutTitle = isMac
+      ? "Filter export results (/ or ⌘⇧F)"
+      : "Filter export results (/ or Ctrl+Shift+F)";
 
     // Define utility items for this page (injected as "slots")
     const utilityItems = [
@@ -2129,6 +2134,7 @@ class App extends React.Component {
                     ref: "resultsFilter",
                     className: "slds-input slds-button slds-m-around_none",
                     "aria-label": "Filter Result",
+                    title: filterShortcutTitle,
                     placeholder: model.filterColumns?.length > 0
                       ? `Filter by (${model.filterColumns.length})`
                       : "Filter",

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -4,7 +4,7 @@ import {sfConn, apiVersion} from "./inspector.js";
 import {csvParse} from "./csv-parse.js";
 import {DescribeInfo, initScrollTable} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, copyToClipboard, getSobjectsList, Constants, applyProductionStyling} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, copyToClipboard, getSobjectsList, Constants, applyProductionStyling, SearchFocusManager} from "./utils.js";
 
 const allApis = [
   {value: "Enterprise", label: "Enterprise (default)"},
@@ -1135,9 +1135,17 @@ class App extends React.Component {
     this.scrollTable = initScrollTable(this.refs.scroller);
     model.resultTableCallback = this.scrollTable.dataChange;
     model.updateImportTableResult();
+
+    this.searchFocusManager = new SearchFocusManager(() => {
+      return document.getElementById("form-search-object");
+    });
+    this.searchFocusManager.register();
   }
   componentWillUnmount() {
     window.removeEventListener(Constants.SOBJECTS_LIST_REFRESHED_EVENT, this.onSobjectsListRefreshed);
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
   componentDidUpdate() {
     let {model} = this.props;

--- a/addon/debug-log.js
+++ b/addon/debug-log.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM initButton */
 import {sfConn, apiVersion} from "./inspector.js";
-import {UserInfoModel, createSpinForMethod, PromptTemplate, Constants, isOptionEnabled} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, PromptTemplate, Constants, isOptionEnabled, SearchFocusManager, isVisibleElement} from "./utils.js";
 import {PageHeader} from "./components/PageHeader.js";
 import ConfirmModal from "./components/ConfirmModal.js";
 import AgentforceModal from "./components/AgentforceModal.js";
@@ -1984,6 +1984,22 @@ class App extends React.Component {
 
   componentDidMount() {
     this.model.init();
+
+    // Prioritize the preview modal search, fallback to the main logs search
+    this.searchFocusManager = new SearchFocusManager(() => {
+      const inputs = [
+        document.querySelector('.sfir-preview-search-input'),
+        document.querySelector('input[placeholder="Search in logs..."]')
+      ];
+      return inputs.find(isVisibleElement);
+    });
+    this.searchFocusManager.register();
+  }
+
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
 
   render() {

--- a/addon/dependencies-explorer.js
+++ b/addon/dependencies-explorer.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion} from "./inspector.js";
-import {UserInfoModel, createSpinForMethod, isRecordId, generatePackageXml} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, isRecordId, generatePackageXml, SearchFocusManager} from "./utils.js";
 import {PageHeader} from "./components/PageHeader.js";
 /* global initButton */
 
@@ -1845,6 +1845,17 @@ ${(() => {
 }
 
 class App extends React.Component {
+  componentDidMount() {
+    this.searchFocusManager = new SearchFocusManager(() => {
+      return document.getElementById("depDropdownSearch");
+    });
+    this.searchFocusManager.register();
+  }
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
+  }
 
   render() {
     let {model} = this.props;
@@ -2440,6 +2451,7 @@ class App extends React.Component {
                   className: "dep-dropdown-search"
                 },
                 h("input", {
+                  id: "depDropdownSearch",
                   type: "text",
                   placeholder: "Search...",
                   value: model._dropdownSearch,

--- a/addon/event-monitor.js
+++ b/addon/event-monitor.js
@@ -1,5 +1,5 @@
 /* global React ReactDOM */
-import {getLinkTarget, UserInfoModel, getBrowserType, createSpinForMethod, copyToClipboard, applyProductionStyling, StorageHistory, SearchFocusManager, isVisibleElement} from "./utils.js";
+import {getLinkTarget, UserInfoModel, getBrowserType, createSpinForMethod, copyToClipboard, applyProductionStyling, StorageHistory, SearchFocusManager} from "./utils.js";
 import {sfConn, apiVersion} from "./inspector.js";
 // Import the CometD library
 import {CometD} from "./lib/cometd/cometd.js";

--- a/addon/event-monitor.js
+++ b/addon/event-monitor.js
@@ -1,5 +1,5 @@
 /* global React ReactDOM */
-import {getLinkTarget, UserInfoModel, getBrowserType, createSpinForMethod, copyToClipboard, applyProductionStyling, StorageHistory} from "./utils.js";
+import {getLinkTarget, UserInfoModel, getBrowserType, createSpinForMethod, copyToClipboard, applyProductionStyling, StorageHistory, SearchFocusManager, isVisibleElement} from "./utils.js";
 import {sfConn, apiVersion} from "./inspector.js";
 // Import the CometD library
 import {CometD} from "./lib/cometd/cometd.js";
@@ -281,6 +281,18 @@ class App extends React.Component {
     this.disableGenerate = this.disableGenerate.bind(this);
     this.getEventChannels();
     this.state = {peLimits: []};
+  }
+
+  componentDidMount() {
+    this.searchFocusManager = new SearchFocusManager(() => {
+      return this.refs.eventFilter;
+    });
+    this.searchFocusManager.register();
+  }
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
 
   async retrievePlatformEvent(channelType, sfHost){

--- a/addon/field-creator.js
+++ b/addon/field-creator.js
@@ -1,7 +1,7 @@
 /* global React ReactDOM field-creator.js */
 import {sfConn, apiVersion} from "./inspector.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, getSobjectsList, Constants, applyProductionStyling} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, getSobjectsList, Constants, applyProductionStyling, SearchFocusManager, isVisibleElement} from "./utils.js";
 
 let h = React.createElement;
 
@@ -237,6 +237,7 @@ class ProfilesModal extends React.Component {
         ),
         h("div", {className: "modal-body overflowYAuto flexGrow1 marginRight-10 paddingRight10 scrollbarThin scrollbarColorBlue"},
           h("input", {
+            id: "permission_search",
             type: "text",
             placeholder: "Search profiles and permission sets...",
             value: this.state.searchTerm,
@@ -1006,10 +1007,23 @@ class App extends React.Component {
       }
     };
     window.addEventListener(Constants.SOBJECTS_LIST_REFRESHED_EVENT, this.onSobjectsListRefreshed);
+
+    // Target the specific IDs, prioritizing the modal if it's visible
+    this.searchFocusManager = new SearchFocusManager(() => {
+      const inputs = [
+        document.getElementById('permission_search'),
+        document.getElementById('object_select')
+      ];
+      return inputs.find(isVisibleElement);
+    });
+    this.searchFocusManager.register();
   }
 
   componentWillUnmount() {
     window.removeEventListener(Constants.SOBJECTS_LIST_REFRESHED_EVENT, this.onSobjectsListRefreshed);
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
 
   handleObjectSearch = (e) => {

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -4,7 +4,7 @@ import {copyToClipboard, downloadCsvFile, applyProductionStyling} from "./utils.
 /* global initButton */
 import {getObjectSetupLinks, getFieldSetupLinks} from "./setup-links.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, PromptTemplate, Constants} from "./utils.js";
+import {UserInfoModel, PromptTemplate, Constants, SearchFocusManager, isVisibleElement} from "./utils.js";
 import AgentforceModal from "./components/AgentforceModal.js";
 
 // Constants
@@ -1667,6 +1667,21 @@ class App extends React.Component {
   }
   componentDidMount() {
     this.refs.rowsFilter.focus();
+
+    // Target the specific IDs, prioritizing the modal if it's visible
+    this.searchFocusManager = new SearchFocusManager(() => {
+      const inputs = [
+        document.getElementById('detailsFilter'),
+        document.getElementById('rowsFilter')
+      ];
+      return inputs.find(isVisibleElement);
+    });
+    this.searchFocusManager.register();
+  }
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
   onUseAllTab(e) {
     let {model} = this.props;
@@ -1867,7 +1882,7 @@ class App extends React.Component {
           h("svg", {className: "slds-icon slds-input__icon slds-input__icon_left slds-icon-text-default", style: {top: "40%"}},
             h("use", {xlinkHref: "symbols.svg#search"})
           ),
-          h("input", {className: "slds-input", placeholder: "Filter", value: model.rowsFilter, onChange: this.onRowsFilterInput, ref: "rowsFilter"}),
+          h("input", {id: "rowsFilter", className: "slds-input", placeholder: "Filter", value: model.rowsFilter, onChange: this.onRowsFilterInput, ref: "rowsFilter"}),
           h("a", {href: "about:blank", className: "sfir-filter-clear", onClick: this.onClearAndFocusFilter},
             h("svg", {className: "sfir-filter-clear-icon"},
               h("use", {xlinkHref: "symbols.svg#clear"})
@@ -2642,7 +2657,7 @@ class DetailsBox extends React.Component {
             className: "slds-modal__title slds-hyphenate",
             tabIndex: -1
           }, "All available metadata for \"" + model.detailsBox.name + "\""),
-          h("input", {className: "slds-input slds-m-top_small", placeholder: "Filter", value: model.detailsFilter, onChange: this.onDetailsFilterInput, ref: "detailsFilter"}),
+          h("input", {id: "detailsFilter", className: "slds-input slds-m-top_small", placeholder: "Filter", value: model.detailsFilter, onChange: this.onDetailsFilterInput, ref: "detailsFilter"}),
         ),
         h("div", {className: "slds-modal__content slds-p-around_medium", id: "modal-content-id-1"},
           h("table", {className: "slds-table slds-table_cell-buffer"},

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -175,6 +175,13 @@
     },
     "api-statistics": {
       "description": "API Statistics"
+    },
+    "focus-search": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F",
+        "mac": "Command+Shift+F"
+      },
+      "description": "Focus Search/Filter Input"
     }
   }
 }

--- a/addon/metadata-retrieve.js
+++ b/addon/metadata-retrieve.js
@@ -1,7 +1,7 @@
 import {sfConn, apiVersion, XML} from "./inspector.js";
 import Toast from "./components/Toast.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, copyToClipboard, generatePackageXml, SearchFocusManager, isVisibleElement} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, copyToClipboard, generatePackageXml, SearchFocusManager} from "./utils.js";
 import ConfirmModal from "./components/ConfirmModal.js";
 import {Spinner} from "./components/Spinner.js";
 

--- a/addon/metadata-retrieve.js
+++ b/addon/metadata-retrieve.js
@@ -1,7 +1,7 @@
 import {sfConn, apiVersion, XML} from "./inspector.js";
 import Toast from "./components/Toast.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, copyToClipboard, generatePackageXml} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, copyToClipboard, generatePackageXml, SearchFocusManager, isVisibleElement} from "./utils.js";
 import ConfirmModal from "./components/ConfirmModal.js";
 import {Spinner} from "./components/Spinner.js";
 
@@ -560,11 +560,19 @@ class App extends React.Component {
     if (packageXml) {
       packageXml.addEventListener("paste", this.onPastePackage);
     }
+
+    this.searchFocusManager = new SearchFocusManager(() => {
+      return this.refs.metadataFilter;
+    });
+    this.searchFocusManager.register();
   }
   componentWillUnmount() {
     const packageXml = document.getElementById("packageXml");
     if (packageXml) {
       packageXml.removeEventListener("paste", this.onPastePackage);
+    }
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
     }
   }
   componentDidUpdate(){

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion, sessionError} from "./inspector.js";
-import {getLinkTarget, isOptionEnabled, isSettingEnabled, getLatestApiVersionFromOrg, setOrgInfo, getPKCEParameters, getBrowserType, getExtensionId, getClientId, getRedirectUri, Constants, copyToClipboard, DataCache, getFlowCompareUrl, isRecordId, getSobjectsList} from "./utils.js";
+import {getLinkTarget, isOptionEnabled, isSettingEnabled, getLatestApiVersionFromOrg, setOrgInfo, getPKCEParameters, getBrowserType, getExtensionId, getClientId, getRedirectUri, Constants, copyToClipboard, DataCache, getFlowCompareUrl, isRecordId, getSobjectsList, SearchFocusManager, isVisibleElement} from "./utils.js";
 import {setupLinks} from "./links.js";
 import AlertBanner from "./components/AlertBanner.js";
 
@@ -327,10 +327,20 @@ class App extends React.PureComponent {
     addEventListener("keydown", this.onShortcutKey);
     parent.postMessage({insextLoaded: true}, "*");
     setOrgInfo(this.props.sfHost);
+
+    // Finds all search inputs in the popup and returns the currently visible one
+    this.searchFocusManager = new SearchFocusManager(() => {
+      const inputs = Array.from(document.querySelectorAll('.input-with-dropdown input'));
+      return inputs.find(isVisibleElement);
+    });
+    this.searchFocusManager.register();
   }
   componentWillUnmount() {
     removeEventListener("message", this.onContextUrlMessage);
     removeEventListener("keydown", this.onShortcutKey);
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
   isMac() {
     return navigator.userAgentData?.platform.toLowerCase().indexOf("mac") > -1 || navigator.userAgent.toLowerCase().indexOf("mac") > -1;

--- a/addon/rest-explore.js
+++ b/addon/rest-explore.js
@@ -3,7 +3,7 @@ import {sfConn, apiVersion} from "./inspector.js";
 /* global initButton */
 import {initScrollTable} from "./data-load.js";
 import {PageHeader} from "./components/PageHeader.js";
-import {UserInfoModel, createSpinForMethod, copyToClipboard, isOptionEnabled, StorageHistory} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, copyToClipboard, isOptionEnabled, StorageHistory, SearchFocusManager} from "./utils.js";
 
 function createRestQueryHistory(storageKey, max) {
   const isSaved = storageKey === "restSavedQueryHistory";
@@ -560,6 +560,11 @@ class App extends React.Component {
       }
     });
 
+    this.searchFocusManager = new SearchFocusManager(() => {
+      return this.refs.endpoint;
+    });
+    this.searchFocusManager.register();
+
     this.scrollTable = initScrollTable(this.refs.scroller);
     model.resultTableCallback = this.scrollTable.dataChange;
 
@@ -582,6 +587,11 @@ class App extends React.Component {
     }
     addEventListener("resize", resize);
     resize();
+  }
+  componentWillUnmount() {
+    if (this.searchFocusManager) {
+      this.searchFocusManager.unregister();
+    }
   }
   componentDidUpdate() {
     this.recalculateSize();

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1369,9 +1369,8 @@ export function formatDuration(minutes) {
 /**
  * Reusable "Focus Search" Shortcut System
  * 
- * Provides a centralized manager to handle both page-level keyboard shortcuts (e.g., "/") 
- * and global Chrome extension commands (e.g., "Ctrl+Shift+F") to automatically focus 
- * a specific search or filter input field. 
+ * Provides a centralized manager to handle both page-level keyboard shortcut (i.e., "/") and global Chrome
+ * extension commands (e.g., "Ctrl+Shift+F") to automatically focus a specific search or filter input field. 
  * 
  * - isEditableElement: Prevents shortcuts from triggering while the user is actively typing in a form field.
  * - isVisibleElement: Ensures the target input is actually visible on the screen before attempting to focus it.

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1377,21 +1377,14 @@ export function formatDuration(minutes) {
  * - SearchFocusManager: The core class that registers event listeners and executes the focus logic.
  */
 export function isEditableElement(element) {
-  if (!element || element.nodeType !== 1) {
-    return false;
-  }
+  if (!element || element.nodeType !== 1) return false;
   const tagName = element.tagName;
-  return tagName === "INPUT"
-    || tagName === "TEXTAREA"
-    || tagName === "SELECT"
-    || element.isContentEditable
-    || element.closest("[contenteditable]") !== null;
+  return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || 
+         element.isContentEditable || element.closest("[contenteditable]") !== null;
 }
 
 export function isVisibleElement(element) {
-  return element
-    && element.getClientRects().length > 0
-    && getComputedStyle(element).visibility !== "hidden";
+  return element && element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden";
 }
 
 export class SearchFocusManager {
@@ -1400,44 +1393,27 @@ export class SearchFocusManager {
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onMessage = this.onMessage.bind(this);
   }
-
   register() {
     window.addEventListener("keydown", this.onKeyDown);
     chrome.runtime.onMessage.addListener(this.onMessage);
   }
-
   unregister() {
     window.removeEventListener("keydown", this.onKeyDown);
     chrome.runtime.onMessage.removeListener(this.onMessage);
   }
-
   focusInput() {
     const input = this.inputElementProvider();
-    if (input && isVisibleElement(input) && document.activeElement !== input) {
-      input.focus();
-    }
+    if (input && isVisibleElement(input) && document.activeElement !== input) input.focus();
   }
-
   onKeyDown(e) {
-    if (e.defaultPrevented) {
-      return;
-    }
-    
-    const isSlashShortcut = e.key === "/"
-      && !e.ctrlKey
-      && !e.altKey
-      && !e.metaKey
-      && !isEditableElement(e.target);
-
+    if (e.defaultPrevented) return;
+    const isSlashShortcut = e.key === "/" && !e.ctrlKey && !e.altKey && !e.metaKey && !isEditableElement(e.target);
     if (isSlashShortcut) {
       e.preventDefault();
       this.focusInput();
     }
   }
-
   onMessage(request) {
-    if (request && request.command === "focus-search") {
-      this.focusInput();
-    }
+    if (request?.command === "focus-search") this.focusInput();
   }
 }

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1365,3 +1365,80 @@ export function formatDuration(minutes) {
 
   return parts.length > 0 ? parts.join(" ") : "Less than a minute";
 }
+
+/**
+ * Reusable "Focus Search" Shortcut System
+ * 
+ * Provides a centralized manager to handle both page-level keyboard shortcuts (e.g., "/") 
+ * and global Chrome extension commands (e.g., "Ctrl+Shift+F") to automatically focus 
+ * a specific search or filter input field. 
+ * 
+ * - isEditableElement: Prevents shortcuts from triggering while the user is actively typing in a form field.
+ * - isVisibleElement: Ensures the target input is actually visible on the screen before attempting to focus it.
+ * - SearchFocusManager: The core class that registers event listeners and executes the focus logic.
+ */
+export function isEditableElement(element) {
+  if (!element || element.nodeType !== 1) {
+    return false;
+  }
+  const tagName = element.tagName;
+  return tagName === "INPUT"
+    || tagName === "TEXTAREA"
+    || tagName === "SELECT"
+    || element.isContentEditable
+    || element.closest("[contenteditable]") !== null;
+}
+
+export function isVisibleElement(element) {
+  return element
+    && element.getClientRects().length > 0
+    && getComputedStyle(element).visibility !== "hidden";
+}
+
+export class SearchFocusManager {
+  constructor(inputElementProvider) {
+    this.inputElementProvider = inputElementProvider;
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onMessage = this.onMessage.bind(this);
+  }
+
+  register() {
+    window.addEventListener("keydown", this.onKeyDown);
+    chrome.runtime.onMessage.addListener(this.onMessage);
+  }
+
+  unregister() {
+    window.removeEventListener("keydown", this.onKeyDown);
+    chrome.runtime.onMessage.removeListener(this.onMessage);
+  }
+
+  focusInput() {
+    const input = this.inputElementProvider();
+    if (input && isVisibleElement(input) && document.activeElement !== input) {
+      input.focus();
+    }
+  }
+
+  onKeyDown(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    
+    const isSlashShortcut = e.key === "/"
+      && !e.ctrlKey
+      && !e.altKey
+      && !e.metaKey
+      && !isEditableElement(e.target);
+
+    if (isSlashShortcut) {
+      e.preventDefault();
+      this.focusInput();
+    }
+  }
+
+  onMessage(request) {
+    if (request && request.command === "focus-search") {
+      this.focusInput();
+    }
+  }
+}


### PR DESCRIPTION
# Describe your changes
Adds `/` and `Ctrl`/`Cmd`+`Shift`+`F` shortcuts on the Data Export page to focus the Filter Result input

## Issue ticket number and link
Closes #811

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
