### PR TITLE
fix: [Shortcuts] Resolve broken setup links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Shortcuts` Fixed broken links for some Setup shortcuts [#1223](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1223) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)

--- a/addon/links.js
+++ b/addon/links.js
@@ -112,7 +112,7 @@ export let setupLinks = [
   {label: "Einstein Conversation Insights Assessor", link: "/lightning/setup/EinsteinCIReadinessCheck/home", section: "Platform Tools > Einstein > Einstein Assessors", prod: false},
   {label: "Revenue Intelligence Assessor", link: "/lightning/setup/EinsteinRevIntlReadinessCheck/home", section: "Platform Tools > Einstein > Einstein Assessors", prod: false},
   {label: "Sales Cloud Einstein Assessor", link: "/lightning/setup/SalesCloudEinsteinReadinessCheck/home", section: "Platform Tools > Einstein > Einstein Assessors", prod: false},
-  {label: "Service Cloud Einstein Assessor", link: "lightning/setup/ServiceCloudEinsteinReadinessCheck/home", section: "Platform Tools > Einstein > Einstein Assessors", prod: false},
+  {label: "Service Cloud Einstein Assessor", link: "/lightning/setup/ServiceCloudEinsteinReadinessCheck/home", section: "Platform Tools > Einstein > Einstein Assessors", prod: false},
   //Platform Tools > Einstein > Einstein Generative AI
   {label: "Agentforce Analytics", link: "/lightning/setup/AgentAnalyticsLibrary/home", section: "Platform Tools > Einstein > Einstein Generative AI > Agentforce Studio", prod: false},
   {label: "Agentforce Agents", link: "/lightning/setup/EinsteinCopilot/home", section: "Platform Tools > Einstein > Einstein Generative AI > Agentforce Studio", prod: false},
@@ -175,7 +175,7 @@ export let setupLinks = [
   //Platform Tools > Feature Settings > Service > Field Service
   {label: "Field Service Settings", link: "/lightning/setup/FieldServiceSettings/home", section: "Platform Tools > Feature Settings > Service > Field Service", prod: false},
   {label: "Field Service Mobile App Builder", link: "/lightning/setup/FieldServiceAppBuilder/home", section: "Platform Tools > Feature Settings > Service > Field Service", prod: false},
-  {label: "Inbound Social Post Errors", link: "/lightning/setup/InboundSocialPostErrors/homee", section: "Platform Tools > Feature Settings > Service > Field Service", prod: false},
+  {label: "Inbound Social Post Errors", link: "/lightning/setup/InboundSocialPostErrors/home", section: "Platform Tools > Feature Settings > Service > Field Service", prod: false},
 
   //Platform Tools > Feature Settings > Service > Knowledge
   {label: "Data Category Assignments", link: "/lightning/setup/KnowledgeDataCategorySetup/home", section: "Platform Tools > Feature Settings > Service > Knowledge", prod: false},
@@ -389,7 +389,7 @@ export let setupLinks = [
   {label: "Network Access", link: "/lightning/setup/NetworkAccess/home", section: "Settings > Security", prod: false},
   {label: "Password Policies", link: "/lightning/setup/SecurityPolicies/home", section: "Settings > Security", prod: false},
   //Settings > Security > Platform Encryption
-  {label: "Advanced Settings", link: "/lightning/setup/SecurityRemoteProxy/home", section: "Settings > Security > Platform Encryption", prod: false},
+  {label: "Encryption Settings", link: "/lightning/setup/EncryptionAdvancedSettings/home", section: "Settings > Security > Platform Encryption", prod: false},
   {label: "Encryption Policy", link: "/lightning/setup/EncryptionPolicy/home", section: "Settings > Security > Platform Encryption", prod: false},
   {label: "Encryption Statistics", link: "/lightning/setup/EncryptionStatistics/home", section: "Settings > Security > Platform Encryption", prod: false},
   {label: "Key Management", link: "/lightning/setup/PlatformEncryptionKeyManagement/home", section: "Settings > Security > Platform Encryption", prod: false},


### PR DESCRIPTION
Fix three issues in setup links:
1. Add missing leading slash in Service Cloud Einstein Assessor link
2. Fix typo in Inbound Social Post Errors URL (homee → home)
3. Update Encryption Settings link label and URL