### PR TITLE
[feat]: Suggest INCLUDES and EXCLUDES keywords in Data Export autocomplete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` Suggest INCLUDES and EXCLUDES keywords and their picklist values in SOQL autocomplete [feature 912](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/912)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Disabled the Copy/Download buttons when the query output has no results [#1258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1258) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -531,11 +531,11 @@ class Model {
     // If we are on the right hand side of a comparison operator, autocomplete field values
     let isFieldValue = query.substring(0, selStart).match(/\s*[<>=!]+\s*('?[^'\s]*)$/);
 
-    // In clause on picklist field
-    let isInWithValues = query.substring(0, selStart).match(/\s*in\s*\(\s*(?:(?:'[^']*'\s*,\s*)+|')('?[^'\s]*)$/i);
+    // IN clause on picklist field, or INCLUDES/EXCLUDES clause on multi-picklist field
+    let isInWithValues = query.substring(0, selStart).match(/\s*\b(?:in|includes|excludes)\s*\(\s*(?:(?:'[^']*'\s*,\s*)+|')('?[^'\s]*)$/i);
     let inValuesUtilized = "";
     if (isInWithValues){
-      if (isInWithValues[0] && isInWithValues[0].match(/\s*in\s*\(\s*(?:')$/i)){ // extra single quote
+      if (isInWithValues[0] && isInWithValues[0].match(/\s*\b(?:in|includes|excludes)\s*\(\s*(?:')$/i)){ // extra single quote
         selStart -= 1;
         isInWithValues[0] = isInWithValues[0].substring(0, isInWithValues[0].length - 1);
       }
@@ -820,6 +820,12 @@ class Model {
                   return {value: fn, title: fn + "()", suffix: "(", rank: 2, autocompleteType: "variable", dataType: ""};
                 }
               })
+          )
+          .concat(
+            // Multi-picklist operators, only relevant after the FROM clause (ie in WHERE filters)
+            new Enumerable(isAfterFrom ? ["INCLUDES", "EXCLUDES"] : [])
+              .filter(fn => fn.toLowerCase().startsWith(searchTerm.toLowerCase()))
+              .map(fn => ({value: fn, title: fn + "()", suffix: "(", rank: 2, autocompleteType: "variable", dataType: ""}))
           )
           .toArray()
           .sort(resultsSort)

--- a/tests/e2e/data-export.spec.js
+++ b/tests/e2e/data-export.spec.js
@@ -127,6 +127,30 @@ test.describe("Data Export", () => {
     await expect(queryInput).toHaveValue("SELECT Id, Name FROM Account");
   });
 
+  test("Autocomplete INCLUDES/EXCLUDES on multi-picklist fields", async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.waitForSelector("textarea#query", {timeout: 2000});
+
+    const queryInput = page.locator("textarea#query");
+
+    // 1. INCLUDES keyword suggestion after a field in the WHERE clause
+    await queryInput.fill("SELECT Id FROM Account WHERE Interests__c INC");
+    await expect(page.locator(".autocomplete-results")).toContainText("INCLUDES");
+    await page.locator(".autocomplete-results a").filter({hasText: "INCLUDES"}).first().click();
+    await expect(queryInput).toHaveValue("SELECT Id FROM Account WHERE Interests__c INCLUDES(");
+
+    // 2. EXCLUDES keyword suggestion
+    await queryInput.fill("SELECT Id FROM Account WHERE Interests__c EXC");
+    await expect(page.locator(".autocomplete-results")).toContainText("EXCLUDES");
+
+    // 3. Picklist value suggestions inside INCLUDES(...)
+    await queryInput.fill("SELECT Id FROM Account WHERE Interests__c INCLUDES ('");
+    await expect(page.locator(".autocomplete-header")).toContainText("Account.Interests__c values");
+    await expect(page.locator(".autocomplete-results")).toContainText("Running");
+    await page.locator(".autocomplete-results a").filter({hasText: "Running"}).first().click();
+    await expect(queryInput).toHaveValue("SELECT Id FROM Account WHERE Interests__c INCLUDES ('Running' ");
+  });
+
   test("Copy as CSV", async ({page, context, extensionId}) => {
     // Grant clipboard permissions to browser context
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);

--- a/tests/e2e/test-mock.js
+++ b/tests/e2e/test-mock.js
@@ -177,6 +177,18 @@ export async function routeMock(route, host) {
               {value: "Partner", label: "Partner", active: true}
             ],
             referenceTo: []},
+          {name: "Interests__c",
+            label: "Interests",
+            type: "multipicklist",
+            createable: true,
+            updateable: true,
+            nillable: true,
+            picklistValues: [
+              {value: "Running", label: "Running", active: true},
+              {value: "Cycling", label: "Cycling", active: true},
+              {value: "Swimming", label: "Swimming", active: true}
+            ],
+            referenceTo: []},
           {name: "Description", label: "Description", type: "textarea", createable: true, updateable: true, nillable: true, referenceTo: []}
         ],
         childRelationships: [


### PR DESCRIPTION
# Describe your changes

Adds multi-picklist operator support to the SOQL autocomplete in Data Export:

- **Keyword suggestions**: typing `inc`/`exc` after a field in the WHERE clause now suggests `INCLUDES`/`EXCLUDES` (only shown after the FROM clause, so they don't pollute SELECT-clause suggestions).
- **Value suggestions**: picklist values are now suggested inside `INCLUDES('...')` and `EXCLUDES('...')`, reusing the existing `IN (...)` value-completion path — the clause-detection regex was extended from `in` to `in|includes|excludes`.
- The regex also gained a word boundary (`\b`), which fixes a latent false-positive where a field name *ending* in "in" followed by `('` could trigger IN-clause value completion.
- **Test**: new Playwright e2e test `Autocomplete INCLUDES/EXCLUDES on multi-picklist fields` covering keyword suggestion, insertion, and value completion; the mocked Account describe gains a `multipicklist` field (`Interests__c`) to support it.

Ran the full mock e2e suite: 154 passed (one unrelated flow-scanner teardown-timeout flake that passes in isolation).

Note: PR #1241 covers INCLUDES/EXCLUDES *formatting*; this PR is only about autocomplete, so they complement each other.

## Issue ticket number and link

Fixes #912

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)