### PR TITLE
feat: [data-import] Prompt when pasted data contains previous import results

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
+- `Data Import` Prompt to start new or continue previous import when pasted data contains previous results #1226 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -52,6 +52,7 @@ class Model {
     this.activeBatches = 0;
     this.isProcessingQueue = false;
     this.importState = null;
+    this.previousImportDetected = false;
     this.greyOutSkippedColumns = localStorage.getItem("greyOutSkippedColumns") === "true";
     this.showStatus = {
       Queued: true,
@@ -205,6 +206,7 @@ class Model {
     }
     this.refreshColumn();
     this.updateResult(this.importData.importTable);
+    this.previousImportDetected = this.hasCompletedImportResults(header, data);
   }
 
   getDataFromJson(json) {
@@ -600,6 +602,36 @@ class Model {
     this.executeBatch();
   }
 
+  hasCompletedImportResults(header, data) {
+    let statusColumnIndex = header.findIndex(c => c.columnValue.toLowerCase() == "__status");
+    if (statusColumnIndex == -1) {
+      return false;
+    }
+    return data.some(row => {
+      let status = (row[statusColumnIndex] || "").toLowerCase();
+      return status == "succeeded" || status == "failed";
+    });
+  }
+
+  resetPreviousImportStatuses() {
+    if (!this.importData.importTable) {
+      return;
+    }
+    let {header, data} = this.importData.importTable;
+    let statusColumnIndex = header.findIndex(c => c.columnValue.toLowerCase() == "__status");
+    if (statusColumnIndex > -1) {
+      for (let row of data) {
+        row[statusColumnIndex] = "";
+      }
+    }
+    this.previousImportDetected = false;
+    this.updateResult(this.importData.importTable);
+  }
+
+  continuePreviousImport() {
+    this.previousImportDetected = false;
+  }
+
   updateResult(importTable) {
     let counts = {Queued: 0, Processing: 0, Succeeded: 0, Failed: 0};
     if (!importTable) {
@@ -974,6 +1006,8 @@ class App extends React.Component {
     this.onSkipAllUnknownFieldsClick = this.onSkipAllUnknownFieldsClick.bind(this);
     this.onConfirmPopupYesClick = this.onConfirmPopupYesClick.bind(this);
     this.onConfirmPopupNoClick = this.onConfirmPopupNoClick.bind(this);
+    this.onStartNewImportClick = this.onStartNewImportClick.bind(this);
+    this.onContinuePreviousImportClick = this.onContinuePreviousImportClick.bind(this);
     this.unloadListener = null;
     this.state = {templateValueIndex: -1};
   }
@@ -1104,6 +1138,18 @@ class App extends React.Component {
     e.preventDefault();
     let {model} = this.props;
     model.confirmPopupNo();
+    model.didUpdate();
+  }
+  onStartNewImportClick(e) {
+    e.preventDefault();
+    let {model} = this.props;
+    model.resetPreviousImportStatuses();
+    model.didUpdate();
+  }
+  onContinuePreviousImportClick(e) {
+    e.preventDefault();
+    let {model} = this.props;
+    model.continuePreviousImport();
     model.didUpdate();
   }
   onImportUndelete(model){
@@ -1322,7 +1368,7 @@ class App extends React.Component {
         h("div", {className: "slds-card slds-m-horizontal_medium slds-p-around_small"},
           h("div", {className: "slds-grid slds-grid_align-spread slds-grid_vertical-align-center"},
             h("div", {className: "slds-col"},
-              h("button", {onClick: this.onDoImportClick, disabled: model.invalidInput() || model.isWorking() || model.importCounts().Queued == 0, className: "slds-button slds-button_brand"}, "Run " + model.importActionName),
+              h("button", {onClick: this.onDoImportClick, disabled: model.invalidInput() || model.isWorking() || model.previousImportDetected || model.importCounts().Queued == 0, className: "slds-button slds-button_brand"}, "Run " + model.importActionName),
               h("button", {disabled: !model.isWorking(), onClick: this.onToggleProcessingClick, className: model.isWorking() && !model.isProcessingQueue ? "slds-button slds-button_neutral" : "slds-button slds-button_neutral"}, model.isWorking() && !model.isProcessingQueue ? "Resume Queued" : "Cancel Queued"),
               h("button", {disabled: !model.importCounts().Failed > 0, onClick: this.onRetryFailedClick, className: "slds-button slds-button_neutral"}, "Retry Failed"),
               h("div", {className: "slds-button-group"},
@@ -1355,7 +1401,7 @@ class App extends React.Component {
                   h("li", {}, "Number, date, time and checkbox values must conform to the relevant ",
                     h("a", {href: "http://www.w3.org/TR/xmlschema-2/#built-in-primitive-datatypes", target: "_blank"}, "XSD datatypes"), "."),
                   h("li", {}, "Columns starting with an underscore are ignored."),
-                  h("li", {}, "You can resume a previous import by including the \"__Status\" column in your input."),
+                  h("li", {}, "If your input includes a \"__Status\" column with completed results (e.g. copied from a previous import), you'll be asked whether to start a new import or continue the previous one."),
                   h("li", {}, "You can supply the other import options by clicking \"Copy options\" and pasting the options into Excel in the top left cell, just above the header row.")
                 )
               ),
@@ -1445,8 +1491,64 @@ class App extends React.Component {
             ),
             h("div", {className: "slds-backdrop slds-backdrop_open", role: "presentation"}))
           : null
-        )
-      ));
+        ),
+        model.previousImportDetected ? h("div", {},
+          h("section",
+            {
+              role: "dialog",
+              tabIndex: -1,
+              className: "slds-modal slds-fade-in-open slds-modal_small"
+            },
+            h("div", {className: "slds-modal__container"},
+              h(
+                "button",
+                {className: "slds-button slds-button_icon slds-modal__close", onClick: this.onStartNewImportClick},
+                h(
+                  "svg",
+                  {className: "slds-button__icon slds-button__icon_large", "aria-hidden": "true"},
+                  h("use", {xlinkHref: "symbols.svg#close"})
+                ),
+                h("span", {className: "slds-assistive-text"}, "Cancel and close")
+              ),
+              h(
+                "div",
+                {className: "slds-modal__content slds-p-around_medium slds-modal__content_headless slds-text-align_center", id: "modal-content-id-2"},
+                h("div", {className: "slds-notify_container slds-is-relative"},
+                  h("div", {className: "slds-notify slds-notify_toast slds-theme_info", role: "status"},
+                    h("span", {className: "slds-assistive-text"}, "info"),
+                    h("span", {className: "slds-icon_container slds-icon-utility-info slds-m-right_small slds-no-flex slds-align-top"},
+                      h("svg", {className: "slds-icon slds-icon_small", "aria-hidden": "true"},
+                        h("use", {xlinkHref: "/symbols.svg#info"})
+                      )
+                    ),
+                    h("div", {className: "slds-notify__content slds-text-align_center"},
+                      h("h2", {className: "slds-text-heading_small"}, "This data contains previous import results.")
+                    )
+                  )
+                ),
+                h("br", {}),
+                h("p", {className: "slds-text-heading_medium slds-p-horizontal_x-large slds-p-bottom_small", style: {fontSize: "1.15rem"}}, "Some rows already have a \"__Status\" of Succeeded or Failed. Start a new import to make every row eligible again, or continue processing where the previous run left off."),
+              ),
+              h(
+                "div",
+                {className: "slds-modal__footer"},
+                h(
+                  "button",
+                  {className: "slds-button slds-button_neutral", "aria-label": "Start New Import", onClick: this.onStartNewImportClick},
+                  "Start New Import"
+                ),
+                h(
+                  "button",
+                  {className: "slds-button slds-button_brand", onClick: this.onContinuePreviousImportClick},
+                  "Continue Previous Import"
+                )
+              )
+            ),
+          ),
+          h("div", {className: "slds-backdrop slds-backdrop_open", role: "presentation"}))
+        : null
+      )
+    );
   }
 }
 


