### PR TITLE
[feat] Add search prefixes to Shortcut tab for improved query performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Add search prefixes to speed up Shortcut tab queries: `/` for setup links only, `!` for metadata, and typed filters (`!flow`, `!profile`, `!class`, `!perm`) [feature 1265](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1265)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Export` Disabled the Copy/Download buttons when the query output has no results [#1258](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1258) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1612,7 +1612,7 @@ class AllDataBoxUsers extends React.PureComponent {
         inputSearchDelay: 400,
         placeholderText: "Name, username, email or alias",
         resultRender: this.resultRender,
-        rightIcon:         h(
+        rightIcon: h(
           "div",
           {
             ref: "filterDropdownRef",
@@ -2378,10 +2378,85 @@ class AllDataBoxShortcut extends React.PureComponent {
     this.getMatches = this.getMatches.bind(this);
     this.onDataSelect = this.onDataSelect.bind(this);
     this.onAddShortcut = this.onAddShortcut.bind(this);
+    this.resultRender = this.resultRender.bind(this);
   }
 
   componentDidMount() {
     this.refs.allDataSearch.refs.showAllDataInp.focus();
+  }
+
+  /**
+   * Parse Shortcut tab query prefixes:
+   * - "/term" → setup links only
+   * - "!term" → all metadata types
+   * - "!flow term" / "!profile term" / "!class term" / "!perm term" → one metadata type
+   * - "term" → setup links + metadata (default)
+   */
+  parseShortcutSearch(shortcutSearch) {
+    const METADATA_TYPE_ALIASES = {
+      flow: "flows",
+      profile: "profiles",
+      class: "classes",
+      perm: "permissionSets"
+    };
+    const ALL_METADATA_TYPES = [
+      "flows",
+      "profiles",
+      "permissionSets",
+      "classes",
+    ];
+
+    if (shortcutSearch.startsWith("/")) {
+      return {
+        includeLinks: true,
+        includeMetadata: false,
+        metadataTypes: [],
+        query: shortcutSearch.slice(1).trim(),
+      };
+    }
+
+    if (shortcutSearch.startsWith("!")) {
+      const rest = shortcutSearch.slice(1).trim();
+      const typeMatch = rest.match(/^([a-zA-Z]+)\s+(.*)$/);
+      if (typeMatch) {
+        const alias = METADATA_TYPE_ALIASES[typeMatch[1].toLowerCase()];
+        if (alias) {
+          return {
+            includeLinks: false,
+            includeMetadata: true,
+            metadataTypes: [alias],
+            query: typeMatch[2].trim(),
+            forceMetadata: true,
+          };
+        }
+      }
+      const singleType = METADATA_TYPE_ALIASES[rest.toLowerCase()];
+      if (singleType) {
+        // "!profile" with no search term yet
+        return {
+          includeLinks: false,
+          includeMetadata: true,
+          metadataTypes: [singleType],
+          query: "",
+          forceMetadata: true,
+        };
+      }
+      return {
+        includeLinks: false,
+        includeMetadata: true,
+        metadataTypes: ALL_METADATA_TYPES,
+        query: rest,
+        forceMetadata: true,
+      };
+    }
+
+    return {
+      includeLinks: true,
+      includeMetadata: true,
+      metadataTypes: null, // use options
+      query: shortcutSearch,
+      forceMetadata: false,
+    };
   }
 
   async getMatches(shortcutSearch) {
@@ -2390,19 +2465,33 @@ class AllDataBoxShortcut extends React.PureComponent {
       return [];
     }
     try {
-      setIsLoading(true);
       shortcutSearch = shortcutSearch.trim();
+      const {
+        includeLinks,
+        includeMetadata,
+        metadataTypes,
+        query,
+        forceMetadata,
+      } = this.parseShortcutSearch(shortcutSearch);
 
-      //search for shortcuts
-      let result = setupLinks.filter((item) =>
-        item.label.toLowerCase().includes(shortcutSearch.toLowerCase())
-      );
-      result.forEach((element) => {
-        element.detail = element.section;
-        element.name = element.link;
-        element.Id = element.name;
-        element.isSetupLink = true;
-      });
+      if (!query) {
+        return [];
+      }
+
+      let result = [];
+
+      //search for setup / custom shortcuts
+      if (includeLinks) {
+        result = setupLinks.filter((item) =>
+          item.label.toLowerCase().includes(query.toLowerCase())
+        );
+        result.forEach((element) => {
+          element.detail = element.section;
+          element.name = element.link;
+          element.Id = element.name;
+          element.isSetupLink = true;
+        });
+      }
 
       let metadataShortcutSearchOptions = localStorage.getItem(
         "metadataShortcutSearchOptions"
@@ -2419,24 +2508,31 @@ class AllDataBoxShortcut extends React.PureComponent {
           != undefined;
       }
 
-      //search for metadata if user did not disabled it (min 2 chars to avoid heavy queries)
-      if (metadataShortcutSearch && shortcutSearch.length >= 2) {
+      // Explicit ! prefix always searches metadata; otherwise respect options
+      const canSearchMetadata
+        = includeMetadata
+        && query.length >= 2
+        && (forceMetadata || metadataShortcutSearch);
+
+      //search for metadata if enabled (min 2 chars to avoid heavy queries)
+      if (canSearchMetadata) {
+        setIsLoading(true);
         const queries = {
           flows:
             "SELECT DurableId, LatestVersionId, ApiName, Label, ProcessType FROM FlowDefinitionView WHERE Label LIKE '%"
-            + shortcutSearch
+            + query
             + "%' LIMIT 15",
           profiles:
             "SELECT Id, Name, UserLicense.Name FROM Profile WHERE Name LIKE '%"
-            + shortcutSearch
+            + query
             + "%' LIMIT 15",
           permissionSets:
             "SELECT Id, Name, Label, Type, LicenseId, License.Name, PermissionSetGroupId FROM PermissionSet WHERE Label LIKE '%"
-            + shortcutSearch
+            + query
             + "%' LIMIT 15",
           classes:
             "SELECT Id, Name, NamespacePrefix, ApiVersion, Status, LengthWithoutComments FROM ApexClass WHERE Name LIKE '%"
-            + shortcutSearch
+            + query
             + "%' LIMIT 20",
         };
         // If metadataShortcutSearchOptions is null, assume all options are checked
@@ -2449,89 +2545,99 @@ class AllDataBoxShortcut extends React.PureComponent {
         const effectiveOptions
           = metadataShortcutSearchOptions || defaultOptions;
 
-        const compositeRequest = effectiveOptions
-          .filter((setting) => setting.checked && queries[setting.name])
-          .map((setting) => ({
+        let typesToQuery;
+        if (metadataTypes) {
+          // Prefix selected specific types (or all for bare "!")
+          typesToQuery = metadataTypes.filter((name) => queries[name]);
+        } else {
+          typesToQuery = effectiveOptions
+            .filter((setting) => setting.checked && queries[setting.name])
+            .map((setting) => setting.name);
+        }
+
+        if (typesToQuery.length > 0) {
+          const compositeRequest = typesToQuery.map((name) => ({
             method: "GET",
             url:
               "/services/data/v"
               + apiVersion
               + "/query/?q="
-              + encodeURIComponent(queries[setting.name]),
-            referenceId: setting.name + "Select",
+              + encodeURIComponent(queries[name]),
+            referenceId: name + "Select",
           }));
 
-        const searchResult = await sfConn.rest(
-          "/services/data/v" + apiVersion + "/composite",
-          {method: "POST", body: {compositeRequest}}
-        );
-        let results = searchResult.compositeResponse.filter(
-          (elm) => elm.httpStatusCode == 200 && elm.body.records.length > 0
-        );
+          const searchResult = await sfConn.rest(
+            "/services/data/v" + apiVersion + "/composite",
+            {method: "POST", body: {compositeRequest}}
+          );
+          let results = searchResult.compositeResponse.filter(
+            (elm) => elm.httpStatusCode == 200 && elm.body.records.length > 0
+          );
 
-        let enablePermSetSummary
-          = localStorage.getItem("enablePermSetSummary") === "true";
+          let enablePermSetSummary
+            = localStorage.getItem("enablePermSetSummary") === "true";
 
-        results.forEach((element) => {
-          element.body.records.forEach((rec) => {
-            if (rec.attributes.type === "FlowDefinitionView") {
-              rec.link
-                = "/builder_platform_interaction/flowBuilder.app?flowDefId="
-                + rec.DurableId
-                + "&flowId="
-                + rec.LatestVersionId;
-              rec.label = rec.Label;
-              rec.name = rec.ApiName;
-              rec.detail = rec.attributes.type + " • " + rec.ProcessType;
-            } else if (rec.attributes.type === "Profile") {
-              rec.link
-                = "/lightning/setup/EnhancedProfiles/page?address=%2F" + rec.Id;
-              rec.label = rec.Name;
-              rec.name = rec.Id;
-              rec.detail = rec.attributes.type + " • " + rec.UserLicense.Name;
-            } else if (rec.attributes.type === "PermissionSet") {
-              rec.label = rec.Label;
-              rec.name = rec.Name;
-              rec.detail = rec.attributes.type + " • " + rec.Type;
-              rec.detail
-                += rec.License?.Name != null ? " • " + rec.License?.Name : "";
+          results.forEach((element) => {
+            element.body.records.forEach((rec) => {
+              if (rec.attributes.type === "FlowDefinitionView") {
+                rec.link
+                  = "/builder_platform_interaction/flowBuilder.app?flowDefId="
+                  + rec.DurableId
+                  + "&flowId="
+                  + rec.LatestVersionId;
+                rec.label = rec.Label;
+                rec.name = rec.ApiName;
+                rec.detail = rec.attributes.type + " • " + rec.ProcessType;
+              } else if (rec.attributes.type === "Profile") {
+                rec.link
+                  = "/lightning/setup/EnhancedProfiles/page?address=%2F" + rec.Id;
+                rec.label = rec.Name;
+                rec.name = rec.Id;
+                rec.detail = rec.attributes.type + " • " + rec.UserLicense.Name;
+              } else if (rec.attributes.type === "PermissionSet") {
+                rec.label = rec.Label;
+                rec.name = rec.Name;
+                rec.detail = rec.attributes.type + " • " + rec.Type;
+                rec.detail
+                  += rec.License?.Name != null ? " • " + rec.License?.Name : "";
 
-              const isGroup = rec.Type === "Group";
-              let psetOrGroupId = isGroup ? rec.PermissionSetGroupId : rec.Id;
-              let type = isGroup ? "PermSetGroups" : "PermSets";
-              let endLink = enablePermSetSummary
-                ? psetOrGroupId + "/summary"
-                : "page?address=%2F" + psetOrGroupId;
-              rec.link = "/lightning/setup/" + type + "/" + endLink;
-            } else if (rec.attributes.type === "ApexClass") {
-              rec.link
-                = "/lightning/setup/ApexClasses/page?address=%2F" + rec.Id;
-              rec.label = rec.Name;
-              rec.name = rec.NamespacePrefix
-                ? rec.NamespacePrefix + "__" + rec.Name
-                : rec.Name;
-              rec.detail
-                = rec.attributes.type
-                + " • "
-                + rec.ApiVersion
-                + ".0 • "
-                + rec.Status
-                + (rec.NamespacePrefix
-                  ? ""
-                  : " • Length: " + rec.LengthWithoutComments);
-            }
-            rec.title = rec.name;
-            result.push(rec);
+                const isGroup = rec.Type === "Group";
+                let psetOrGroupId = isGroup ? rec.PermissionSetGroupId : rec.Id;
+                let type = isGroup ? "PermSetGroups" : "PermSets";
+                let endLink = enablePermSetSummary
+                  ? psetOrGroupId + "/summary"
+                  : "page?address=%2F" + psetOrGroupId;
+                rec.link = "/lightning/setup/" + type + "/" + endLink;
+              } else if (rec.attributes.type === "ApexClass") {
+                rec.link
+                  = "/lightning/setup/ApexClasses/page?address=%2F" + rec.Id;
+                rec.label = rec.Name;
+                rec.name = rec.NamespacePrefix
+                  ? rec.NamespacePrefix + "__" + rec.Name
+                  : rec.Name;
+                rec.detail
+                  = rec.attributes.type
+                  + " • "
+                  + rec.ApiVersion
+                  + ".0 • "
+                  + rec.Status
+                  + (rec.NamespacePrefix
+                    ? ""
+                    : " • Length: " + rec.LengthWithoutComments);
+              }
+              rec.title = rec.name;
+              result.push(rec);
+            });
           });
-        });
+        }
       }
       //if no result found, add the global search link
       result.length > 0
         ? result
         : result.push({
-          Id: "global-search-" + shortcutSearch,
-          link: "/one/one.app#" + this.getEncodedGlobalSearch(shortcutSearch),
-          label: '"' + shortcutSearch + '"',
+          Id: "global-search-" + query,
+          link: "/one/one.app#" + this.getEncodedGlobalSearch(query),
+          label: '"' + query + '"',
           detail: "No results found",
           name: "Use Global Search",
         });
@@ -2568,6 +2674,8 @@ class AllDataBoxShortcut extends React.PureComponent {
   }
 
   resultRender(matches, shortcutQuery) {
+    const {query} = this.parseShortcutSearch((shortcutQuery || "").trim());
+    const highlightQuery = query || shortcutQuery || "";
     return matches.map((value, index) => ({
       key: value.Id || "shortcut-" + index,
       value,
@@ -2583,8 +2691,8 @@ class AllDataBoxShortcut extends React.PureComponent {
             text: value.label,
             start: value.label
               .toLowerCase()
-              .indexOf(shortcutQuery.toLowerCase()),
-            length: shortcutQuery.length,
+              .indexOf(highlightQuery.toLowerCase()),
+            length: highlightQuery.length,
           })
         ),
         h(
@@ -2599,8 +2707,8 @@ class AllDataBoxShortcut extends React.PureComponent {
             text: value.name,
             start: value.name
               .toLowerCase()
-              .indexOf(shortcutQuery.toLowerCase()),
-            length: shortcutQuery.length,
+              .indexOf(highlightQuery.toLowerCase()),
+            length: highlightQuery.length,
           })
         ),
       ],
@@ -2623,7 +2731,7 @@ class AllDataBoxShortcut extends React.PureComponent {
         getMatches: this.getMatches,
         onDataSelect: this.onDataSelect,
         inputSearchDelay: 200,
-        placeholderText: "Quick find links, shortcuts",
+        placeholderText: "Search… /links !perm !flow !profile !class",
         resultRender: this.resultRender,
         sfHost,
         icon: "add",

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -124,10 +124,32 @@ If you want to _always_ open extension's links in a new tab, you can enable> **W
 * Event <ins>M</ins>onitor : m
 * <ins>F</ins>ield Creator : f
 
-## Disable metadata search from Shortcut tab
+## Shortcut tab search
 
-By default when you enter keyword in the Shortcut tab, the search is performed on the Setup link shortcuts _AND_ metadata (Flows, Profiles, Permission Sets and Apex Classes).
-If you want to disable the search on the metadata, update related option:
+By default when you enter a keyword in the Shortcut tab, the search is performed on the Setup link shortcuts _AND_ metadata (Flows, Profiles, Permission Sets and Apex Classes).
+
+Metadata search can be slow on orgs with a lot of metadata. Use search prefixes to narrow the scope and speed up results:
+
+| Prefix | Scope | Example |
+| --- | --- | --- |
+| _(none)_ | Setup links + metadata (default) | `profiles` |
+| `/` | Setup / custom links only (no API call) | `/profiles` |
+| `!` | All metadata types | `!MyMetadata` |
+| `!flow` | Flows only | `!flow Onboarding` |
+| `!profile` | Profiles only | `!profile System` |
+| `!class` / `!apex` | Apex Classes only | `!class AccountService` |
+| `!perm` / `!pset` | Permission Sets only | `!perm Sales` |
+
+Notes:
+
+* Prefix type aliases are case-insensitive (`!Profile`, `!FLOW`, etc.).
+* Typed metadata prefixes (`!flow`, `!profile`, …) always query that metadata type, even if it is unchecked under **Searchable metadata from Shortcut tab**.
+* Metadata queries still require at least 2 characters after the prefix (for example `!flow Ab`).
+* `/` is local-only and is the fastest way to find a Setup page from the built-in / custom shortcut list.
+
+### Disable metadata search from Shortcut tab
+
+If you want to disable metadata search for the default (unprefixed) queries, update related option:
 
 <img width="892" alt="image" src="https://github.com/user-attachments/assets/2541fc22-9f1b-4cd1-90cd-d4615b313d96">
 

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -34,7 +34,7 @@ const SHORTCUT_METADATA_MOCKS = [
       Type: "Regular",
       License: null,
       PermissionSetGroupId: null,
-      attributes: {type: "PermissionSet"}
+      attributes: {typae: "PermissionSet"}
     }
   },
   {
@@ -153,100 +153,102 @@ test.describe("Popup", () => {
         return;
       }
 
+      const request = route.request();
+      const url = request.url();
+      const method = request.method();
+
+      // REST API - Composite Query (user details + Shortcut tab metadata search).
+      // Handled before routeMock() because test-mock.js has a generic composite fallback
+      // that would otherwise swallow these requests and respond with empty records.
+      if (url.includes(mockHost) && url.includes("/composite") && method === "POST") {
+        const requestBody = await request.postData();
+        const body = JSON.parse(requestBody);
+
+        // User search composite
+        if (body.compositeRequest && body.compositeRequest[0]?.url?.includes("FROM User WHERE")) {
+          await fulfillSuccess(route, {
+            compositeResponse: [
+              {
+                httpStatusCode: 200,
+                body: {
+                  totalSize: 1,
+                  records: [{
+                    Id: "005000000000001AAA",
+                    Name: "Test User",
+                    Email: "test@example.com",
+                    Username: "test@example.com",
+                    Alias: "tuser",
+                    IsActive: true,
+                    Profile: {
+                      Name: "System Administrator"
+                    },
+                    UserRole: {
+                      Name: "CEO"
+                    }
+                  }]
+                }
+              }
+            ]
+          });
+          return;
+        }
+
+        // User details composite
+        if (body.compositeRequest && body.compositeRequest[0]?.url?.includes("WHERE Id='")) {
+          await fulfillSuccess(route, {
+            compositeResponse: [
+              {
+                httpStatusCode: 200,
+                body: {
+                  totalSize: 1,
+                  records: [{
+                    Id: "005000000000001AAA",
+                    Name: "Test User",
+                    Email: "test@example.com",
+                    Username: "test@example.com",
+                    Alias: "tuser",
+                    IsActive: true,
+                    FederationIdentifier: "test@example.com",
+                    ProfileId: "00e000000000001AAA",
+                    Profile: {
+                      Name: "System Administrator"
+                    },
+                    ContactId: null,
+                    IsPortalEnabled: false,
+                    UserPreferencesUserDebugModePref: false,
+                    UserRole: {
+                      Name: "CEO"
+                    },
+                    LocaleSidKey: "en_US",
+                    LanguageLocaleKey: "en_US"
+                  }]
+                }
+              }
+            ]
+          });
+          return;
+        }
+
+        // Shortcut search composite (Shortcuts tab: default, "!", "!flow", "!profile", "!class", "!perm" searches)
+        if (body.compositeRequest && body.compositeRequest.some((req) => SHORTCUT_METADATA_MOCKS.some(({match}) => req.url?.includes(match)))) {
+          const compositeResponse = body.compositeRequest.map((req) => {
+            const mock = SHORTCUT_METADATA_MOCKS.find(({match}) => req.url?.includes(match));
+            return {
+              httpStatusCode: 200,
+              body: {totalSize: mock ? 1 : 0, records: mock ? [mock.record] : []}
+            };
+          });
+          await fulfillSuccess(route, {compositeResponse});
+          return;
+        }
+      }
+
       //we check if we have a mock for this request
       if (await routeMock(route, mockHost)) {
         return;
       }
 
-      const request = route.request();
-      const url = request.url();
-      const method = request.method();
-
       if (url.includes(mockHost)) {
-
-        // REST API - Composite Query (for user details)
-        if (url.includes("/composite") && method === "POST") {
-          const requestBody = await request.postData();
-          const body = JSON.parse(requestBody);
-
-          // User search composite
-          if (body.compositeRequest && body.compositeRequest[0]?.url?.includes("FROM User WHERE")) {
-            await fulfillSuccess(route, {
-              compositeResponse: [
-                {
-                  httpStatusCode: 200,
-                  body: {
-                    totalSize: 1,
-                    records: [{
-                      Id: "005000000000001AAA",
-                      Name: "Test User",
-                      Email: "test@example.com",
-                      Username: "test@example.com",
-                      Alias: "tuser",
-                      IsActive: true,
-                      Profile: {
-                        Name: "System Administrator"
-                      },
-                      UserRole: {
-                        Name: "CEO"
-                      }
-                    }]
-                  }
-                }
-              ]
-            });
-            return;
-          }
-
-          // User details composite
-          if (body.compositeRequest && body.compositeRequest[0]?.url?.includes("WHERE Id='")) {
-            await fulfillSuccess(route, {
-              compositeResponse: [
-                {
-                  httpStatusCode: 200,
-                  body: {
-                    totalSize: 1,
-                    records: [{
-                      Id: "005000000000001AAA",
-                      Name: "Test User",
-                      Email: "test@example.com",
-                      Username: "test@example.com",
-                      Alias: "tuser",
-                      IsActive: true,
-                      FederationIdentifier: "test@example.com",
-                      ProfileId: "00e000000000001AAA",
-                      Profile: {
-                        Name: "System Administrator"
-                      },
-                      ContactId: null,
-                      IsPortalEnabled: false,
-                      UserPreferencesUserDebugModePref: false,
-                      UserRole: {
-                        Name: "CEO"
-                      },
-                      LocaleSidKey: "en_US",
-                      LanguageLocaleKey: "en_US"
-                    }]
-                  }
-                }
-              ]
-            });
-            return;
-          }
-
-          // Shortcut search composite (Shortcuts tab: default, "!", "!flow", "!profile", "!class", "!perm" searches)
-          if (body.compositeRequest && body.compositeRequest.some((req) => SHORTCUT_METADATA_MOCKS.some(({match}) => req.url?.includes(match)))) {
-            const compositeResponse = body.compositeRequest.map((req) => {
-              const mock = SHORTCUT_METADATA_MOCKS.find(({match}) => req.url?.includes(match));
-              return {
-                httpStatusCode: 200,
-                body: {totalSize: mock ? 1 : 0, records: mock ? [mock.record] : []}
-              };
-            });
-            await fulfillSuccess(route, {compositeResponse});
-            return;
-          }
-        }
 
         // Tooling API - TraceFlag Query
         if (url.includes("/tooling/query") && url.includes("TraceFlag")) {

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -7,6 +7,60 @@ import {
 } from "./test-helpers";
 import {routeMock} from "./test-mock";
 
+// Stub records returned by the Shortcut tab metadata composite mock, keyed by a
+// distinctive substring of the SOQL query used for each metadata type in popup.js.
+// Values mirror the real metadata deployed from test/main/ (flow, class, permission set)
+// so search terms and assertions are identical whether tests run mocked or against a real org.
+const SHORTCUT_METADATA_MOCKS = [
+  {
+    match: "FlowDefinitionView",
+    record: {
+      DurableId: "301000000000001AAA",
+      LatestVersionId: "301000000000002AAA",
+      ApiName: "RecordTrigger_InspectorTest",
+      Label: "RecordTrigger InspectorTest",
+      ProcessType: "AutoLaunchedFlow",
+      attributes: {type: "FlowDefinitionView"}
+    }
+  },
+  {
+    // PermissionSet is checked before Profile since "PermissionSet" does not contain "Profile"
+    // but both queries are otherwise disjoint; order here only matters for readability.
+    match: "PermissionSet",
+    record: {
+      Id: "0PS000000000001AAA",
+      Name: "SfInspector",
+      Label: "Sf Inspector",
+      Type: "Regular",
+      License: null,
+      PermissionSetGroupId: null,
+      attributes: {type: "PermissionSet"}
+    }
+  },
+  {
+    // Standard "System Administrator" profile exists in every org (real or scratch)
+    match: "Profile",
+    record: {
+      Id: "00e000000000001AAA",
+      Name: "System Administrator",
+      UserLicense: {Name: "Salesforce"},
+      attributes: {type: "Profile"}
+    }
+  },
+  {
+    match: "ApexClass",
+    record: {
+      Id: "01p000000000001AAA",
+      Name: "SalesforceInspectorTest",
+      NamespacePrefix: null,
+      ApiVersion: 66,
+      Status: "Active",
+      LengthWithoutComments: 100,
+      attributes: {type: "ApexClass"}
+    }
+  }
+];
+
 test.describe("Popup", () => {
   const {mockHost, mockToken, apiVersion} = TEST_CONSTANTS;
 
@@ -180,28 +234,17 @@ test.describe("Popup", () => {
             return;
           }
 
-          // Shortcut search composite
-          if (body.compositeRequest && body.compositeRequest[0]?.url?.includes("FlowDefinitionView")) {
-            await fulfillSuccess(route, {
-              compositeResponse: [
-                {
-                  httpStatusCode: 200,
-                  body: {
-                    totalSize: 1,
-                    records: [{
-                      DurableId: "301000000000001AAA",
-                      LatestVersionId: "301000000000002AAA",
-                      ApiName: "TestFlow",
-                      Label: "Test Flow",
-                      ProcessType: "AutoLaunchedFlow",
-                      attributes: {
-                        type: "FlowDefinitionView"
-                      }
-                    }]
-                  }
-                }
-              ]
+          // Shortcut search composite (Shortcuts tab: default, "!", "!flow", "!profile", "!class", "!perm" searches)
+          if (body.compositeRequest && body.compositeRequest.some((req) => SHORTCUT_METADATA_MOCKS.some(({match}) => req.url?.includes(match)))) {
+            const compositeResponse = body.compositeRequest.map((req) => {
+              const mock = SHORTCUT_METADATA_MOCKS.find(({match}) => req.url?.includes(match));
+              return {
+                httpStatusCode: 200,
+                body: {totalSize: mock ? 1 : 0, records: mock ? [mock.record] : []}
+              };
             });
+            await fulfillSuccess(route, {compositeResponse});
+            return;
           }
         }
 
@@ -304,9 +347,6 @@ test.describe("Popup", () => {
 
     //click on the button to open the popup
     await page.locator(".insext-btn").click();
-
-    // Locate the iframe by its name, id, or index
-    //const frame = await page.frame({ name: 'popup' });
 
     const frame = await page.frameLocator(".insext-popup");
 
@@ -634,6 +674,41 @@ test.describe("Popup", () => {
   });
 
   test.describe("Shortcuts Tab", () => {
+    const shortcutInputSelector = "input[placeholder*='!profile']";
+    // referenceId used in popup.js composite request for each metadata type (name + "Select")
+    const ALL_METADATA_REFERENCE_IDS = ["flowsSelect", "profilesSelect", "permissionSetsSelect", "classesSelect"];
+
+    async function openShortcutsTab(page) {
+      await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Shortcuts')").click();
+      await page.frameLocator(".insext-popup").locator(shortcutInputSelector).waitFor({timeout: 1000});
+      return page.frameLocator(".insext-popup").locator(shortcutInputSelector);
+    }
+
+    /**
+     * Captures the metadata types (referenceIds) requested via the Shortcut tab's
+     * composite search. Asserting on this (rather than on specific record content)
+     * keeps these tests valid whether mocks are enabled or tests run against a real org.
+     */
+    function captureShortcutMetadataRequests(page) {
+      const referenceIds = [];
+      const handler = (request) => {
+        if (request.method() !== "POST" || !request.url().includes("/composite")) {
+          return;
+        }
+        let body;
+        try {
+          body = JSON.parse(request.postData() || "{}");
+        } catch {
+          return;
+        }
+        (body.compositeRequest || [])
+          .filter((r) => ALL_METADATA_REFERENCE_IDS.includes(r.referenceId))
+          .forEach((r) => referenceIds.push(r.referenceId));
+      };
+      page.on("request", handler);
+      return {referenceIds, stop: () => page.off("request", handler)};
+    }
+
     test("Switch to Shortcuts Tab", async ({page, extensionId}) => {
       await initPopupPage(page, extensionId);
 
@@ -645,28 +720,120 @@ test.describe("Popup", () => {
       await expect(shortcutsTab).toHaveClass(/slds-is-active/);
 
       // Verify shortcut search input appears
-      await expect(page.frameLocator(".insext-popup").locator("input[placeholder*='Quick find']")).toBeVisible({timeout: 1000});
+      await expect(page.frameLocator(".insext-popup").locator(shortcutInputSelector)).toBeVisible({timeout: 1000});
     });
 
-    test("Search Shortcut", async ({page, extensionId}) => {
+    test("Search Shortcut (default: links + metadata)", async ({page, extensionId}) => {
       await initPopupPage(page, extensionId);
-
-      // Click Shortcuts tab
-      await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Shortcuts')").click();
-
-      // Wait for shortcut search input
-      await page.frameLocator(".insext-popup").locator("input[placeholder*='Quick find']").waitFor({timeout: 1000});
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
 
       // Type in search
-      const searchInput = page.frameLocator(".insext-popup").locator("input[placeholder*='Quick find']");
       await searchInput.fill("Flow");
+      await page.waitForTimeout(1200);
+      capture.stop();
 
-      // Wait for autocomplete results
-      await page.waitForTimeout(1000);
+      // Default search includes both setup links (e.g. "Flow Trigger Explorer") and metadata
+      await expect(page.frameLocator(".insext-popup").locator("text=Flow Trigger Explorer")).toBeVisible({timeout: 3000});
+      expect(capture.referenceIds).toContain("flowsSelect");
+    });
 
-      // Verify flow appears in results (if metadata search is enabled)
-      // Note: This depends on localStorage settings
-      await page.waitForTimeout(1000);
+    test("Search Shortcut with '/' prefix returns setup links only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "/" prefix should search setupLinks only, skipping the metadata composite call entirely
+      await searchInput.fill("/Flow Trigger");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      // Setup link shortcut is shown
+      await expect(page.frameLocator(".insext-popup").locator("text=Flow Trigger Explorer")).toBeVisible({timeout: 3000});
+
+      // No metadata composite request should have been sent at all
+      expect(capture.referenceIds).toEqual([]);
+    });
+
+    test("Search Shortcut with '!' prefix returns metadata only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "Inspector" is not a type alias, so the bare "!" prefix must query every metadata
+      // type. It also happens to match the "Sf Inspector" permission set deployed from
+      // test/main/, giving a real content assertion in addition to the referenceId check.
+      // (Note: asserting *absence* of setup links here is unreliable against a real org,
+      // since arbitrary search terms can coincidentally match unrelated real metadata.)
+      await searchInput.fill("!Inspector");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      // Bare "!" queries every metadata type, regardless of the "Searchable metadata" options
+      for (const referenceId of ALL_METADATA_REFERENCE_IDS) {
+        expect(capture.referenceIds).toContain(referenceId);
+      }
+      await expect(page.frameLocator(".insext-popup").locator("text=Sf Inspector")).toBeVisible({timeout: 3000});
+    });
+
+    test("Search Shortcut with '!flow' prefix returns flows only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "RecordTrigger_InspectorTest" is the flow deployed from test/main/ (required test prerequisite)
+      await searchInput.fill("!flow RecordTrigger");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      expect(capture.referenceIds).toEqual(["flowsSelect"]);
+      await expect(page.frameLocator(".insext-popup").locator("text=RecordTrigger InspectorTest")).toBeVisible({timeout: 3000});
+    });
+
+    test("Search Shortcut with '!profile' prefix returns profiles only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "System Administrator" is a standard profile present in every org (real or scratch)
+      await searchInput.fill("!profile System Administrator");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      expect(capture.referenceIds).toEqual(["profilesSelect"]);
+      await expect(page.frameLocator(".insext-popup").locator("text=System Administrator")).toBeVisible({timeout: 3000});
+    });
+
+    test("Search Shortcut with '!class' prefix returns Apex classes only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "SalesforceInspectorTest" is the Apex class deployed from test/main/. Also verifies the
+      // typed prefix forces the query even though "Apex Classes" is unchecked by default in
+      // "Searchable metadata from Shortcut tab" (see options.js).
+      await searchInput.fill("!class SalesforceInspectorTest");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      expect(capture.referenceIds).toEqual(["classesSelect"]);
+      // Non-namespaced Apex classes render the same name twice (label + name lines), producing
+      // two <mark> highlights for a single result row, so use .first() rather than a unique match.
+      await expect(page.frameLocator(".insext-popup").locator("text=SalesforceInspectorTest").first()).toBeVisible({timeout: 3000});
+    });
+
+    test("Search Shortcut with '!perm' prefix returns Permission Sets only", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+      const searchInput = await openShortcutsTab(page);
+      const capture = captureShortcutMetadataRequests(page);
+
+      // "Sf Inspector" is the permission set deployed from test/main/ (SfInspector.permissionset-meta.xml)
+      await searchInput.fill("!perm Sf Inspector");
+      await page.waitForTimeout(1200);
+      capture.stop();
+
+      expect(capture.referenceIds).toEqual(["permissionSetsSelect"]);
+      await expect(page.frameLocator(".insext-popup").locator("text=Sf Inspector")).toBeVisible({timeout: 3000});
     });
   });
 

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -34,7 +34,7 @@ const SHORTCUT_METADATA_MOCKS = [
       Type: "Regular",
       License: null,
       PermissionSetGroupId: null,
-      attributes: {typae: "PermissionSet"}
+      attributes: {type: "PermissionSet"}
     }
   },
   {


### PR DESCRIPTION
- Implemented search prefixes in the Shortcut tab to enhance query speed: `/` for setup links only, `!` for all metadata, and specific typed filters (`!flow`, `!profile`, `!class`, `!perm`).
- Updated documentation in `how-to.md` to reflect new search functionality and usage examples.
- Added tests to ensure correct behavior of the new search functionality.

This change addresses feature request #1265 and improves user experience by allowing more efficient searches.

# Describe your changes

## Issue ticket number and link
Closes #1265 

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [x] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [ ] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [x] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
