### PR TITLE
Fix Users tab details not displayed for users without Manage Users permission

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Fix missing user details card (LoginAs buttons) on the Users tab for users without the "Manage Users" permission [discussion #1270](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1270)
 - `Metadata` Add 'Run Relevant Tests' option to metadata deploy Test Level picklist [feature 1286](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1286)
 - `Popup` Fix language flag icons for Catalan and Basque on the Users tab [issue #1196](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1196)
 - `Custom Shortcuts` Add "Global" toggle to share a shortcut across all orgs instead of keeping it specific to the current org [feature 191](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/191)

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1327,6 +1327,7 @@ class AllDataBoxUsers extends React.PureComponent {
     this.state = {
       selectedUser: null,
       selectedUserId: null,
+      selectedUserError: null,
       userSearchFields,
       excludeInactiveUsersFromSearch,
       excludePortalUsersFromSearch,
@@ -1529,7 +1530,7 @@ class AllDataBoxUsers extends React.PureComponent {
 
   async onDataSelect(userRecord) {
     if (userRecord && userRecord.Id) {
-      await this.setState({selectedUserId: userRecord.Id, selectedUser: null});
+      await this.setState({selectedUserId: userRecord.Id, selectedUser: null, selectedUserError: null});
       await this.querySelectedUserDetails();
     }
   }
@@ -1545,11 +1546,29 @@ class AllDataBoxUsers extends React.PureComponent {
     // leverage USER_MODE to get the user details with fields that are not accessible by the regular API
     const hasProfileId = await this.hasFieldAccess("ProfileId");
     const hasIsPortalEnabled = await this.hasFieldAccess("IsPortalEnabled");
-    const querySelect = "SELECT Id, Name, Email, Username, UserRole.Name, Alias, LocaleSidKey, LanguageLocaleKey, IsActive, FederationIdentifier, ContactId, UserPreferencesUserDebugModePref, (SELECT Id, IsFrozen FROM UserLogins LIMIT 1)" + (hasProfileId ? ", ProfileId, Profile.Name" : "") + (hasIsPortalEnabled ? ", IsPortalEnabled" : "") + " FROM User WHERE Id='" + selectedUserId + "' WITH USER_MODE LIMIT 1";
+    const querySelect = "SELECT Id, Name, Email, Username, UserRole.Name, Alias, LocaleSidKey, LanguageLocaleKey, IsActive, FederationIdentifier, ContactId, UserPreferencesUserDebugModePref" + (hasProfileId ? ", ProfileId, Profile.Name" : "") + (hasIsPortalEnabled ? ", IsPortalEnabled" : "");
+    const queryFrom = " FROM User WHERE Id='" + selectedUserId + "' WITH USER_MODE LIMIT 1";
+    // Reading UserLogins requires the Manage Users permission; with USER_MODE the whole query fails without it, so retry without the subquery
+    const queries = [
+      querySelect + ", (SELECT Id, IsFrozen FROM UserLogins LIMIT 1)" + queryFrom,
+      querySelect + queryFrom
+    ];
 
     try {
       setIsLoading(true);
-      const userResult = await sfConn.rest("/services/data/v" + apiVersion + "/query/?q=" + encodeURIComponent(querySelect));
+      let userResult;
+      for (let i = 0; i < queries.length; i++) {
+        try {
+          userResult = await sfConn.rest("/services/data/v" + apiVersion + "/query/?q=" + encodeURIComponent(queries[i]));
+          break;
+        } catch (err) {
+          console.error("Unable to query user details:", err);
+          if (i == queries.length - 1) {
+            this.setState({selectedUserError: "Unable to query user details. Your user may lack read access to some User fields."});
+            return;
+          }
+        }
+      }
       let userDetail = userResult.records[0];
       userDetail.debugModeActionLabel = userDetail.UserPreferencesUserDebugModePref ? "Disable" : "Enable";
       //query NetworkMember only if it is a portal user (display "Login to Experience" button)
@@ -1558,6 +1577,9 @@ class AllDataBoxUsers extends React.PureComponent {
           if (res.records && res.records.length > 0){
             userDetail.NetworkId = res.records[0].NetworkId;
           }
+        }).catch(err => {
+          //not blocking, the user details can be displayed without the "Login to Experience" button
+          console.error("Unable to query NetworkMember:", err);
         });
       }
       await this.setState({selectedUser: userDetail});
@@ -1602,7 +1624,7 @@ class AllDataBoxUsers extends React.PureComponent {
   }
 
   render() {
-    let {selectedUser, filterDropdownOpen, excludePortalUsersFromSearch, excludeInactiveUsersFromSearch} = this.state;
+    let {selectedUser, selectedUserError, filterDropdownOpen, excludePortalUsersFromSearch, excludeInactiveUsersFromSearch} = this.state;
     let {sfHost, linkTarget, contextOrgId, contextUserId, contextPath}
       = this.props;
 
@@ -1684,7 +1706,7 @@ class AllDataBoxUsers extends React.PureComponent {
             contextPath,
             showToast: this.props.showToast,
           })
-          : h("div", {className: "center"}, "No user details available")
+          : h("div", {className: "center"}, selectedUserError || "No user details available")
       )
     );
   }

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -673,6 +673,63 @@ test.describe("Popup", () => {
       // Note: Clicking this will trigger API calls, but we'll just verify the button exists
       await expect(enableLogsButton).toBeEnabled();
     });
+
+    test("Login As Buttons", async ({page, extensionId}) => {
+      await initPopupPage(page, extensionId);
+
+      // Click Users tab
+      await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
+
+      // Wait for user search input
+      await page.frameLocator(".insext-popup").locator("input[placeholder*='Name, username']").waitFor({timeout: 1000});
+
+      // Type and select a user (a different user than the logged-in one)
+      const searchInput = page.frameLocator(".insext-popup").locator("input[placeholder*='Name, username']");
+      await searchInput.fill(TEST_CONSTANTS.testUserSearchTerm);
+      await page.waitForTimeout(1000);
+      await page.frameLocator(".insext-popup").locator(".slds-dropdown__item:has-text('" + TEST_CONSTANTS.testUserSearchTerm + "')").first().click();
+
+      // Wait for user details to load
+      await page.waitForTimeout(2000);
+
+      // Verify LoginAs and Incognito buttons appear
+      await expect(page.frameLocator(".insext-popup").locator("a:has-text('LoginAs')")).toBeVisible({timeout: 1000});
+      await expect(page.frameLocator(".insext-popup").locator("a:has-text('Incognito')")).toBeVisible({timeout: 1000});
+    });
+
+    test("Login As Buttons without UserLogins access", async ({page, extensionId}) => {
+      // Simulate a user without the Manage Users permission: with USER_MODE, the
+      // UserLogins subquery fails the whole user details query (discussion #1270).
+      // The extension should fall back to a query without the subquery.
+      await page.route(/\/query\/\?q=[^&]*UserLogins/, route =>
+        route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify([{message: "sObject type 'UserLogin' is not supported.", errorCode: "INVALID_TYPE"}])
+        })
+      );
+
+      await initPopupPage(page, extensionId);
+
+      // Click Users tab
+      await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
+
+      // Wait for user search input
+      await page.frameLocator(".insext-popup").locator("input[placeholder*='Name, username']").waitFor({timeout: 1000});
+
+      // Type and select a user
+      const searchInput = page.frameLocator(".insext-popup").locator("input[placeholder*='Name, username']");
+      await searchInput.fill(TEST_CONSTANTS.testUserSearchTerm);
+      await page.waitForTimeout(1000);
+      await page.frameLocator(".insext-popup").locator(".slds-dropdown__item:has-text('" + TEST_CONSTANTS.testUserSearchTerm + "')").first().click();
+
+      // Wait for user details to load
+      await page.waitForTimeout(2000);
+
+      // The details card and LoginAs buttons should still be displayed
+      await expect(page.frameLocator(".insext-popup").locator("a:has-text('LoginAs')")).toBeVisible({timeout: 1000});
+      await expect(page.frameLocator(".insext-popup").locator("a:has-text('Incognito')")).toBeVisible({timeout: 1000});
+    });
   });
 
   test.describe("Shortcuts Tab", () => {

--- a/tests/e2e/test-mock.js
+++ b/tests/e2e/test-mock.js
@@ -511,13 +511,43 @@ export async function routeMock(route, host) {
       }
 
       // REST API - User Query (for Users tab)
+      // The searched user Id differs from the logged-in user (005000000000001AAA)
+      // so that the LoginAs buttons are rendered on the user details card
       if (query.includes(" from user") || query.includes("from+users")) {
+        // User details query (by Id); UserLogins is only returned when the subquery was requested
+        if (query.includes("where id='005000000000002aaa'")) {
+          const userDetail = {
+            Id: "005000000000002AAA",
+            Name: TEST_CONSTANTS.testUserSearchTerm,
+            Email: "integration@example.com",
+            Username: "integration@example.com",
+            Alias: "intuser",
+            IsActive: true,
+            FederationIdentifier: null,
+            ContactId: null,
+            UserPreferencesUserDebugModePref: false,
+            ProfileId: "00e000000000001AAA",
+            Profile: {Name: "System Administrator"},
+            UserRole: {Name: "CEO"},
+            LocaleSidKey: "en_US",
+            LanguageLocaleKey: "en_US"
+          };
+          if (query.includes("userlogins")) {
+            userDetail.UserLogins = {totalSize: 1, done: true, records: [{Id: "0Yw000000000001AAA", IsFrozen: false}]};
+          }
+          await fulfillSuccess(route, {
+            totalSize: 1,
+            done: true,
+            records: [userDetail]
+          });
+          return true;
+        }
         await fulfillSuccess(route, {
-          totalSize: 2,
+          totalSize: 1,
           done: true,
           records: [
             {
-              Id: "005000000000001AAA",
+              Id: "005000000000002AAA",
               Name: TEST_CONSTANTS.testUserSearchTerm,
               Email: "integration@example.com",
               Username: "integration@example.com",


### PR DESCRIPTION
UPDATE: Hardens code but does not resolve #1270 and #1282

## Fix
- `querySelectedUserDetails` retries the query **without the `UserLogins` subquery** when the full query fails (the frozen-user check just degrades gracefully for non-admins).
- If both queries fail, a visible message is shown in the popup instead of an empty card.
- The `NetworkMember` follow-up query (portal users) is now non-blocking too, so a permission error there no longer hides the card.

## Tests
Two new mocked Playwright tests in `popup.spec.js`:
- **Login As Buttons** — asserts the LoginAs/Incognito buttons render when selecting another active user (the mock previously used the same Id for the searched and logged-in user, so this path was never covered).
- **Login As Buttons without UserLogins access** — simulates the Manage Users permission failure (400 on the `UserLogins` query) and asserts the buttons still render via the fallback. This test fails without the fix.

`npm run test:e2e:mock -- popup.spec.js`: 29/29 pass. No new eslint errors.

