### PR TITLE
fix [Popup]: Search icon spacing on Objects/Shortcuts/Users tabs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
+- `Popup` Fix search icon spacing on Objects/Shortcuts/Users tabs #1227 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,12 @@
 
 ## Version 2.1
 
+- `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Show All Data` Add **Refresh** button to re-fetch the latest field values and persist the filter value in the URL [feature 1201](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1201)
 - `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
-- `Popup` Fix search icon spacing on Objects/Shortcuts/Users tabs #1227 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/addon/popup.css
+++ b/addon/popup.css
@@ -170,7 +170,7 @@ input.api-input {
 
 .input-with-dropdown:not(.sfir-has-right-icon) .slds-input__icon_left {
   left: auto;
-  right: var(--sfir-spacing-md);
+  right: var(--sfir-spacing-sm);
   top: 50%;
   margin-top: -0.375rem;
 }
@@ -181,6 +181,13 @@ input.api-input {
   width: var(--sfir-font-sm);
   height: var(--sfir-font-sm);
   fill: var(--sfir-text-secondary);
+}
+
+.input-with-dropdown.sfir-has-right-icon .slds-input__icon_left {
+  left: var(--sfir-spacing-sm);
+  right: auto;
+  top: 50%;
+  margin-top: -0.375rem;
 }
 
 .input-with-dropdown .sfir-search-spinner {
@@ -194,13 +201,32 @@ input.api-input {
 }
 
 .input-with-dropdown:not(.sfir-has-right-icon) .sfir-search-spinner {
-  right: var(--sfir-spacing-md);
+  right: var(--sfir-spacing-sm);
   left: auto;
 }
 
 .input-with-dropdown.sfir-has-right-icon .sfir-search-spinner {
-  left: var(--sfir-spacing-md);
+  left: var(--sfir-spacing-sm);
   right: auto;
+}
+
+.input-with-dropdown.sfir-has-right-icon .slds-input__icon_right.sfir-input-right-icon {
+  position: absolute;
+  top: 50%;
+  transform: none;
+  margin-top: -0.375rem;
+  right: var(--sfir-spacing-sm);
+  left: auto;
+}
+
+.input-with-dropdown:not(.sfir-has-right-icon) input {
+  padding-left: 0.75rem;
+  padding-right: 1.75rem;
+}
+
+.input-with-dropdown.sfir-has-right-icon input {
+  padding-left: 1.75rem;
+  padding-right: 1.75rem;
 }
 
 .input-with-dropdown .sfir-search-spinner .slds-spinner {

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4600,8 +4600,8 @@ class AllDataSearch extends React.PureComponent {
       "div",
       {
         className:
-          "input-with-dropdown slds-form-element__control slds-grow slds-input-has-icon slds-input-has-icon_left-right"
-          + (rightIcon ? " sfir-has-right-icon" : ""),
+          "input-with-dropdown slds-form-element__control slds-grow slds-input-has-icon "
+          + (rightIcon ? "slds-input-has-icon_left-right sfir-has-right-icon" : "slds-input-has-icon_right"),
       },
       h("input", {
         className: "slds-input sfir-font-size_11px",

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -4082,7 +4082,7 @@ class AllDataSelection extends React.PureComponent {
             "article",
             {
               className:
-                "slds-card slds-card_boundary slds-p-horizontal_small slds-p-vertical_xx-small sfir-background-grey",
+                "slds-card slds-card_boundary slds-p-horizontal_small slds-p-vertical_x-small sfir-background-grey",
             },
             h(
               "div",


### PR DESCRIPTION
# Describe your changes

Fixes uneven padding around the search icon on the Objects and Shortcuts tabs, and a position mismatch between the search icon and its loading spinner on the Users tab.

| Before | After |
|----------|---------|
| ![Before 1](https://github.com/user-attachments/assets/c5110232-fc30-4c5c-b072-975cc9a82857) | ![After 1](https://github.com/user-attachments/assets/0de05bf5-ab08-401e-bec1-8b2627c85332) |
| ![Before 2](https://github.com/user-attachments/assets/79c196ab-3cdb-4b44-b8d4-d72b683770b4) | ![After 2](https://github.com/user-attachments/assets/3f76a0e0-bede-4fba-843e-6356696da797) |
| ![Before 3](https://github.com/user-attachments/assets/11e6a0fa-4b3a-4d2d-bce5-b0aeeab61f5e) | ![After 3](https://github.com/user-attachments/assets/e32504af-a6ea-42f4-9271-2f5d6b701597) |



## Issue ticket number and link

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
