### PR TITLE
feat: [Data Export/Import/Show All Data] Add quick navigation shortcuts to record Id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1
 
-- `Data Export` / `Show All Data` Add quick navigation shortcuts to record Ids: `Ctrl`/`Cmd` + `Click` or middle-click to view in Salesforce, and `Ctrl`/`Cmd` + `Shift` + `Click` to open in Show All Data [feature #214](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/214) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+- `Data Import` / `Data Export` / `Show All Data` Add quick navigation shortcuts to record Ids: `Ctrl`/`Cmd` + `Click` or middle-click to view in Salesforce, and `Ctrl`/`Cmd` + `Shift` + `Click` to open in Show All Data [feature #214](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/214) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Add search prefixes to speed up Shortcut tab queries: `/` for setup links only, `!` for metadata, and typed filters (`!flow`, `!profile`, `!class`, `!perm`) [feature 1265](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1265)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` / `Show All Data` Add quick navigation shortcuts to record Ids: `Ctrl`/`Cmd` + `Click` or middle-click to view in Salesforce, and `Ctrl`/`Cmd` + `Shift` + `Click` to open in Show All Data [feature #214](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/214) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Add search prefixes to speed up Shortcut tab queries: `/` for setup links only, `!` for metadata, and typed filters (`!flow`, `!profile`, `!class`, `!perm`) [feature 1265](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1265)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` / `Show All Data` Add quick navigation shortcuts to record Ids: `Ctrl`/`Cmd` + `Click` or middle-click to view in Salesforce, and `Ctrl`/`Cmd` + `Shift` + `Click` to open in Show All Data [issue #214] (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Add search prefixes to speed up Shortcut tab queries: `/` for setup links only, `!` for metadata, and typed filters (`!flow`, `!profile`, `!class`, `!perm`) [feature 1265](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1265)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/data-load.js
+++ b/addon/data-load.js
@@ -134,16 +134,56 @@ function renderCell(rt, cell, td) {
   function popLink(recordInfo, label) {
     let a = document.createElement("a");
     a.href = "about:blank";
-    a.title = "Show all data";
+    let isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    let modKey = isMac ? "Cmd" : "Ctrl";
+    a.title = `Click: Menu\n${modKey} + Click: View in Salesforce\n${modKey} + Shift + Click: Show All Data`;
+    // Handle Middle-Click
+    a.addEventListener("auxclick", e => {
+      if (e.button === 1) {
+        e.preventDefault();
+        let {recordId} = recordInfo();
+        if (recordId && isRecordId(recordId)) {
+          window.open("https://" + rt.sfHost + "/" + recordId, "_blank");
+        }
+      }
+    });
     a.addEventListener("click", e => {
       e.preventDefault();
+      let isCmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
+      let {objectTypes, recordId} = recordInfo();
+      // Ctrl/Cmd + Shift + Click -> Show All Data
+      if (isCmdOrCtrl && e.shiftKey) {
+        if (objectTypes.length === 1 && objectTypes[0] !== "Unknown") {
+          let objectType = objectTypes[0];
+          let args = new URLSearchParams();
+          args.set("host", rt.sfHost);
+          args.set("objectType", objectType);
+          if (rt.isTooling) {
+            args.set("useToolingApi", "1");
+          }
+          if (recordId) {
+            args.set("recordId", recordId);
+          }
+          window.open("inspect.html?" + args, "_blank");
+        } else if (recordId && isRecordId(recordId)) {
+          window.open("https://" + rt.sfHost + "/" + recordId, "_blank");
+        }
+        return;
+      } 
+      // Ctrl/Cmd + Click -> View in Salesforce
+      else if (isCmdOrCtrl) {
+        if (recordId && isRecordId(recordId)) {
+          window.open("https://" + rt.sfHost + "/" + recordId, "_blank");
+        }
+        return;
+      }
+      // Default Plain Click -> Standard Pop-up Menu
       let pop = document.createElement("div");
       pop.className = "slds-dropdown slds-dropdown_left slds-dropdown_actions";
       let ul = document.createElement("ul");
       ul.className = "slds-dropdown__list";
       pop.appendChild(ul);
       td.appendChild(pop);
-      let {objectTypes, recordId} = recordInfo();
       let objectType = undefined;
       function setLinks(linkOptions = {isCopy: true, isQueryRecord: true, isShowAllData: true, isViewInSalesforce: true}) {
         // Show All Data link

--- a/addon/images/copy.svg
+++ b/addon/images/copy.svg
@@ -1,8 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-labelledby="title"
-aria-describedby="desc" role="img" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Copy</title>
-  <desc>A solid styled icon from Orion Icon Library.</desc>
-  <path data-name="layer2"
-  fill="#202020" d="M14 14h50v50H14z"></path>
-  <path data-name="layer1" fill="#202020" d="M50 0H0v50h10V10h40V0z"></path>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52">
+  <path d="M44 2H18a4 4 0 00-4 4v2h24a4 4 0 014 4v28h2a4 4 0 004-4V6a4 4 0 00-4-4z"/><path d="M38 16a4 4 0 00-4-4H8a4 4 0 00-4 4v30a4 4 0 004 4h26a4 4 0 004-4V16zm-18 7c0 .6-.4 1-1 1h-8c-.6 0-1-.4-1-1v-2c0-.6.4-1 1-1h8c.6 0 1 .4 1 1v2zm8 16c0 .6-.4 1-1 1H11c-.6 0-1-.4-1-1v-2c0-.6.4-1 1-1h16c.6 0 1 .4 1 1v2zm4-8c0 .6-.4 1-1 1H11c-.6 0-1-.4-1-1v-2c0-.6.4-1 1-1h20c.6 0 1 .4 1 1v2z"/>
 </svg>

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -2274,10 +2274,47 @@ class FieldValueCell extends React.Component {
     row.rowList.model.didUpdate();
   }
   onRecordIdClick(e) {
-    e.preventDefault();
     let {row} = this.props;
-    row.toggleRecordIdPop(this);
-    row.rowList.model.didUpdate();
+    let isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    let isCmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
+    let isMiddleClick = e.button === 1;
+    // Ctrl/Cmd + Shift + Click -> Open in Show All Data
+    if (isCmdOrCtrl && e.shiftKey) {
+      e.preventDefault();
+      let recordId = row.dataTypedValue;
+      let keyPrefix = recordId.substring(0, 3);
+      let objectName = null;
+      
+      if (row.rowList.model.globalDescribe) {
+        let matchingSobjects = row.rowList.model.globalDescribe.sobjects.filter(s => s.keyPrefix == keyPrefix);
+        if (matchingSobjects.length === 1 && matchingSobjects[0].name !== "Unknown") {
+          objectName = matchingSobjects[0].name;
+        }
+      }
+      if (objectName) {
+        let args = new URLSearchParams();
+        args.set("host", row.rowList.model.sfHost);
+        args.set("objectType", objectName);
+        if (row.rowList.model.useToolingApi) {
+          args.set("useToolingApi", "1");
+        }
+        args.set("recordId", recordId);
+        window.open("inspect.html?" + args, '_blank');
+      } else {
+        window.open(row.idLink(), '_blank');
+      }
+    } 
+    // Ctrl/Cmd + Click OR Middle-click -> Open in Salesforce
+    else if (isCmdOrCtrl || isMiddleClick) {
+      e.preventDefault();
+      window.open(row.idLink(), '_blank');
+    } 
+    // Plain Left Click -> Open standard Pop-up Menu
+    else if (e.button === 0) {
+      e.preventDefault();
+      row.toggleRecordIdPop(this);
+      row.rowList.model.didUpdate();
+    }
   }
   onLinkClick(e) {
     if (e.target.className?.includes("copy-id")) {
@@ -2322,7 +2359,14 @@ class FieldValueCell extends React.Component {
     } else if (row.isId()) {
       return h("td", {className: col.className, onDoubleClick: this.onTryEdit},
         h("div", {className: "pop-menu-container"},
-          h("div", {className: "sfir-inspect-table-text quick-select"}, h("a", {href: row.idLink() /*used to show visited color*/, onClick: this.onRecordIdClick}, row.dataStringValue())),
+          h("div", {className: "sfir-inspect-table-text quick-select"}, 
+            h("a", {
+              href: row.idLink(), /*used to show visited color*/
+              onClick: this.onRecordIdClick,
+              onAuxClick: this.onRecordIdClick,
+              title: "Click: Menu\nCtrl/Cmd + Click: View in Salesforce\nCtrl/Cmd + Shift + Click: Show All Data"
+            }, row.dataStringValue())
+          ),
           row.recordIdPop == null ? null : h("div", {className: "slds-dropdown slds-dropdown_left slds-dropdown_actions pop-menu"},
             h("ul", {className: "slds-dropdown__list"},
               row.recordIdPop.map(link =>

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -2347,6 +2347,9 @@ class FieldValueCell extends React.Component {
   }
   render() {
     let {row, col} = this.props;
+    let isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    let modKey = isMac ? "Cmd" : "Ctrl";
+    let tooltipTitle = `Click: Menu\n${modKey} + Click: View in Salesforce\n${modKey} + Shift + Click: Show All Data`;
     if (row.isEditing()) {
       return h("td", {className: col.className},
         h("textarea", {value: row.dataEditValue, onChange: this.onDataEditValueInput, onKeyDown: this.onKeyDown}),
@@ -2364,7 +2367,7 @@ class FieldValueCell extends React.Component {
               href: row.idLink(), /*used to show visited color*/
               onClick: this.onRecordIdClick,
               onAuxClick: this.onRecordIdClick,
-              title: "Click: Menu\nCtrl/Cmd + Click: View in Salesforce\nCtrl/Cmd + Shift + Click: Show All Data"
+              title: tooltipTitle
             }, row.dataStringValue())
           ),
           row.recordIdPop == null ? null : h("div", {className: "slds-dropdown slds-dropdown_left slds-dropdown_actions pop-menu"},


### PR DESCRIPTION
# Describe your changes
This PR introduces quick navigation shortcuts for Record Ids to streamline workflows without requiring an extra click through the tooltip menu.

Add keyboard/mouse shortcuts for record-id links: `Ctrl/Cmd+Click` opens the record in Salesforce, `Ctrl/Cmd+Shift+Click` opens Show All Data (when object is known) and middle-click opens the record in a new tab.

Note on Shortcut Mapping vs. Original Request (#214):
The original request suggested using `Ctrl/Cmd + Click` or right-click to open Show All Data. However, this implementation uses `Ctrl/Cmd + Shift + Click` for Show All Data and reserves `Ctrl/Cmd + Click` (and Middle-click) for opening the record in Salesforce.

Why? In standard web behavior, `Ctrl/Cmd + Click` and Middle-click are universally expected to open a link's primary `href` in a new tab. Overriding this muscle memory to open the Inspector's Show All Data page instead would frustrate users expecting standard browser behavior. Adding `Shift` provides a dedicated power-user shortcut while keeping the native web experience intact.

Changes Implemented:
These changes are reflected in both Data Export and Show All Data:
- `Ctrl/Cmd + Click`: Opens the record directly in Salesforce (standard browser behavior).
- `Middle-Click`: Opens the record directly in Salesforce (standard browser behavior).
- `Ctrl/Cmd + Shift + Click`: Opens the record directly in the Show All Data page.
- Plain `Left-Click`: Remains unchanged (opens the standard pop-up menu).

Need to update for `View in Salesforce` after #1242

## Issue ticket number and link
Closes #1362
Closes #214
Supersedes #1261

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
