### PR TITLE
Fix: [Dependencies Explorer] Salesforce links for Object Manager metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 ## Version 2.1
 
+- `Dependencies Explorer` Fix broken Salesforce setup links for Object Manager metadata records [issue #1278](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1278) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fix language flag icons for Catalan and Basque on the Users tab [issue #1196](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1196)
 - `Custom Shortcuts` Add "Global" toggle to share a shortcut across all orgs instead of keeping it specific to the current org [feature 191](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/191)
-- `Typo Fix` Fix Dependencies Explorer Typo  [issue #1276](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1276) (contribution by [Divyanshu Bist](https://github.com/DivyanshuBist)
+- `Typo Fix` Fix Dependencies Explorer Typo  [issue #1276](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1276) (contribution by [Divyanshu Bist](https://github.com/DivyanshuBist))
 - `Popup` Add search prefixes to speed up Shortcut tab queries: `/` for setup links only, `!` for metadata, and typed filters (`!flow`, `!profile`, `!class`, `!perm`) [feature 1265](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1265)
 - `Data Export` Fixed Field Suggestions label visibility [issue #1255](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1255) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fixed search icon spacing on the Objects, Shortcuts, and Users tabs [#1227](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1227) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/dependencies-explorer.js
+++ b/addon/dependencies-explorer.js
@@ -1,6 +1,6 @@
 /* global React ReactDOM */
 import {sfConn, apiVersion} from "./inspector.js";
-import {UserInfoModel, createSpinForMethod, isRecordId, generatePackageXml} from "./utils.js";
+import {UserInfoModel, createSpinForMethod, isRecordId, generatePackageXml, getSalesforceViewLink, getObjectManagerParent} from "./utils.js";
 import {PageHeader} from "./components/PageHeader.js";
 /* global initButton */
 
@@ -627,12 +627,19 @@ class Model {
       type: this.selectedMetadataItem.type
     };
 
+    // Fetch parent object for the entry point so the main header link works
+    if (entryPoint.id) {
+        getObjectManagerParent(entryPoint.id).then(parent => {
+            if (parent) this.lastAnalyzedItem.parentObject = parent;
+        }).catch(err => console.warn(err));
+    }
+
     // Fetch both directions in parallel
     Promise.all([
       this._getDependencies(entryPoint, "dependsOn").then(async deps => {
         let enhanced = await this._enhanceCustomFieldData(deps);
         let unsupported = await this._createUnsupportedDependencies(enhanced);
-        return [...enhanced, ...unsupported];
+        return await this._enhanceWithParentObjects([...enhanced, ...unsupported]);
       }).catch(err => {
         console.warn('Error fetching "depends on" dependencies:', err);
         return [];
@@ -640,7 +647,7 @@ class Model {
       this._getDependencies(entryPoint, "dependedOnBy").then(async deps => {
         let enhanced = await this._enhanceCustomFieldData(deps);
         let unsupported = await this._createUnsupportedDependencies(enhanced);
-        return [...enhanced, ...unsupported];
+        return await this._enhanceWithParentObjects([...enhanced, ...unsupported]);
       }).catch(err => {
         console.warn('Error fetching "depended on by" dependencies:', err);
         return [];
@@ -840,6 +847,31 @@ class Model {
       });
     }
     return newDependencies;
+  }
+
+  async _enhanceWithParentObjects(dependencies) {
+    const uniqueIds = new Set();
+    dependencies.forEach(dep => {
+      if (dep.id) uniqueIds.add(dep.id);
+      if (dep.referencedBy && dep.referencedBy.id) uniqueIds.add(dep.referencedBy.id);
+    });
+
+    const parentMap = new Map();
+    await Promise.all(
+      Array.from(uniqueIds).map(async id => {
+        const parent = await getObjectManagerParent(id);
+        if (parent) parentMap.set(id, parent);
+      })
+    );
+
+    dependencies.forEach(dep => {
+      if (dep.id) dep.parentObject = parentMap.get(dep.id);
+      if (dep.referencedBy && dep.referencedBy.id) {
+        dep.referencedBy.parentObject = parentMap.get(dep.referencedBy.id);
+      }
+    });
+
+    return dependencies;
   }
 
   // --- Helper functions for metadata lookups ---
@@ -1696,58 +1728,43 @@ ${(() => {
     return !dep.id || dep.type === "ExternalReference" || dep.type === "DynamicReference";
   }
 
-  _buildSalesforceUrl(targetType, targetId, dep) {
-    const baseUrl = `https://${this.sfHost}`;
-
-    const urlTemplates = {
-      "ApexClass": `${baseUrl}/lightning/setup/ApexClasses/page?address=%2F${targetId}`,
-      "ApexTrigger": `${baseUrl}/lightning/setup/ApexTriggers/page?address=%2F${targetId}`,
-      "CustomObject": `${baseUrl}/lightning/setup/ObjectManager/${targetId}/Details/view`,
-      "CustomField": this._buildCustomFieldUrl(baseUrl, targetId, dep),
-      "ApexPage": `${baseUrl}/lightning/setup/VisualforcePages/page?address=%2F${targetId}`,
-      "ApexComponent": `${baseUrl}/lightning/setup/VisualforceComponents/page?address=%2F${targetId}`,
-      "StaticResource": `${baseUrl}/lightning/setup/StaticResources/page?address=%2F${targetId}`,
-      "LightningComponent": `${baseUrl}/lightning/setup/LightningComponents/page?address=%2F${targetId}`,
-      "ValidationRule": `${baseUrl}/lightning/setup/ObjectManager/${targetId}/ValidationRules/view`,
-      "CustomLabel": `${baseUrl}/lightning/setup/CustomLabels/page?address=%2F${targetId}`,
-      "Flow": `${baseUrl}/lightning/setup/Flows/page?address=%2F${targetId}`,
-      "LightningWebComponent": `${baseUrl}/lightning/setup/LightningWebComponents/page?address=%2F${targetId}`,
-      "EmailTemplate": `${baseUrl}/lightning/setup/EmailTemplates/page?address=%2F${targetId}`,
-      "WorkflowAlert": `${baseUrl}/lightning/setup/WorkflowAlerts/page?address=%2F${targetId}`,
-      "WebLink": `${baseUrl}/lightning/setup/ObjectManager/${targetId}/ButtonsLinksAndActions/view`,
-      "Layout": `${baseUrl}/lightning/setup/ObjectManager/${targetId}/PageLayouts/view`,
-      "FlexiPage": `${baseUrl}/lightning/setup/FlexiPages/page?address=%2F${targetId}`,
-      "GlobalPicklist": `${baseUrl}/lightning/setup/GlobalPicklists/page?address=%2F${targetId}`
-    };
-
-    return urlTemplates[targetType] || null;
-  }
-
-  _buildCustomFieldUrl(baseUrl, targetId, dep) {
-    // For custom fields, we need to get the object ID first
-    if (dep.name && dep.name.includes(".")) {
-      const [objectName, fieldName] = dep.name.split(".");
-      return `${baseUrl}/lightning/setup/ObjectManager/${objectName}/FieldsAndRelationships/${targetId}/view`;
-    }
-    return `${baseUrl}/lightning/setup/ObjectManager/${targetId}/FieldsAndRelationships/view`;
-  }
-
   generateSalesforceUrl(dep) {
-    // For Depends On: use dep.id (the dependency item)
-    // For Referenced By: use dep.referencedBy.id (the item that references this)
-    let targetId, targetType;
+    let targetId, parentObj, targetType;
 
     if (this.currentFilter === "dependedOnBy") {
-      // Referenced By: link to the item that references this
       targetId = dep.referencedBy ? dep.referencedBy.id : dep.id;
+      parentObj = dep.referencedBy ? dep.referencedBy.parentObject : dep.parentObject;
       targetType = dep.referencedBy ? dep.referencedBy.type : dep.type;
     } else {
-      // Depends On: link to the dependency item itself
       targetId = dep.id;
+      parentObj = dep.parentObject;
       targetType = dep.type;
     }
 
-    return this._buildSalesforceUrl(targetType, targetId, dep);
+    // Only enable the "Open in Salesforce" link for these specific metadata types.
+    const supportedTypes = [
+      "ApexClass", "ApexTrigger", "CustomObject", "CustomField", 
+      "ApexPage", "ApexComponent", "StaticResource", "LightningComponent", 
+      "ValidationRule", "CustomLabel", "Flow", "LightningWebComponent", 
+      "WorkflowAlert", "WebLink", "Layout", "FlexiPage", "GlobalPicklist"
+    ];
+
+    if (!targetId || !supportedTypes.includes(targetType)) {
+      return null;
+    }
+
+    // Fallback parsing from name (e.g. Account.MyField) if parentObj isn't dynamically resolved
+    if (!parentObj) {
+      const nameToParse = this.currentFilter === "dependedOnBy"
+        ? (dep.referencedBy ? dep.referencedBy.name : dep.name)
+        : dep.name;
+
+      if (nameToParse && nameToParse.includes(".")) {
+        parentObj = nameToParse.split(".")[0];
+      }
+    }
+
+    return getSalesforceViewLink(this.sfHost, targetId, parentObj);
   }
 
   /**
@@ -2592,7 +2609,8 @@ class App extends React.Component {
                 const url = model.generateSalesforceUrl({
                   id: item.id,
                   type: item.type,
-                  name: item.fullName
+                  name: item.fullName,
+                  parentObject: item.parentObject
                 });
                 if (url) {
                   return [

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -582,6 +582,117 @@ export function getFlowCompareUrl(sfHost, recordId) {
 }
 
 /**
+ * Generates a Salesforce URL for viewing a record, using hardcoded setup-page
+ * routes for record types whose standard `/id` redirect is broken.
+ * Falls back to the standard record URL for anything not in the map.
+ * @param {string} sfHost - Salesforce host (e.g. "myorg.lightning.force.com").
+ * @param {string} recordId - The 15/18-char record Id.
+ * @param {string} [parentObjectIdentifier] - Parent object API name or DurableId
+ * @returns {string} Full URL to open the record/metadata in Salesforce.
+ */
+export function getSalesforceViewLink(sfHost, recordId, parentObjectIdentifier) {
+  const prefix = recordId.substring(0, 3);
+  const origin = "https://" + sfHost;
+  const baseUrl = origin + "/lightning/setup";
+
+  switch (prefix) {
+    // --- Setup ---
+    case "01p": return `${baseUrl}/ApexClasses/page?address=%2F${recordId}`; // Apex Class
+    case "07L": return `${origin}/one/one.app#/alohaRedirect/p/setup/layout/ApexDebugLogDetailEdit/d?apex_log_id=${recordId}`; // Apex Debug Log
+    case "00e": return `${baseUrl}/Profiles/page?address=%2F${recordId}`; // Profile
+    case "00E": return `${baseUrl}/Roles/page?address=%2F${recordId}`; // Role
+    case "0PS": return `${baseUrl}/PermSets/page?address=%2F${recordId}`; // Permission Set
+    case "0PG": return `${baseUrl}/PermSetGroups/page?address=%2F${recordId}`; // Permission Set Group
+    case "00G": return `${baseUrl}/PublicGroups/page?address=%2Fp%2Fown%2FQueue%2Fd%3Fid%3D${recordId}`; // Public Group / Queue
+    case "0MI": return `${baseUrl}/Territory2Models/page?address=%2F${recordId}`; // Territory2
+    case "0MA": return `${baseUrl}/Territory2Models/page?address=%2F${recordId}`; // Territory2 Model
+    case "300": return `${baseUrl}/Flows/page?address=%2F${recordId}`; // Flow Details & Versions
+    case "301": return `${baseUrl}/Flows/page?address=%2F${recordId}`; // Flow Details
+    case "01Q": return `${baseUrl}/WorkflowRules/page?address=%2F${recordId}`; // Workflow Rule
+    case "01W": return `${baseUrl}/WorkflowAlerts/page?address=%2F${recordId}`; // Workflow Email Alert
+    case "04Y": return `${baseUrl}/WorkflowFieldUpdates/page?address=%2F${recordId}`; // Workflow Field Update
+    case "04a": return `${baseUrl}/ApprovalProcesses/page?address=%2F${recordId}`; // Approval Process
+    case "0Nt": return `${baseUrl}/Picklists/page?address=%2F${recordId}`; // Global Value Set
+    case "101": return `${baseUrl}/CustomLabels/page?address=%2F${recordId}`; // Custom Label
+    case "081": return `${baseUrl}/StaticResources/page?address=%2F${recordId}`; // Static Resource
+    case "00X": return `${baseUrl}/CommunicationTemplatesEmail/page?address=%2F${recordId}`; // Email Template
+    case "066": return `${baseUrl}/ApexPages/page?address=%2F${recordId}`; // Visualforce Page
+    case "099": return `${baseUrl}/ApexComponents/page?address=%2F${recordId}`; // Visualforce Component
+    case "0Ab": return `${baseUrl}/LightningComponentBundles/page?address=%2F${recordId}`; // Aura Component
+    case "0Rb": return `${baseUrl}/LightningComponentBundles/page?address=%2F${recordId}`; // Lightning Web Component (LWC)
+    case "01r": return `${baseUrl}/CustomTabs/page?address=%2F${recordId}`; // Custom Tab
+    case "01I": return `${baseUrl}/ObjectManager/${recordId}/Details/view`; // Custom Object
+
+    // --- Object Manager ---
+    case "00N": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/FieldsAndRelationships/${recordId}/view`; // Field
+    case "00h": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/PageLayouts/${recordId}/view`; // Page Layout
+    case "0M0": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/LightningPages/${recordId}/view`; // Lightning Record Page
+    case "00b": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/ButtonsLinksActions/${recordId}/view`; // Button / Link / Action
+    case "0AH": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/CompactLayouts/${recordId}/view`; // Compact Layout
+    case "0IX": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/FieldSets/${recordId}/view`; // Field Set
+    case "012": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/RecordTypes/${recordId}/view`; // Record Type
+    case "01q": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/ApexTriggers/${recordId}/view`; // Apex Trigger
+    case "03d": return `${baseUrl}/ObjectManager/${parentObjectIdentifier}/ValidationRules/${recordId}/view`; // Validation Rule
+
+    default: return `${origin}/${recordId}`;
+  }
+}
+
+/**
+ * For each Object Manager-scoped metadata type (keyed by the 3-char Id prefix),
+ * the Tooling API sobject to query and the field on it that identifies the
+ * SObject it belongs to. That field's value is already in the exact format
+ * getSalesforceViewLink's parentObjectIdentifier needs: the API name for
+ * standard objects, or the owning custom object's EntityDefinition DurableId
+ * for custom objects - never the type of the metadata record itself.
+ */
+const OBJECT_MANAGER_PARENT_LOOKUP = {
+  "00N": {sobject: "CustomField", field: "TableEnumOrId"}, // Field
+  "00h": {sobject: "Layout", field: "TableEnumOrId"}, // Page Layout
+  "0M0": {sobject: "FlexiPage", field: "EntityDefinitionId"}, // Lightning Record Page
+  "00b": {sobject: "WebLink", field: "EntityDefinitionId"}, // Button / Link / Action
+  "0AH": {sobject: "CompactLayout", field: "SobjectType"}, // Compact Layout
+  "0IX": {sobject: "FieldSet", field: "EntityDefinitionId"}, // Field Set
+  "012": {sobject: "RecordType", field: "SobjectType"}, // Record Type
+  "01q": {sobject: "ApexTrigger", field: "TableEnumOrId"}, // Apex Trigger
+  "03d": {sobject: "ValidationRule", field: "EntityDefinitionId"}, // Validation Rule
+};
+
+// recordId -> resolved parent object (or null). Metadata doesn't change which
+// object it belongs to without changing Id, so this never needs to expire.
+const objectManagerParentCache = new Map();
+
+/**
+ * Resolves the SObject that owns an Object Manager-scoped metadata record,
+ * for use as getSalesforceViewLink's parentObjectIdentifier argument. Returns null
+ * (without any API call) for record Ids that aren't one of these metadata types,
+ * since getSalesforceViewLink ignores parentObjectIdentifier for everything else.
+ * @param {string} recordId - The 15/18-char record Id of the metadata record.
+ * @returns {Promise<string|null>} The parent object's API name (standard) or
+ *  EntityDefinition DurableId (custom), or null if not applicable/found.
+ */
+export async function getObjectManagerParent(recordId) {
+  const prefix = recordId.substring(0, 3);
+  const lookup = OBJECT_MANAGER_PARENT_LOOKUP[prefix];
+  if (!lookup) {
+    return null;
+  }
+  if (objectManagerParentCache.has(recordId)) {
+    return objectManagerParentCache.get(recordId);
+  }
+  try {
+    const query = `SELECT ${lookup.field} FROM ${lookup.sobject} WHERE Id = '${recordId}'`;
+    const res = await sfConn.rest(`/services/data/v${apiVersion}/tooling/query/?q=${encodeURIComponent(query)}`);
+    const parent = (res && res.records && res.records[0]) ? res.records[0][lookup.field] : null;
+    objectManagerParentCache.set(recordId, parent);
+    return parent;
+  } catch (err) {
+    console.error("getObjectManagerParent", err);
+    return null;
+  }
+}
+
+/**
  * Downloads a CSV file with optional UTF-8 BOM for Excel compatibility
  * @param {string} csvContent - The CSV content to download
  * @param {string} filename - The filename for the downloaded file


### PR DESCRIPTION
# Describe your changes

Resolve broken Object Manager setup links by centralizing Salesforce URL generation and resolving parent objects. Added utils.getSalesforceViewLink and getObjectManagerParent (with tooling lookups and a cache) and updated the Dependencies Explorer model to fetch/enhance dependencies with parentObject info. Replaced per-type URL builders with getSalesforceViewLink, added fallback name parsing, and updated CHANGES.md release notes.


## Issue ticket number and link

Closes #1278

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
