### PR TITLE
fix [Metadata]: File upload retrieval action and status button trigger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,10 @@
 
 ## Version 2.1
 
+- `Metadata` Uploading or pasting a package.xml now correctly enables the "Retrieve Metadata" button, and the "Save status info" button now correctly downloads activity logs instead of opening a file picker. #1228 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
-- `Metadata` Fixed: Uploading or pasting a package.xml now correctly unlocks the "Retrieve Metadata" button, and the "Save status info" button now correctly downloads your activity logs instead of opening a file picker. #1228 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 
 ## Version 2.1
 
-- `Metadata` Fixed the "Retrieve Metadata" button remaining disabled after uploading a `package.xml` file [issue #1256](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1256) (contribution by [Prem Kumar](https://github.com/prem-k-r))
-- `Metadata` Fixed the "Save status info" button opening the file picker instead of downloading activity logs [issue #1257](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1257) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+- `Metadata` Fix "Retrieve Metadata" button [issue #1256](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1256) and "Save status info" button [issue #1257](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1257) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Show All Data` Add **Refresh** button to re-fetch the latest field values and persist the filter value in the URL [feature 1201](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1201)
 - `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
+- `Metadata` Fixed: Uploading or pasting a package.xml now correctly unlocks the "Retrieve Metadata" button, and the "Save status info" button now correctly downloads your activity logs instead of opening a file picker. #1228 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/addon/metadata-retrieve.js
+++ b/addon/metadata-retrieve.js
@@ -174,19 +174,35 @@ class Model {
     });
   }
 
-  retrieveMetaFromPackageXml(packageXml){
+  parsePackageXml(packageXml) {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(packageXml, "text/xml");
-
-    const retrieveRequest = {apiVersion, unpackaged: {types: []}};
+    const retrieveRequest = { apiVersion, unpackaged: { types: [] } };
 
     const types = xmlDoc.getElementsByTagName("types");
     for (let typeNode of types) {
-      const name = typeNode.getElementsByTagName("name")[0].textContent;
+      const nameNode = typeNode.getElementsByTagName("name")[0];
+      if (!nameNode) continue;
+      const name = nameNode.textContent;
       const members = [...typeNode.getElementsByTagName("members")].map(m => m.textContent).sort();
-      retrieveRequest.unpackaged.types.push({name, members});
+      retrieveRequest.unpackaged.types.push({ name, members });
     }
     retrieveRequest.unpackaged.types.sort((a, b) => a.name.localeCompare(b.name));
+
+    if (this.metadataObjects && this.metadataObjects.length > 0) {
+      const typeNames = retrieveRequest.unpackaged.types.map(t => t.name);
+      this.metadataObjects.forEach(obj => {
+        if (typeNames.includes(obj.xmlName)) {
+          obj.selected = true;
+        }
+      });
+    }
+
+    return retrieveRequest;
+  }
+
+  retrieveMetaFromPackageXml(packageXml) {
+    const retrieveRequest = this.parsePackageXml(packageXml);
     this.retrieveMetadata(retrieveRequest);
   }
 
@@ -642,6 +658,8 @@ class App extends React.Component {
         try {
           const importedPackage = event.target.result;
           model.packageXml = importedPackage;
+          model.parsePackageXml(importedPackage);
+
           this.setState({
             showToast: true,
             toastMessage: fileName + " imported successfully!",
@@ -777,7 +795,7 @@ class App extends React.Component {
     let {model} = this.props;
     let clipText = e.clipboardData.getData("text/plain");
     model.packageXml = clipText;
-    model.retrieveMetaFromPackageXml(clipText);
+    model.parsePackageXml(clipText);
     model.didUpdate();
   }
   onUpdateManagedPackageSelection(e){
@@ -1045,7 +1063,18 @@ class App extends React.Component {
                 onClick: this.onStartClick,
                 disabled: !model.deployRequestId && (!model.metadataObjects || !model.metadataObjects.some(obj => obj.selected))
               }, "Retrieve Metadata"),
-              model.statusLink ? h("button", {className: "slds-button slds-button_icon slds-button_icon-border-filled slds-m-left_x-small", onClick: () => this.refs.fileInput.click(), title: "Save status info"},
+              model.statusLink ? h("button", {
+                className: "slds-button slds-button_icon slds-button_icon-border-filled slds-m-left_x-small",
+                onClick: () => {
+                  const a = document.createElement("a");
+                  a.href = model.statusLink;
+                  a.download = "status_info.json";
+                  document.body.appendChild(a);
+                  a.click();
+                  document.body.removeChild(a);
+                },
+                title: "Save status info"
+              },
                 h("svg", {className: "slds-button__icon"},
                   h("use", {xlinkHref: "symbols.svg#info"})
                 )

--- a/addon/metadata-retrieve.js
+++ b/addon/metadata-retrieve.js
@@ -177,7 +177,7 @@ class Model {
   parsePackageXml(packageXml) {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(packageXml, "text/xml");
-    const retrieveRequest = { apiVersion, unpackaged: { types: [] } };
+    const retrieveRequest = {apiVersion, unpackaged: {types: []}};
 
     const types = xmlDoc.getElementsByTagName("types");
     for (let typeNode of types) {
@@ -185,7 +185,7 @@ class Model {
       if (!nameNode) continue;
       const name = nameNode.textContent;
       const members = [...typeNode.getElementsByTagName("members")].map(m => m.textContent).sort();
-      retrieveRequest.unpackaged.types.push({ name, members });
+      retrieveRequest.unpackaged.types.push({name, members});
     }
     retrieveRequest.unpackaged.types.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -1075,9 +1075,9 @@ class App extends React.Component {
                 },
                 title: "Save status info"
               },
-                h("svg", {className: "slds-button__icon"},
-                  h("use", {xlinkHref: "symbols.svg#info"})
-                )
+              h("svg", {className: "slds-button__icon"},
+                h("use", {xlinkHref: "symbols.svg#info"})
+              )
               ) : null,
               h("button", {className: "slds-button slds-button_icon slds-button_icon-border-filled slds-m-left_x-small", onClick: () => this.downloadXml(), title: "Download package.xml"},
                 h("svg", {className: "slds-button__icon"},

--- a/tests/e2e/metadata-retrieve.spec.js
+++ b/tests/e2e/metadata-retrieve.spec.js
@@ -256,6 +256,13 @@ test.describe("Metadata Retrieve", () => {
 
     // Wait for page to load
     await page.waitForSelector("button[title='Import package.xml or package zip file']", {timeout: 1000});
+    let retrieveRequestCount = 0;
+    page.on("request", request => {
+      const requestBody = request.postData();
+      if (request.method() === "POST" && requestBody?.includes("retrieve") && !requestBody.includes("checkRetrieveStatus")) {
+        retrieveRequestCount++;
+      }
+    });
 
     // Create a test package.xml file
     const packageXmlContent = `<?xml version="1.0" encoding="UTF-8"?>
@@ -281,5 +288,35 @@ test.describe("Metadata Retrieve", () => {
 
     // Verify success toast appears
     await expect(page.locator("text=imported successfully")).toBeVisible({timeout: 1000});
+
+    const apexClassCheckbox = page
+      .locator(".slds-accordion__list-item")
+      .filter({hasText: "ApexClass"})
+      .first()
+      .locator("input.metadata")
+      .first();
+    await expect(apexClassCheckbox).toBeChecked();
+    await expect(page.locator("button:has-text('Retrieve Metadata')")).toBeEnabled();
+    expect(retrieveRequestCount).toBe(0);
+  });
+
+  test("Save Status Info Downloads Retrieve Status JSON", async ({page, extensionId}) => {
+    await initMetadataRetrievePage(page, extensionId);
+
+    const firstCheckbox = page.locator(".slds-accordion__list-item").first().locator("input.metadata");
+    await firstCheckbox.click();
+
+    const metadataDownloadPromise = page.waitForEvent("download");
+    await page.locator("button:has-text('Retrieve Metadata')").click();
+    const metadataDownload = await metadataDownloadPromise;
+    expect(metadataDownload.suggestedFilename()).toBe("metadata.zip");
+
+    const statusButton = page.locator("button[title='Save status info']");
+    await expect(statusButton).toBeVisible();
+
+    const statusDownloadPromise = page.waitForEvent("download");
+    await statusButton.click();
+    const statusDownload = await statusDownloadPromise;
+    expect(statusDownload.suggestedFilename()).toBe("status_info.json");
   });
 });


### PR DESCRIPTION
# Describe your changes
**Fixed two bugs in the metadata module:** 
- Uploading a `package.xml` now correctly enables the "Retrieve Metadata" button, 
- "Save status info" icon now downloads the activity logs instead of opening the file picker.


## Issue ticket number and link
Closes #1256
Closes #1257


## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