### PR DESCRIPTION
## Describe your changes

### Issue
Currently, when a user pastes data that contains previous import result columns
(such as "__Status", "__Id", "__Action", and "__Errors"), the import treats it
as a continuation of the previous session.

For example:
1. Import data into a UAT org.
2. All rows become "Succeeded".
3. Copy the import results.
4. Open the Data Import page in a Production org.
5. Paste the copied data.

Since every row already has "__Status = Succeeded", there are no queued
records, so the Run button remains disabled. The user cannot start a new
import unless they manually clear or edit the status column.

This is a common workflow when promoting the same dataset between
environments. In these cases, users expect pasting data to start a new
import session, not continue the previous one — while still preserving the
existing behavior for users who intentionally paste previous results to
resume an interrupted import.

### Approach
When pasted data contains a "__Status" column with completed statuses
(Succeeded/Failed), the user is now prompted before the import state updates:

> "This data contains previous import results."
> - **Start New Import** — resets row statuses so all records become eligible
>   again. Existing result columns ("__Id", "__Action", "__Errors") are kept
>   for reference only (display columns, not read by the import logic).
> - **Continue Previous Import** — preserves existing statuses, unchanged from
>   current behavior, so interrupted imports or remaining queued/failed
>   records can still be resumed.

Detection only runs once, right after a paste/load (`setData`), not inside
`updateResult`, so it won't fire mid-import as batches produce their own
Succeeded/Failed rows.

### Screenshots
<img width="1895" height="941" alt="image" src="https://github.com/user-attachments/assets/78824f1a-598d-46e4-9290-60a561f4e4c6" />

<img width="1519" height="535" alt="image" src="https://github.com/user-attachments/assets/09b4c37f-cf12-4c63-8e3e-ff88f694e0de" />


### Use cases
- Importing data between any two Salesforce orgs.
- Testing in one org and then importing the same file into another.
- Re-running the same dataset after fixing validation rules, permissions, or
  automation.
- Reusing a previously exported import result for scheduled or repeated
  imports.

## Issue ticket number and link
Closes #1357


## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
