### PR TITLE
fix [Popup]: Object doesn't refresh when switching between object list views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Fix object not refreshing when switching between object list views [issue #1254](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1254) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Metadata Retrieve` Fix sort preference (`Sort metadata by`) not persisting due to misspelled localStorage key
 - `Popup` Add filter icon and menu on User tab search input [discussion #1147](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1147)
 - `Event Monitor` Allow users to generate, publish and save Platform Events based on their definition

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1712,7 +1712,7 @@ class AllDataBoxSObject extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     let {contextRecordId, sobjectsLoading, contextSobject} = this.props;
-    if (prevProps.contextRecordId !== contextRecordId) {
+    if (prevProps.contextRecordId !== contextRecordId || prevProps.contextSobject !== contextSobject) {
       this.updateSelection(contextRecordId, contextSobject);
     }
     if (prevProps.sobjectsLoading !== sobjectsLoading && !sobjectsLoading) {


### PR DESCRIPTION
# Describe your changes
## Issue
#1254 

When switching between two object list views (e.g. Accounts tab →
Opportunities tab) without opening a specific record, the popup keeps
showing data for the previously viewed object instead of updating.
Only a full page refresh fixes it. Switching between specific records
works fine.

## Cause
`AllDataBoxSObject.componentDidUpdate` only re-runs `updateSelection`
when `contextRecordId` changes. On a list view, `getRecordId()` always
returns the literal string "list" regardless of object, so navigating
from one object's list view to another's leaves `contextRecordId`
unchanged ("list" === "list") even though `contextSobject` did change.
The check never fires, so the popup keeps stale state.

Specific records aren't affected since each object's record IDs have
distinct key prefixes, so `contextRecordId` always changes there.

## Fix
Also check `contextSobject` in the comparison

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
