### PR TITLE
[feat]: Ctrl/Cmd+Click record Ids in Data Export to open Show All Data in a new tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` Ctrl+Click (Cmd+Click on Mac) or middle-click a record Id in the results to open its Show All Data page directly in a new tab [feature 214](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/214)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Disabled the Copy/Download buttons when the query output has no results [#1258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1258) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -134,9 +134,42 @@ function renderCell(rt, cell, td) {
   function popLink(recordInfo, label) {
     let a = document.createElement("a");
     a.href = "about:blank";
-    a.title = "Show all data";
+    a.title = "Show all data (Ctrl+Click or Cmd+Click to open in a new tab)";
+    function getShowAllDataUrl() {
+      // Only when the object type is unambiguous, otherwise the pop-up menu is needed to resolve it
+      let {objectTypes, recordId} = recordInfo();
+      if (objectTypes.length !== 1 || objectTypes[0] === "Unknown") {
+        return null;
+      }
+      let args = new URLSearchParams();
+      args.set("host", rt.sfHost);
+      args.set("objectType", objectTypes[0]);
+      if (rt.isTooling) {
+        args.set("useToolingApi", "1");
+      }
+      if (recordId) {
+        args.set("recordId", recordId);
+      }
+      return "inspect.html?" + args;
+    }
+    a.addEventListener("auxclick", e => {
+      if (e.button === 1) {
+        let url = getShowAllDataUrl();
+        if (url) {
+          e.preventDefault();
+          window.open(url, "_blank");
+        }
+      }
+    });
     a.addEventListener("click", e => {
       e.preventDefault();
+      if (e.ctrlKey || e.metaKey) {
+        let url = getShowAllDataUrl();
+        if (url) {
+          window.open(url, "_blank");
+          return;
+        }
+      }
       let pop = document.createElement("div");
       pop.className = "slds-dropdown slds-dropdown_left slds-dropdown_actions";
       let ul = document.createElement("ul");


### PR DESCRIPTION
# Describe your changes

Implements the behavior discussed in the issue (per @tprouvot's implementation hint in the comments):

- **Ctrl+Click / Cmd+Click** on a record Id in Data Export results opens its **Show All Data** page directly in a new tab, skipping the pop-up menu.
- **Middle-click** does the same (matching browser open-in-new-tab muscle memory).
- **Plain click is unchanged** — it still opens the pop-up menu with Show all data / Query Record / View in Salesforce / Copy Id.
- Direct navigation only happens when the object type is unambiguous (single keyPrefix match, not `Unknown`); for ambiguous Ids or event log file paths the pop-up menu opens as before, since it is needed to resolve the object type.
- The link tooltip now advertises the shortcut: "Show all data (Ctrl+Click or Cmd+Click to open in a new tab)".

All changes are contained in `popLink` within `renderCell` (addon/data-load.js), so the behavior applies wherever the result table renders record Ids.

## Issue ticket number and link

Fixes #214

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests (no existing test covers the pop-up link behavior; verified manually that plain click still opens the menu)
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)