### PR TITLE
fix(data-import): Resolve "Unknown object" error for standard objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition
+- `Cache` Resolve "Unknown object" error for standard objects in Data Import and Field Explorer #1231 (contribution by [Prem Kumar](https://github.com/prem-k-r))
 
 ## Version 2.0
 

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1117,6 +1117,9 @@ async function fetchSobjectsList(sfHost, currentFetch, cacheEnabled, cachedSobje
           isEverCreatable,
           newUrl,
           layoutable: layoutable || false,
+          createable: createable || false,
+          deletable: deletable || false,
+          updateable: updateable || false,
         };
         entityMap.set(name, entity);
       }


### PR DESCRIPTION
# Describe your changes

Root Cause
A race condition exists in utils.js during the concurrent fetchSobjectsList caching process. When a new standard object was added to the entityMap inside the addEntity() function, its initial creation block omitted the createable, deletable, and updateable DML flags. Because the regularApi describe call typically resolves much faster than the toolingApi call in Production orgs, standard objects were being cached first but losing their DML flags in the process. This caused the Data Import page to reject them as invalid targets, resulting in the "Unknown object" error.

Solution
- Added the createable, deletable, and updateable properties to the object initialization block (else statement) inside addEntity().
- This ensures the DML boolean values are properly captured on the first pass and safely persisted, completely neutralizing the race condition regardless of which API promise resolves first.  

## Issue ticket number and link
Closes #1146, 
Closes #1189

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
