### PR TITLE
feat [data-export]: Add mouse wheel scrolling to field suggestions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` Added support for horizontal scrolling in field suggestions using the mouse wheel [#1237](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1237) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1715,6 +1715,20 @@ class App extends React.Component {
     let queryInput = this.refs.query;
     model.setQueryInput(queryInput);
     model.soqlPrompt = this.refs.prompt;
+
+    // Allow horizontal scrolling with the mouse wheel
+    let autocompleteResultsCont = this.refs.autocompleteResults;
+    if (autocompleteResultsCont) {
+      autocompleteResultsCont.addEventListener("wheel", (event) => {
+        if (autocompleteResultsCont.scrollWidth > autocompleteResultsCont.clientWidth) {
+          if (event.deltaY !== 0) {
+            event.preventDefault();
+            autocompleteResultsCont.scrollLeft += event.deltaY;
+          }
+        }
+      }, { passive: false });
+    }
+
     //Set the cursor focus on query text area
     if (localStorage.getItem("disableQueryInputAutoFocus") !== "true"){
       queryInput.focus();
@@ -2010,7 +2024,7 @@ class App extends React.Component {
                     ))
                 ),
               ),
-              h("div", {className: "autocomplete-results slds-m-top_small"},
+              h("div", {className: "autocomplete-results slds-m-top_small", ref: "autocompleteResults"},
                 model.autocompleteResults.results.map(r => (
                   h("span", {className: "slds-pill slds-pill_link slds-m-vertical_xxx-small", key: r.value},
                     h("span", {className: "slds-pill__icon_container " + r.autocompleteType + " " + r.dataType},


### PR DESCRIPTION
# Describe your changes
This PR improves the user experience of the field suggestions (autocomplete) dropdown by allowing users to scroll horizontally using their standard vertical mouse wheel. Previously, users had to manually click show all suggestions, now they can scroll too.

## Issue ticket number and link
Closes #1358

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
