### PR TITLE
WIP/evidence: browser-aware Playwright fixtures + working Firefox extension install (blocked upstream)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "eslint-plugin-react": "^7.37.2",
         "fs-extra": "11.2.0",
         "globals": "^15.12.0",
+        "playwright-webextext": "^0.0.5",
         "replace-in-file": "8.2.0",
         "zip-dir": "2.0.0"
       }
@@ -2623,6 +2624,28 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright-webextext": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/playwright-webextext/-/playwright-webextext-0.0.5.tgz",
+      "integrity": "sha512-PhlMiWOfP8UmYTAbzR7uv09Twz+bkLqsgz/8EVcZROq7C6hgepJFYHD+pw4qFLK8mVGNv88N82yTdRdJDDgtdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.0.0",
+        "playwright": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-react": "^7.37.2",
     "fs-extra": "11.2.0",
     "globals": "^15.12.0",
+    "playwright-webextext": "^0.0.5",
     "replace-in-file": "8.2.0",
     "zip-dir": "2.0.0"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,11 +39,11 @@ export default defineConfig({
     },
     {
       name: "firefox",
+      // The extension is preinstalled in a Firefox profile prepared by
+      // playwright.global-setup.js; tests/e2e/fixtures.js launches a
+      // persistent context on a per-worker copy of that profile.
       use: {
         ...devices["Desktop Firefox"],
-        launchOptions: {
-          args: ["--profile", path.join(process.cwd(), "target/firefox-profile")],
-        },
       },
     },
   ],

--- a/playwright.global-setup.js
+++ b/playwright.global-setup.js
@@ -1,10 +1,15 @@
 import fs from "fs-extra";
-import path from "path";
+
+export const FIREFOX_EXTENSION_ID = "salesforceinspector@reloaded";
+// Fixed internal UUID seeded via extensions.webextensions.uuids so the
+// moz-extension:// origin is deterministic across test runs.
+export const FIREFOX_EXTENSION_UUID = "9c04c81d-73d5-4a34-8feb-1c4bcd571c4a";
 
 export default async function globalSetup() {
   const addonTarget = "target/firefox-test";
-  const profileDir = "target/firefox-profile";
 
+  // Build an unpacked Firefox version of the addon; tests/e2e/fixtures.js
+  // installs it as a temporary add-on (no signing required) at browser launch
   fs.emptyDirSync(addonTarget);
   fs.copySync("addon", addonTarget, {
     filter(src) {
@@ -14,15 +19,4 @@ export default async function globalSetup() {
   });
   fs.copySync("addon/manifest-firefox.json", `${addonTarget}/manifest.json`);
   fs.removeSync(`${addonTarget}/manifest-firefox.json`);
-
-  // Install extension into a Firefox profile using the gecko extension ID as folder name
-  const extInstallDir = path.join(profileDir, "extensions", "salesforceinspector@reloaded");
-  fs.emptyDirSync(extInstallDir);
-  fs.copySync(addonTarget, extInstallDir);
-
-  fs.ensureDirSync(profileDir);
-  fs.writeFileSync(
-    path.join(profileDir, "prefs.js"),
-    'user_pref("extensions.autoDisableScopes", 0);\n'
-  );
 }

--- a/tests/e2e/data-export.spec.js
+++ b/tests/e2e/data-export.spec.js
@@ -34,8 +34,8 @@ test.describe("Data Export", () => {
     });
   });
 
-  test("Execute Simple Export", async ({page, context, extensionId}) => {
-    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+  test("Execute Simple Export", async ({page, context, extensionUrl}) => {
+    await page.goto(`${extensionUrl}/data-export.html?host=${mockHost}`);
 
     // Wait for the query box to appear
     await page.waitForSelector("textarea#query", {timeout: 2000});
@@ -71,8 +71,8 @@ test.describe("Data Export", () => {
     await expect(firstDataRow.locator("td").nth(2)).toContainText("Test Account 1");
   });
 
-  test("Autocomplete Suggestions", async ({page, context, extensionId}) => {
-    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+  test("Autocomplete Suggestions", async ({page, context, extensionUrl}) => {
+    await page.goto(`${extensionUrl}/data-export.html?host=${mockHost}`);
     await page.waitForSelector("textarea#query", {timeout: 2000});
 
     const queryInput = page.locator("textarea#query");
@@ -127,11 +127,11 @@ test.describe("Data Export", () => {
     await expect(queryInput).toHaveValue("SELECT Id, Name FROM Account");
   });
 
-  test("Copy as CSV", async ({page, context, extensionId}) => {
+  test("Copy as CSV", async ({page, context, extensionUrl}) => {
     // Grant clipboard permissions to browser context
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-    await page.goto(`chrome-extension://${extensionId}/data-export.html?host=${mockHost}`);
+    await page.goto(`${extensionUrl}/data-export.html?host=${mockHost}`);
     await page.waitForSelector("textarea#query", {timeout: 2000});
 
     // Run a query first

--- a/tests/e2e/data-import.spec.js
+++ b/tests/e2e/data-import.spec.js
@@ -44,13 +44,13 @@ test.describe("Data Import", () => {
  * Initializes the import page
  * @param {Object} page - Playwright page object
  * @param {Object} context - Playwright browser context
- * @param {string} extensionId - Extension ID
+ * @param {string} extensionUrl - Extension base URL
  * @returns {Promise<void>}
  */
-  async function initImportPage(page, context, extensionId) {
+  async function initImportPage(page, context, extensionUrl) {
     // Grant clipboard permissions to browser context
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await page.goto(`chrome-extension://${extensionId}/data-import.html?host=${mockHost}`);
+    await page.goto(`${extensionUrl}/data-import.html?host=${mockHost}`);
 
     // Inject localStorage data after page loads (init script might fail due to security restrictions)
     await page.evaluate(({host, token, version}) => {
@@ -230,15 +230,15 @@ test.describe("Data Import", () => {
     await expect(page.locator("text=/\\d+ Succeeded/")).toContainText("4 Succeeded");
   }
 
-  test("Load Page and Verify Autocomplete Lists", async ({page, context, extensionId}) => {
-    const objectInput = await initImportPage(page, context, extensionId);
+  test("Load Page and Verify Autocomplete Lists", async ({page, context, extensionUrl}) => {
+    const objectInput = await initImportPage(page, context, extensionUrl);
 
     // Verify the object input has the value
     await expect(objectInput).toHaveValue("Inspector_Test__c");
   });
 
-  test("All Records Operations from CSV", async ({page, context, extensionId}) => {
-    await initImportPage(page, context, extensionId);
+  test("All Records Operations from CSV", async ({page, context, extensionUrl}) => {
+    await initImportPage(page, context, extensionUrl);
     //create records and get the record ids
     const createdRecordIds = await createRecords(page, "create");
     await updateRecords(page, new Array(createdRecordIds[0]));
@@ -246,8 +246,8 @@ test.describe("Data Import", () => {
     await deleteRecords(page, createdRecordIds.concat(upsertedRecordIds));
   });
 
-  test("Create Records from Excel Format", async ({page, context, extensionId}) => {
-    await initImportPage(page, context, extensionId);
+  test("Create Records from Excel Format", async ({page, context, extensionUrl}) => {
+    await initImportPage(page, context, extensionUrl);
 
     // Set action to Insert
     await page.locator("#form-import-action").selectOption("create");
@@ -276,8 +276,8 @@ test.describe("Data Import", () => {
     await expect(page.locator("text=/\\d+ Succeeded/")).toBeVisible();
   });
 
-  test("Copy Options", async ({page, context, extensionId}) => {
-    await initImportPage(page, context, extensionId);
+  test("Copy Options", async ({page, context, extensionUrl}) => {
+    await initImportPage(page, context, extensionUrl);
 
     // Set action to Update
     await page.locator("#form-import-action").selectOption("update");
@@ -293,8 +293,8 @@ test.describe("Data Import", () => {
     await expect(clipboardContent).toContain("object=Inspector_Test__c");
   });
 
-  test("Validation Errors - Empty Data", async ({page, context, extensionId}) => {
-    await initImportPage(page, context, extensionId);
+  test("Validation Errors - Empty Data", async ({page, context, extensionUrl}) => {
+    await initImportPage(page, context, extensionUrl);
 
     // Try to paste empty data
     await pasteData(page, "#data-paste", "");
@@ -305,8 +305,8 @@ test.describe("Data Import", () => {
     await expect(errorDiv).not.toHaveAttribute("hidden", "");
   });
 
-  test("Validation Errors - Invalid Field Name", async ({page, context, extensionId}) => {
-    await initImportPage(page, context, extensionId);
+  test("Validation Errors - Invalid Field Name", async ({page, context, extensionUrl}) => {
+    await initImportPage(page, context, extensionUrl);
 
     // Paste data with invalid field name
     const csvData = "Na*me\r\ntest0";

--- a/tests/e2e/dependencies-explorer.spec.js
+++ b/tests/e2e/dependencies-explorer.spec.js
@@ -33,16 +33,16 @@ test.describe("Dependencies Explorer", () => {
     });
   });
 
-  async function initDependenciesExplorerPage(page, extensionId, metadataType = "ApexClass") {
-    await page.goto(`chrome-extension://${extensionId}/dependencies-explorer.html?host=${mockHost}&metadataType=${metadataType}`);
+  async function initDependenciesExplorerPage(page, extensionUrl, metadataType = "ApexClass") {
+    await page.goto(`${extensionUrl}/dependencies-explorer.html?host=${mockHost}&metadataType=${metadataType}`);
 
     // Wait for metadata items to load (tooling query)
     await page.waitForSelector(".dep-dropdown-trigger:not(:has-text('Loading...'))", {timeout: 5000});
     await page.waitForTimeout(300);
   }
 
-  test("Load page with ApexClass and verify SalesforceInspectorTest", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "ApexClass");
+  test("Load page with ApexClass and verify SalesforceInspectorTest", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "ApexClass");
 
     await expect(page).toHaveTitle(/Dependencies Explorer/);
 
@@ -53,8 +53,8 @@ test.describe("Dependencies Explorer", () => {
   });
 
   // Skipped: MetadataComponentDependency mock in test-mock.js returns empty in E2E context
-  test.skip("Analyze ApexClass dependencies shows Inspector_Test__c", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "ApexClass");
+  test.skip("Analyze ApexClass dependencies shows Inspector_Test__c", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "ApexClass");
 
     await page.locator(".dep-dropdown-trigger").click();
     await page.locator(".dep-dropdown-item:has-text('SalesforceInspectorTest')").click();
@@ -68,8 +68,8 @@ test.describe("Dependencies Explorer", () => {
     await expect(page.locator("text=CustomObject")).toBeVisible();
   });
 
-  test("Load page with Flow and verify RecordTrigger_InspectorTest", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "Flow");
+  test("Load page with Flow and verify RecordTrigger_InspectorTest", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "Flow");
 
     await page.locator(".dep-dropdown-trigger").click();
     // Flow display: "RecordTrigger_InspectorTest (AutoLaunchedFlow, v1, Active)"
@@ -77,8 +77,8 @@ test.describe("Dependencies Explorer", () => {
   });
 
   // Skipped: same MetadataComponentDependency mock issue as ApexClass
-  test.skip("Analyze Flow dependencies shows Inspector_Test__c", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "Flow");
+  test.skip("Analyze Flow dependencies shows Inspector_Test__c", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "Flow");
 
     // Select RecordTrigger_InspectorTest (from test/main/default/flows/)
     await page.locator(".dep-dropdown-trigger").click();
@@ -96,8 +96,8 @@ test.describe("Dependencies Explorer", () => {
     await expect(page.locator("text=CustomObject")).toBeVisible();
   });
 
-  test("Analyze button disabled until item selected", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "ApexClass");
+  test("Analyze button disabled until item selected", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "ApexClass");
 
     const analyzeBtn = page.locator("button:has-text('Analyze Dependencies')");
     await expect(analyzeBtn).toBeDisabled();
@@ -108,8 +108,8 @@ test.describe("Dependencies Explorer", () => {
     await expect(analyzeBtn).toBeEnabled();
   });
 
-  test("Welcome message when no analysis run", async ({page, extensionId}) => {
-    await initDependenciesExplorerPage(page, extensionId, "ApexClass");
+  test("Welcome message when no analysis run", async ({page, extensionUrl}) => {
+    await initDependenciesExplorerPage(page, extensionUrl, "ApexClass");
 
     await expect(page.locator("text=Welcome to the Dependencies Explorer!")).toBeVisible();
     await expect(page.locator("text=Select a metadata type and item to analyze")).toBeVisible();

--- a/tests/e2e/event-monitor.spec.js
+++ b/tests/e2e/event-monitor.spec.js
@@ -37,11 +37,11 @@ test.describe("Event Monitor", () => {
 
   /** @description Initializes the event monitor page
    * @param {Object} page - Playwright page object
-   * @param {Object} extensionId - Extension ID
+   * @param {string} extensionUrl - Extension base URL
    * @returns {Promise<void>}
    */
-  async function initEventMonitorPage(page, extensionId) {
-    await page.goto(`chrome-extension://${extensionId}/event-monitor.html?host=${mockHost}`);
+  async function initEventMonitorPage(page, extensionUrl) {
+    await page.goto(`${extensionUrl}/event-monitor.html?host=${mockHost}`);
 
     // Wait for page to load
     await page.waitForSelector("select.slds-select");
@@ -75,8 +75,8 @@ test.describe("Event Monitor", () => {
     });
   }
 
-  test("Load Page and Verify Channel Types", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Load Page and Verify Channel Types", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Verify channel type dropdown exists and has options
     const channelTypeSelect = page.locator("select.slds-select").first();
@@ -86,8 +86,8 @@ test.describe("Event Monitor", () => {
     await expect(channelTypeSelect).toHaveValue("standardPlatformEvent");
   });
 
-  test("Load Standard Platform Events", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Load Standard Platform Events", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Longer wait needed when run in full suite (org API load); do not reduce
     await page.waitForTimeout(1000);
@@ -98,8 +98,8 @@ test.describe("Event Monitor", () => {
     await expect(options.length).toBeGreaterThan(0);
   });
 
-  test("Change Channel Type to Custom Platform Event", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Change Channel Type to Custom Platform Event", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Select "Custom Platform Event" channel type
     await page.locator("select.slds-select").first().selectOption("platformEvent");
@@ -112,8 +112,8 @@ test.describe("Event Monitor", () => {
     await expect(options.some(text => text.includes("Event"))).toBeTruthy();
   });
 
-  test("Change Channel Type to Change Event", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Change Channel Type to Change Event", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Select "Change Event" channel type
     await page.locator("select.slds-select").first().selectOption("changeEvent");
@@ -124,8 +124,8 @@ test.describe("Event Monitor", () => {
     await expect(channelSelect.locator("option").filter({hasText: "All Change Events"})).toHaveCount(1);
   });
 
-  test("Enter Custom Channel Path", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Enter Custom Channel Path", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     await page.waitForSelector("input[type='text']");
 
@@ -137,8 +137,8 @@ test.describe("Event Monitor", () => {
     await expect(customChannelInput).toHaveValue("/event/CustomChannel");
   });
 
-  test("Change Replay ID", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Change Replay ID", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     await page.waitForSelector("input[type='number']");
 
@@ -150,8 +150,8 @@ test.describe("Event Monitor", () => {
     await expect(replayIdInput).toHaveValue("12345");
   });
 
-  test("Subscribe Button State", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Subscribe Button State", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     await page.waitForSelector("button[title='Subscribe to channel']");
 
@@ -165,8 +165,8 @@ test.describe("Event Monitor", () => {
     await expect(unsubscribeButton).toBeDisabled();
   });
 
-  test("Toggle Help", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Toggle Help", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Find and click help button
     const helpButton = page.locator("button[title='Event Monitor Help']");
@@ -177,8 +177,8 @@ test.describe("Event Monitor", () => {
     await expect(page.locator("text=Subscribe to a channel to see events")).toBeVisible();
   });
 
-  test("Toggle Metrics", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Toggle Metrics", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Find and click metrics button
     const metricsButton = page.locator("button[title='Show Metrics']");
@@ -190,8 +190,8 @@ test.describe("Event Monitor", () => {
     await expect(page.locator(".slds-card__body.slds-card__body_inner p.slds-m-bottom_x-small").first()).toContainText("Platform Events: Remaining");
   });
 
-  test("Event Filter Input", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Event Filter Input", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Wait for filter input to appear
     await page.waitForSelector("input[placeholder='Filter events...']");
@@ -205,8 +205,8 @@ test.describe("Event Monitor", () => {
     // which is complex. This test verifies the UI element exists and is properly disabled.
   });
 
-  test("Copy and Clear Buttons State", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Copy and Clear Buttons State", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Wait for buttons to appear
     await page.waitForSelector("button:has-text('Copy')");
@@ -220,10 +220,10 @@ test.describe("Event Monitor", () => {
     await expect(clearButton).toBeDisabled();
   });
 
-  test("Copy as JSON with Events", async ({page, extensionId, context}) => {
+  test("Copy as JSON with Events", async ({page, extensionUrl, context}) => {
     // Grant clipboard permissions
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await initEventMonitorPage(page, extensionId);
+    await initEventMonitorPage(page, extensionUrl);
     await addFakeTestEvent(page);
 
     // Copy button should now be enabled
@@ -242,8 +242,8 @@ test.describe("Event Monitor", () => {
     await expect(clipboardContent).toContain("TestEvent");
   });
 
-  test("Clear Events", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Clear Events", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
     await addFakeTestEvent(page);
 
     // Clear button should be enabled
@@ -258,8 +258,8 @@ test.describe("Event Monitor", () => {
     await expect(page.locator("button:has-text('Clear')")).toBeDisabled();
   });
 
-  test("Replay ID -2 Confirmation Popup", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Replay ID -2 Confirmation Popup", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     await page.waitForSelector("input[type='number']");
 
@@ -281,8 +281,8 @@ test.describe("Event Monitor", () => {
     await expect(page.locator(".slds-modal button:has-text('Cancel').slds-modal__close")).toBeEnabled();
   });
 
-  test("Generate and Publish Platform Event", async ({page, extensionId}) => {
-    await initEventMonitorPage(page, extensionId);
+  test("Generate and Publish Platform Event", async ({page, extensionUrl}) => {
+    await initEventMonitorPage(page, extensionUrl);
 
     // Select Custom Platform Event channel type
     await page.locator("select.slds-select").first().selectOption("platformEvent");

--- a/tests/e2e/field-creator.spec.js
+++ b/tests/e2e/field-creator.spec.js
@@ -10,8 +10,8 @@ test.describe("Field Creator", () => {
   const {mockHost, mockToken, apiVersion} = TEST_CONSTANTS;
 
   /** @desc Initializes the field creator page, waits for objects to load and selects an object */
-  async function initPage(page, extensionId, objectName){
-    await page.goto(`chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`);
+  async function initPage(page, extensionUrl, objectName){
+    await page.goto(`${extensionUrl}/field-creator.html?host=${mockHost}`);
     await page.waitForSelector("#object_select");
 
     // Wait for objects and entity definitions to load (utils.js fetches sobjects, tooling/sobjects, and EntityDefinition via COUNT + batched queries)
@@ -60,8 +60,8 @@ test.describe("Field Creator", () => {
     });
   });
 
-  test("Load Page and Verify Initial State", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Load Page and Verify Initial State", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     // Wait for page to load
@@ -83,8 +83,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("button:has-text('Add Row')")).toBeVisible();
   });
 
-  test("Search and Select Object", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Search and Select Object", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Verify object is selected
     await expect(page.locator("#object_select")).toHaveValue("Account");
@@ -93,8 +93,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("a:has-text('(Fields)')")).toBeVisible();
   });
 
-  test("Add Field Row", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Add Field Row", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("#add_row");
@@ -108,8 +108,8 @@ test.describe("Field Creator", () => {
     await expect(fieldRows).toHaveCount(2);
   });
 
-  test("Edit Field Label and Name", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Edit Field Label and Name", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("#fields_table tbody tr");
@@ -123,8 +123,8 @@ test.describe("Field Creator", () => {
     await expect(nameInput).toHaveValue("TestField");
   });
 
-  test("Change Field Type", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Change Field Type", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Find the type select in the first row
     const typeSelect = page.locator("#fields_table tbody tr").first().locator("select.form-control");
@@ -134,8 +134,8 @@ test.describe("Field Creator", () => {
     await expect(typeSelect).toHaveValue("Number");
   });
 
-  test("Open Field Options Modal", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Open Field Options Modal", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Set field label and type
     await page.locator("#fields_table tbody tr").first().locator("input[placeholder='Field label...']").fill("Test Field");
@@ -150,8 +150,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("label:has-text('Description')")).toBeVisible();
   });
 
-  test("Field Options Modal - Text Field", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Field Options Modal - Text Field", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Set field type to Text
     const typeSelect = page.locator("#fields_table tbody tr").first().locator("select.form-control");
@@ -169,8 +169,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("input#externalId")).toBeVisible();
   });
 
-  test("Field Options Modal - Picklist Field", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Field Options Modal - Picklist Field", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Set field type to Picklist
     const typeSelect = page.locator("#fields_table tbody tr").first().locator("select.form-control");
@@ -187,8 +187,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("input[name='firstvaluedefault']")).toBeVisible();
   });
 
-  test("Save Field Options", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Save Field Options", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Set field label and type
     const labelInput = page.locator("#fields_table tbody tr").first().locator("input[placeholder='Field label...']");
@@ -216,8 +216,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("text=Set Field Options")).not.toBeVisible();
   });
 
-  test("Open Field Permissions Modal", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Open Field Permissions Modal", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Click Permissions button
     await page.locator("#fields_table tbody tr").first().locator("button:has-text('Permissions')").click();
@@ -227,8 +227,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("input[placeholder='Search profiles and permission sets...']")).toBeVisible();
   });
 
-  test("Field Permissions Modal - Search", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Field Permissions Modal - Search", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Click Permissions button
     const permissionsButton = page.locator("#fields_table tbody tr").first().locator("button:has-text('Permissions')");
@@ -255,8 +255,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator(".modal-dialog table.slds-table")).toBeVisible();
   });
 
-  test("Field Permissions Modal - Select Permissions", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Field Permissions Modal - Select Permissions", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("#fields_table tbody tr");
@@ -294,8 +294,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("text=Set Field Permissions")).not.toBeVisible();
   });
 
-  test("Delete Field Row", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Delete Field Row", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("#add_row");
@@ -312,8 +312,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("#fields_table tbody tr")).toHaveCount(1);
   });
 
-  test("Clone Field Row", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Clone Field Row", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("#fields_table tbody tr");
@@ -332,8 +332,8 @@ test.describe("Field Creator", () => {
     await expect(clonedLabelInput).toHaveValue("Test Field");
   });
 
-  test("Open Import Modal", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Open Import Modal", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("button:has-text('Import')");
@@ -347,8 +347,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("textarea.importTextarea")).toBeVisible();
   });
 
-  test("Import CSV Fields", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Import CSV Fields", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("button:has-text('Import')");
@@ -373,8 +373,8 @@ test.describe("Field Creator", () => {
     await expect(page.locator("#fields_table tbody tr")).toHaveCount(3); // 1 initial + 2 imported
   });
 
-  test("Deploy Fields - Success", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Deploy Fields - Success", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Set field label and name
     await page.locator("#fields_table tbody tr").first().locator("input[placeholder='Field label...']").focus();
@@ -419,8 +419,8 @@ test.describe("Field Creator", () => {
     }
   });
 
-  test("Toggle Managed Package Filter", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Toggle Managed Package Filter", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Find the managed package toggle label (click on the label instead of checkbox)
     const managedToggleLabel = page.locator("label.slds-checkbox_toggle");
@@ -436,8 +436,8 @@ test.describe("Field Creator", () => {
     await expect(checkbox).toBeChecked();
   });
 
-  test("Deploy Button Disabled Without Object Selection", async ({page, extensionId}) => {
-    const creatorUrl = `chrome-extension://${extensionId}/field-creator.html?host=${mockHost}`;
+  test("Deploy Button Disabled Without Object Selection", async ({page, extensionUrl}) => {
+    const creatorUrl = `${extensionUrl}/field-creator.html?host=${mockHost}`;
     await page.goto(creatorUrl);
 
     await page.waitForSelector("button:has-text('Deploy Fields')");
@@ -447,8 +447,8 @@ test.describe("Field Creator", () => {
     await expect(deployButton).toBeDisabled();
   });
 
-  test("Field Type Validation for Platform Events", async ({page, extensionId}) => {
-    await initPage(page, extensionId, "Account");
+  test("Field Type Validation for Platform Events", async ({page, extensionUrl}) => {
+    await initPage(page, extensionUrl, "Account");
 
     // Note: We would need to mock a platform event object for this test
     // For now, we'll test that the field type dropdown exists and works

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -1,10 +1,39 @@
-import {test as base, chromium} from "@playwright/test";
+import {test as base, chromium, firefox} from "@playwright/test";
+import fs from "fs-extra";
 import path from "path";
+import {withExtension} from "playwright-webextext";
 import {initializeResponseTracking} from "./test-helpers.js";
+import {FIREFOX_EXTENSION_ID, FIREFOX_EXTENSION_UUID} from "../../playwright.global-setup.js";
 
 export const test = base.extend({
-  // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
+  context: async ({browserName}, use, testInfo) => {
+    if (browserName === "firefox") {
+      // Firefox locks its profile, so give each worker its own profile dir.
+      // Pin the extension's internal UUID so moz-extension:// URLs are stable.
+      // eslint-disable-next-line no-undef
+      const workerProfile = path.join(process.cwd(), `target/firefox-profile-${testInfo.workerIndex}`);
+      fs.emptyDirSync(workerProfile);
+      fs.writeFileSync(
+        path.join(workerProfile, "user.js"),
+        `user_pref("extensions.webextensions.uuids", "{\\"${FIREFOX_EXTENSION_ID}\\":\\"${FIREFOX_EXTENSION_UUID}\\"}");\n`
+      );
+
+      // withExtension installs target/firefox-test (built by
+      // playwright.global-setup.js) as a temporary add-on, so it does not
+      // need to be signed
+      const firefoxWithAddon = withExtension(
+        firefox,
+        // eslint-disable-next-line no-undef
+        path.join(process.cwd(), "target/firefox-test")
+      );
+      const context = await firefoxWithAddon.launchPersistentContext(workerProfile, {
+        headless: true,
+      });
+      await use(context);
+      await context.close();
+      return;
+    }
+
     // eslint-disable-next-line no-undef
     const pathToExtension = path.join(process.cwd(), "addon");
     const context = await chromium.launchPersistentContext("", {
@@ -39,13 +68,18 @@ export const test = base.extend({
     await use(context);
     await context.close();
   },
-  extensionId: async ({context}, use) => {
+  extensionUrl: async ({context, browserName}, use) => {
+    if (browserName === "firefox") {
+      // UUID is pinned via extensions.webextensions.uuids in the test profile
+      await use(`moz-extension://${FIREFOX_EXTENSION_UUID}`);
+      return;
+    }
     // for manifest v3:
     let [background] = context.serviceWorkers();
     if (!background) { background = await context.waitForEvent("serviceworker"); }
 
     const extensionId = background.url().split("/")[2];
-    await use(extensionId);
+    await use(`chrome-extension://${extensionId}`);
   },
   page: async ({page}, use) => {
     // Initialize response tracking early to catch responses that complete
@@ -56,4 +90,3 @@ export const test = base.extend({
   },
 });
 export const expect = base.expect;
-

--- a/tests/e2e/flow-scanner.spec.js
+++ b/tests/e2e/flow-scanner.spec.js
@@ -9,8 +9,8 @@ import { routeMock } from "./test-mock";
 test.describe("Flow Scanner", () => {
   const {mockHost, mockToken, apiVersion} = TEST_CONSTANTS;
 
-  test.beforeEach(async ({context, extensionId}) => {
-    TEST_CONSTANTS.extensionId = extensionId;
+  test.beforeEach(async ({context, extensionUrl}) => {
+    TEST_CONSTANTS.extensionUrl = extensionUrl;
 
     // Inject session data with model exposure
     await injectSessionData(context, {
@@ -103,8 +103,8 @@ test.describe("Flow Scanner", () => {
     });
   });
 
-  async function initFlowScannerPage(page, extensionId, mockHost, mockFlowDefId = null, mockFlowId = null) {
-    await page.goto(`chrome-extension://${extensionId}/flow-scanner.html?host=${mockHost}${mockFlowDefId ? `&flowDefId=${mockFlowDefId}` : ""}${mockFlowId ? `&flowId=${mockFlowId}` : ""}`);
+  async function initFlowScannerPage(page, extensionUrl, mockHost, mockFlowDefId = null, mockFlowId = null) {
+    await page.goto(`${extensionUrl}/flow-scanner.html?host=${mockHost}${mockFlowDefId ? `&flowDefId=${mockFlowDefId}` : ""}${mockFlowId ? `&flowId=${mockFlowId}` : ""}`);
     await page.waitForSelector("#root", {timeout: 10000});
     await page.waitForSelector("text=Flow Scanner", {timeout: 10000});
 
@@ -125,15 +125,15 @@ test.describe("Flow Scanner", () => {
     await page.waitForTimeout(500);
   }
 
-  test("Load Flow Scanner Page", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Load Flow Scanner Page", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Verify Flow Information section appears (use more specific selector)
     await expect(page.locator("h2:has-text('Flow Information')").first()).toBeVisible();
   });
 
-  test("Display Flow Information", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Display Flow Information", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Verify flow information section exists
     const flowInfoSection = page.locator(".flow-info-section");
@@ -147,15 +147,15 @@ test.describe("Flow Scanner", () => {
     await expect(hasFlowContent).toBe(true);
   });
 
-  test("Display Scan Results", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Display Scan Results", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Verify Scan Results section appears (check for results area)
     await expect(page.locator(".scan-results-area, .summary-body").first()).toBeVisible({timeout: 5000});
   });
 
-  test("Expand All Results", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Expand All Results", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Click Expand All button
     const expandAllButton = page.locator("button:has-text('Expand All')");
@@ -164,8 +164,8 @@ test.describe("Flow Scanner", () => {
     }
   });
 
-  test("Collapse All Results", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Collapse All Results", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Click Collapse All button
     const collapseAllButton = page.locator("button:has-text('Collapse All')");
@@ -174,8 +174,8 @@ test.describe("Flow Scanner", () => {
     }
   });
 
-  test("Toggle Severity Group", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Toggle Severity Group", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Find and click a severity group header (e.g., Errors)
     const errorHeader = page.locator(".severity-title-left:has-text('Errors')").first();
@@ -184,8 +184,8 @@ test.describe("Flow Scanner", () => {
     }
   });
 
-  test("Export Results", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Export Results", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Click Export button
     const exportButton = page.locator("button:has-text('Export')");
@@ -198,8 +198,8 @@ test.describe("Flow Scanner", () => {
     }
   });
 
-  test("Toggle Flow Description", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Toggle Flow Description", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Find and click description toggle button
     const descriptionToggle = page.locator("button.description-toggle-btn, button:has-text('Show description'), button:has-text('Hide description')").first();
@@ -207,8 +207,8 @@ test.describe("Flow Scanner", () => {
     await descriptionToggle.click();
   });
 
-  test("Open Purge Versions Modal", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Open Purge Versions Modal", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     const versionsText = await page.locator("text=/\\d+ versions?/i").first().textContent().catch(() => "");
     const versionCount = parseInt(versionsText) || 0;
@@ -223,8 +223,8 @@ test.describe("Flow Scanner", () => {
     await expect(page.locator("text=Purge Old Versions")).toBeVisible();
   }, {timeout: 45000});
 
-  test("Open Agentforce Modal", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Open Agentforce Modal", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Find Agentforce button (Einstein icon)
     const agentforceButton = page.locator("button[title='Open Agentforce Flow Scanner'], button:has(svg use[xlinkHref*='einstein'])").first();
@@ -235,8 +235,8 @@ test.describe("Flow Scanner", () => {
     await expect(page.locator("text=Agentforce Flow Scanner")).toBeVisible();
   });
 
-  test("Open Help/Settings", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Open Help/Settings", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Find settings/help button
     const settingsButton = page.locator("button[title='Open Flow Scanner Options'], button:has(svg use[xlinkHref*='settings'])").first();
@@ -247,8 +247,8 @@ test.describe("Flow Scanner", () => {
 
   });
 
-  test("Display Flow Versions", async ({page, extensionId}) => {
-    await initFlowScannerPage(page, extensionId, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
+  test("Display Flow Versions", async ({page, extensionUrl}) => {
+    await initFlowScannerPage(page, extensionUrl, mockHost, TEST_CONSTANTS.flowDefId, TEST_CONSTANTS.flowId);
 
     // Verify flow info section loaded successfully (which includes versions)
     await expect(page.locator(".flow-info-section")).toBeVisible({timeout: 5000});
@@ -262,10 +262,10 @@ test.describe("Flow Scanner", () => {
     expect(hasFlowData).toBe(true);
   });
 
-  test.skip("Error Handling - Missing Parameters", async ({page, extensionId}) => {
+  test.skip("Error Handling - Missing Parameters", async ({page, extensionUrl}) => {
     // Skip this test as it requires specific error handling that may not work in test environment
     // The error occurs during initialization before React renders
-    await initFlowScannerPage(page, extensionId, mockHost);
+    await initFlowScannerPage(page, extensionUrl, mockHost);
 
     // Wait for error to appear - check for error text anywhere on page
     await page.waitForFunction(
@@ -280,10 +280,10 @@ test.describe("Flow Scanner", () => {
     await expect(page.locator("text=Missing required parameters").first()).toBeVisible({timeout: 5000});
   });
 
-  test.skip("Retry After Error", async ({page, extensionId}) => {
+  test.skip("Retry After Error", async ({page, extensionUrl}) => {
     // Skip this test as it requires specific error handling that may not work in test environment
     // The error occurs during initialization before React renders
-    await initFlowScannerPage(page, extensionId, mockHost);
+    await initFlowScannerPage(page, extensionUrl, mockHost);
 
     // Wait for error - check for error text anywhere on page
     await page.waitForFunction(

--- a/tests/e2e/inspect.spec.js
+++ b/tests/e2e/inspect.spec.js
@@ -9,8 +9,8 @@ import {routeMock} from "./test-mock";
 test.describe("Inspect", () => {
   const {mockHost, mockToken, apiVersion} = TEST_CONSTANTS;
 
-  test.beforeEach(async ({context, extensionId}) => {
-    TEST_CONSTANTS.extensionId = extensionId;
+  test.beforeEach(async ({context, extensionUrl}) => {
+    TEST_CONSTANTS.extensionUrl = extensionUrl;
 
     // Inject session data with model exposure
     await injectSessionData(context, {
@@ -39,23 +39,23 @@ test.describe("Inspect", () => {
 
   /** @description Initializes the inspect page
    * @param {Object} page - Playwright page object
-   * @param {Object} extensionId - Extension ID
+   * @param {string} extensionUrl - Extension base URL
    * @param {string} recordId - Record ID
    * @returns {Promise<void>}
    */
-  async function initInspectPage(page, extensionId, recordId = null, useToolingApi = false) {
-    await page.goto(`chrome-extension://${extensionId}/inspect.html?host=${mockHost}&objectType=Account${recordId ? `&recordId=${recordId}` : ""}${useToolingApi ? "&useToolingApi=1" : ""}`);
+  async function initInspectPage(page, extensionUrl, recordId = null, useToolingApi = false) {
+    await page.goto(`${extensionUrl}/inspect.html?host=${mockHost}&objectType=Account${recordId ? `&recordId=${recordId}` : ""}${useToolingApi ? "&useToolingApi=1" : ""}`);
     await page.waitForSelector("#root", {timeout: 2000});
     await page.waitForSelector("text=Inspect", {timeout: 2000});
   }
 
-  async function initInspectPageWaitRecordName(page, extensionId) {
-    await initInspectPage(page, extensionId, TEST_CONSTANTS.accountRecordId);
+  async function initInspectPageWaitRecordName(page, extensionUrl) {
+    await initInspectPage(page, extensionUrl, TEST_CONSTANTS.accountRecordId);
     await page.waitForSelector(`td:has-text('${TEST_CONSTANTS.accountRecordId}')`, {timeout: 2000});
   }
 
-  test("Load Inspect Page - Object Only", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Load Inspect Page - Object Only", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     // Wait for table so the page is fully loaded before asserting
     await page.waitForSelector("table.slds-table", {timeout: 2000});
@@ -69,15 +69,15 @@ test.describe("Inspect", () => {
     await expect(page.locator("button:has-text('Relationships')")).toBeVisible();
   });
 
-  test("Load Inspect Page - With Record ID", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Load Inspect Page - With Record ID", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Verify record name appears in table (more specific)
     await expect(page.locator(`td:has-text('${TEST_CONSTANTS.accountRecordName}')`).first()).toBeVisible();
   });
 
-  test("Switch Tabs", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Switch Tabs", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector(".slds-builder-header_container li span[title=Fields]", {timeout: 1000});
 
@@ -91,8 +91,8 @@ test.describe("Inspect", () => {
     await page.locator(".slds-builder-header_container li span[title=All]").click();
   });
 
-  test("Filter Fields", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Filter Fields", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     // Wait for table first so the page is fully loaded (filter is in header, same render)
     await page.waitForSelector("table.slds-table", {timeout: 2000});
@@ -109,8 +109,8 @@ test.describe("Inspect", () => {
     await expect(page.locator("text=Name").first()).toBeVisible();
   });
 
-  test("Toggle Column Visibility", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Toggle Column Visibility", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector(".slds-builder-header_container li span[title=Fields]", {timeout: 1000});
 
@@ -135,8 +135,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Calculate Field Usage", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Calculate Field Usage", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector(".slds-builder-header_container li span[title=Fields]", {timeout: 1000});
 
@@ -168,8 +168,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Enter Edit Mode - Update", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Enter Edit Mode - Update", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Click Edit button
     const editButton = page.locator("button:has-text('Edit')");
@@ -183,8 +183,8 @@ test.describe("Inspect", () => {
     await expect(page.locator("button:has-text('Cancel')")).toBeVisible();
   });
 
-  test("Edit Field Value", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Edit Field Value", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Enter edit mode
     await page.locator("button:has-text('Edit')").click();
@@ -205,8 +205,8 @@ test.describe("Inspect", () => {
     await expect(textarea).toHaveValue("Updated Account Name");
   });
 
-  test("Cancel Edit", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Cancel Edit", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Enter edit mode
     await page.locator("button:has-text('Edit')").click();
@@ -220,8 +220,8 @@ test.describe("Inspect", () => {
     await expect(page.locator("button:has-text('Save')")).not.toBeVisible();
   });
 
-  test("Enter Delete Mode", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Enter Delete Mode", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Click Delete button
     const deleteButton = page.locator("button:has-text('Delete')");
@@ -234,8 +234,8 @@ test.describe("Inspect", () => {
     await expect(page.locator("button:has-text('Confirm delete')")).toBeVisible();
   });
 
-  test("Enter Create Mode", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Enter Create Mode", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     // Click New button
     const newButton = page.locator("button:has-text('New')");
@@ -248,10 +248,10 @@ test.describe("Inspect", () => {
     await expect(page.locator("button:has-text('Save new')")).toBeVisible();
   });
 
-  test("Export Table - Copy", async ({page, context, extensionId}) => {
+  test("Export Table - Copy", async ({page, context, extensionUrl}) => {
     // Grant clipboard permissions to browser context
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await initInspectPage(page, extensionId);
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("table.slds-table", {timeout: 1000});
     await page.waitForTimeout(250); // Wait for table to fully render
@@ -273,8 +273,8 @@ test.describe("Inspect", () => {
     await expect(clipboardValue).toContain("Field API Name");
   });
 
-  test("Export Table - Download CSV", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Export Table - Download CSV", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("table.slds-table", {timeout: 1000});
     await page.waitForTimeout(250); // Wait for table to fully render
@@ -296,8 +296,8 @@ test.describe("Inspect", () => {
     await page.waitForTimeout(250);
   });
 
-  test("Toggle Table Borders", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Toggle Table Borders", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("table.slds-table", {timeout: 1000});
     await page.waitForTimeout(250); // Wait for table to fully render
@@ -322,8 +322,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Show Object Metadata", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Show Object Metadata", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("a:has-text('More')", {timeout: 1000});
 
@@ -336,8 +336,8 @@ test.describe("Inspect", () => {
     await expect(page.locator("text=All available metadata")).toBeVisible();
   });
 
-  test("Field Actions Menu", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Field Actions Menu", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("table.slds-table", {timeout: 1000});
 
@@ -354,8 +354,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Relationship Actions Menu", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Relationship Actions Menu", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector("text=Relationships", {timeout: 1000});
 
@@ -376,8 +376,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Object Actions Menu", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Object Actions Menu", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Find object actions dropdown button - look in utility items area
     const objectActionsContainer = page.locator(".object-actions").first();
@@ -392,15 +392,15 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Tooling API Support", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId, null, true);
+  test("Tooling API Support", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl, null, true);
 
     // Verify Tooling API indicator appears
     await expect(page.locator("text=Tooling API")).toBeVisible();
   });
 
-  test("Record ID Popup", async ({page, extensionId}) => {
-    await initInspectPageWaitRecordName(page, extensionId);
+  test("Record ID Popup", async ({page, extensionUrl}) => {
+    await initInspectPageWaitRecordName(page, extensionUrl);
 
     // Find a reference field value (ID) and click it
     const idLink = page.locator("a:has-text('" + TEST_CONSTANTS.accountRecordId + "')").first();
@@ -414,8 +414,8 @@ test.describe("Inspect", () => {
     }
   });
 
-  test("Column Filtering", async ({page, extensionId}) => {
-    await initInspectPage(page, extensionId);
+  test("Column Filtering", async ({page, extensionUrl}) => {
+    await initInspectPage(page, extensionUrl);
 
     await page.waitForSelector(".slds-builder-header_container li span[title=Fields]", {timeout: 1000});
 

--- a/tests/e2e/limits.spec.js
+++ b/tests/e2e/limits.spec.js
@@ -32,8 +32,8 @@ test.describe("Org Limits", () => {
     });
   });
 
-  async function initLimitsPage(page, extensionId) {
-    await page.goto(`chrome-extension://${extensionId}/limits.html?host=${mockHost}`);
+  async function initLimitsPage(page, extensionUrl) {
+    await page.goto(`${extensionUrl}/limits.html?host=${mockHost}`);
 
     // Wait for limits API response and page to load
     await waitSuccessfulHttpResponse(page, "/services/data/v" + apiVersion + "/limits", 5000);
@@ -42,15 +42,15 @@ test.describe("Org Limits", () => {
     await page.waitForSelector("h2:has-text('Limits snapshot')", {timeout: 3000});
   }
 
-  test("Load page and verify title", async ({page, extensionId}) => {
-    await initLimitsPage(page, extensionId);
+  test("Load page and verify title", async ({page, extensionUrl}) => {
+    await initLimitsPage(page, extensionUrl);
 
     await expect(page).toHaveTitle(/Org Limits/);
     await expect(page.locator("h2:has-text('Limits snapshot')")).toBeVisible();
   });
 
-  test("Display limits data from API", async ({page, extensionId}) => {
-    await initLimitsPage(page, extensionId);
+  test("Display limits data from API", async ({page, extensionUrl}) => {
+    await initLimitsPage(page, extensionUrl);
 
     // At least one limit gauge should be visible
     const limitGauges = page.locator("figure .meter-value");
@@ -62,16 +62,16 @@ test.describe("Org Limits", () => {
     await expect(page.locator("figcaption").first()).toContainText("consumed");
   });
 
-  test("Copy button is enabled when limits load", async ({page, extensionId}) => {
-    await initLimitsPage(page, extensionId);
+  test("Copy button is enabled when limits load", async ({page, extensionUrl}) => {
+    await initLimitsPage(page, extensionUrl);
 
     const copyButton = page.locator("button:has-text('Copy')");
     await expect(copyButton).toBeVisible();
     await expect(copyButton).toBeEnabled();
   });
 
-  test("Sort dropdown has options", async ({page, extensionId}) => {
-    await initLimitsPage(page, extensionId);
+  test("Sort dropdown has options", async ({page, extensionUrl}) => {
+    await initLimitsPage(page, extensionUrl);
 
     const sortSelect = page.locator("select.slds-select");
     await expect(sortSelect).toBeVisible();
@@ -82,8 +82,8 @@ test.describe("Org Limits", () => {
     await expect(sortSelect.locator("option[value='asc']")).toHaveCount(1);
   });
 
-  test("Change sort order", async ({page, extensionId}) => {
-    await initLimitsPage(page, extensionId);
+  test("Change sort order", async ({page, extensionUrl}) => {
+    await initLimitsPage(page, extensionUrl);
 
     const sortSelect = page.locator("select.slds-select");
     await sortSelect.selectOption("consumption");
@@ -93,9 +93,9 @@ test.describe("Org Limits", () => {
     await expect(page).toHaveURL(/sort=consumption/);
   });
 
-  test("Copy as JSON to clipboard", async ({page, extensionId, context}) => {
+  test("Copy as JSON to clipboard", async ({page, extensionUrl, context}) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await initLimitsPage(page, extensionId);
+    await initLimitsPage(page, extensionUrl);
 
     const copyButton = page.locator("button:has-text('Copy')");
     await copyButton.click();

--- a/tests/e2e/metadata-retrieve.spec.js
+++ b/tests/e2e/metadata-retrieve.spec.js
@@ -33,8 +33,8 @@ test.describe("Metadata Retrieve", () => {
     });
   });
 
-  async function initMetadataRetrievePage(page, extensionId) {
-    await page.goto(`chrome-extension://${extensionId}/metadata-retrieve.html?host=${mockHost}`);
+  async function initMetadataRetrievePage(page, extensionUrl) {
+    await page.goto(`${extensionUrl}/metadata-retrieve.html?host=${mockHost}`);
 
     // Wait for metadata objects to load
     await page.waitForSelector(".filter-input", {timeout: 10000});
@@ -43,8 +43,8 @@ test.describe("Metadata Retrieve", () => {
     await page.waitForTimeout(500);
   }
 
-  test("Load Page and Verify Initial State", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Load Page and Verify Initial State", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Verify filter input exists
     const filterInput = page.locator(".filter-input");
@@ -58,8 +58,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(page.locator("button[title='Copy package.xml']")).toBeVisible();
   });
 
-  test("Load Metadata Objects", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Load Metadata Objects", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Verify metadata objects are displayed
     const metadataItems = page.locator(".slds-accordion__list-item");
@@ -69,8 +69,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(page.locator("text=ApexClass")).toBeVisible();
   });
 
-  test("Filter Metadata Objects", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Filter Metadata Objects", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Type in filter
     const filterInput = page.locator(".filter-input");
@@ -88,8 +88,8 @@ test.describe("Metadata Retrieve", () => {
     }
   });
 
-  test("Clear Filter", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Clear Filter", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Type in filter
     const filterInput = page.locator(".filter-input");
@@ -103,8 +103,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(filterInput).toHaveValue("");
   });
 
-  test("Select All Metadata Objects", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Select All Metadata Objects", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Find and click Select All label (click on label instead of checkbox to avoid interception)
     const selectAllLabel = page.locator("label.slds-checkbox_toggle").first();
@@ -119,8 +119,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(retrieveButton).toBeEnabled();
   });
 
-  test("Select Individual Metadata Object", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Select Individual Metadata Object", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Find first metadata object checkbox
     const firstCheckbox = page.locator(".slds-accordion__list-item").first().locator("input.metadata");
@@ -135,8 +135,8 @@ test.describe("Metadata Retrieve", () => {
     expect(packageXml).toContain("<Package");
   });
 
-  test("Expand Metadata Object to List Children", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Expand Metadata Object to List Children", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Click on ApexClass to expand
     const apexClassItem = page.locator(".slds-accordion__list-item:has-text('ApexClass')");
@@ -150,8 +150,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(children.first()).toBeVisible({timeout: 1000});
   });
 
-  test("Toggle Managed Packages Filter", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Toggle Managed Packages Filter", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Find managed packages toggle (second checkbox toggle)
     const managedToggle = page.locator("label.slds-checkbox_toggle").nth(1);
@@ -167,8 +167,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(checkbox).toBeChecked();
   });
 
-  test("Generate Package XML", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Generate Package XML", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Select a metadata object
     const firstCheckbox = page.locator(".slds-accordion__list-item").first().locator("input.metadata");
@@ -184,10 +184,10 @@ test.describe("Metadata Retrieve", () => {
     expect(packageXml).toContain("</Package>");
   });
 
-  test("Copy Package XML", async ({page, context, extensionId}) => {
+  test("Copy Package XML", async ({page, context, extensionUrl}) => {
     // Grant clipboard permissions to browser context
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await initMetadataRetrievePage(page, extensionId);
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Select a metadata object
     const firstCheckbox = page.locator(".slds-accordion__list-item").first().locator("input.metadata");
@@ -204,8 +204,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(clipboardContent).toContain("<Package");
   });
 
-  test("Show Deployment Options", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Show Deployment Options", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Wait for page to load
     await page.waitForSelector("button[title='Display Deployment Settings']", {timeout: 1000});
@@ -222,8 +222,8 @@ test.describe("Metadata Retrieve", () => {
     await expect(page.locator("label:has-text('Test Level')")).toBeVisible();
   });
 
-  test("Change Test Level", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Change Test Level", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Wait for page to load
     await page.waitForSelector("button[title='Display Deployment Settings']", {timeout: 1000});
@@ -243,16 +243,16 @@ test.describe("Metadata Retrieve", () => {
     await expect(testLevelSelect).toHaveValue("RunLocalTests");
   });
 
-  test("Retrieve Metadata Button Disabled When Nothing Selected", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Retrieve Metadata Button Disabled When Nothing Selected", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Verify Retrieve Metadata button is disabled initially
     const retrieveButton = page.locator("button:has-text('Retrieve Metadata')");
     await expect(retrieveButton).toBeDisabled();
   });
 
-  test("Import Package XML", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Import Package XML", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     // Wait for page to load
     await page.waitForSelector("button[title='Import package.xml or package zip file']", {timeout: 1000});
@@ -300,8 +300,8 @@ test.describe("Metadata Retrieve", () => {
     expect(retrieveRequestCount).toBe(0);
   });
 
-  test("Save Status Info Downloads Retrieve Status JSON", async ({page, extensionId}) => {
-    await initMetadataRetrievePage(page, extensionId);
+  test("Save Status Info Downloads Retrieve Status JSON", async ({page, extensionUrl}) => {
+    await initMetadataRetrievePage(page, extensionUrl);
 
     const firstCheckbox = page.locator(".slds-accordion__list-item").first().locator("input.metadata");
     await firstCheckbox.click();

--- a/tests/e2e/options.spec.js
+++ b/tests/e2e/options.spec.js
@@ -29,8 +29,8 @@ test.describe("Options", () => {
     });
   });
 
-  async function initOptionsPage(page, extensionId, selectedTab = null, gotoTab = null) {
-    await page.goto(`chrome-extension://${extensionId}/options.html?host=${mockHost}${selectedTab ? `&selectedTab=${selectedTab}` : ""}`);
+  async function initOptionsPage(page, extensionUrl, selectedTab = null, gotoTab = null) {
+    await page.goto(`${extensionUrl}/options.html?host=${mockHost}${selectedTab ? `&selectedTab=${selectedTab}` : ""}`);
     await page.waitForSelector(".sfir-options-tab-container", {timeout: 1000});
     if (gotoTab) {
       await page.locator(`a[role='tab']:has-text('${gotoTab}')`).click();
@@ -43,7 +43,7 @@ test.describe("Options", () => {
   }
 
   test.describe("User Experience", () => {
-    test("Load Options Page", async ({page, extensionId}) => {
+    test("Load Options Page", async ({page, extensionUrl}) => {
       // Set up console error listener to debug
       const consoleErrors = [];
       page.on("console", msg => {
@@ -52,7 +52,7 @@ test.describe("Options", () => {
         }
       });
 
-      await initOptionsPage(page, extensionId);
+      await initOptionsPage(page, extensionUrl);
 
       // Wait for root element to exist
       await page.waitForSelector("#root", {timeout: 1000});
@@ -64,8 +64,8 @@ test.describe("Options", () => {
       await expect(page.locator(".slds-text-heading_small:has-text('Options')").first()).toBeVisible();
     });
 
-    test("Verify Tabs Exist", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId);
+    test("Verify Tabs Exist", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl);
 
       // Verify all main tabs are present (use role="tab" to be specific)
       await expect(page.locator("a[role='tab']:has-text('User Experience')")).toBeVisible();
@@ -79,8 +79,8 @@ test.describe("Options", () => {
       await expect(page.locator("a[role='tab']:has-text('Custom Shortcuts')")).toBeVisible();
     });
 
-    test("Toggle Option - Popup Dark Theme", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId);
+    test("Toggle Option - Popup Dark Theme", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl);
 
       // Find Popup Dark theme checkbox by key
       const checkbox = page.locator("input#popupDarkTheme");
@@ -102,8 +102,8 @@ test.describe("Options", () => {
       await expect(newChecked).toBe(!initialChecked);
     });
 
-    test("MultiCheckboxButtonGroup - Show Buttons", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId);
+    test("MultiCheckboxButtonGroup - Show Buttons", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl);
 
       // Find "Show buttons" checkbox group - use first occurrence (User Experience tab)
       const showButtonsText = page.locator("text=Show buttons").first();
@@ -130,8 +130,8 @@ test.describe("Options", () => {
       await expect(newChecked).toBe(!initialChecked);
     });
 
-    test("MultiCheckboxButtonGroup - Metadata Shortcut Search Options", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId);
+    test("MultiCheckboxButtonGroup - Metadata Shortcut Search Options", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl);
 
       // Find "Searchable metadata from Shortcut tab" checkbox group
       const metadataGroup = page.locator("text=Searchable metadata from Shortcut tab").locator("..").locator("..");
@@ -156,8 +156,8 @@ test.describe("Options", () => {
       expect(newChecked).toBe(!initialChecked);
     });
 
-    test("Arrow Button Orientation and Position", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId);
+    test("Arrow Button Orientation and Position", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl);
 
       // Find arrow orientation select
       await page.waitForSelector("select[name='arrowPosition']", {timeout: 1000});
@@ -184,8 +184,8 @@ test.describe("Options", () => {
   });
 
   test.describe("API", () => {
-    test("Switch to API Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "API");
+    test("Switch to API Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "API");
 
       // Verify API tab is active
       await expect(page.locator(".options-tab:has-text('API')")).toHaveClass(/slds-is-active/);
@@ -194,8 +194,8 @@ test.describe("Options", () => {
       await expect(page.locator("span:has-text('API Version')").first()).toBeVisible();
     });
 
-    test("Change API Version", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "API");
+    test("Change API Version", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "API");
 
       // Wait for API version input
       await page.waitForSelector("#api input[type='number']", {timeout: 1000});
@@ -216,15 +216,15 @@ test.describe("Options", () => {
       await expect(parseInt(value)).toBeGreaterThanOrEqual(60);
     });
 
-    test("URL Parameter - Select Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, "api");
+    test("URL Parameter - Select Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, "api");
 
       // Verify API tab is active by default
       await expect(page.locator(".options-tab:has-text('API')")).toHaveClass(/slds-is-active/);
     });
 
-    test("Restore Default API Version", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "API");
+    test("Restore Default API Version", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "API");
 
       // Wait for API version input
       await page.waitForSelector("#api input[type='number']", {timeout: 1000});
@@ -248,8 +248,8 @@ test.describe("Options", () => {
       }
     });
 
-    test("Delete Token Button", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "API");
+    test("Delete Token Button", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "API");
 
       // Wait for Delete Token button
       await page.waitForSelector("button:has-text('Delete Token')", {timeout: 1000});
@@ -263,14 +263,14 @@ test.describe("Options", () => {
   });
 
   test.describe("Data Export", () => {
-    test("Switch to Data Export Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Data Export");
+    test("Switch to Data Export Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Data Export");
       // Verify CSV Separator option is visible
       await expect(page.locator("text=CSV Separator")).toBeVisible();
     });
 
-    test("Change CSV Separator", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Data Export");
+    test("Change CSV Separator", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Data Export");
 
       // Wait for CSV Separator input
       await page.waitForSelector("input#csvSeparatorInput", {timeout: 1000});
@@ -288,15 +288,15 @@ test.describe("Options", () => {
   });
 
   test.describe("Data Import", () => {
-    test("Switch to Data Import Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Data Import");
+    test("Switch to Data Import Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Data Import");
 
       // Verify Default batch size option is visible
       await expect(page.locator("text=Default batch size")).toBeVisible();
     });
 
-    test("Change Default Batch Size", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Data Import");
+    test("Change Default Batch Size", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Data Import");
 
       // Wait for batch size input
       await page.waitForSelector("input[placeholder='200']", {timeout: 1000});
@@ -314,15 +314,15 @@ test.describe("Options", () => {
   });
 
   test.describe("Field Creator", () => {
-    test("Switch to Field Creator Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Field Creator");
+    test("Switch to Field Creator Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Field Creator");
 
       // Verify Field Naming Convention option is visible
       await expect(page.locator("text=Field Naming Convention")).toBeVisible();
     });
 
-    test("Change Field Naming Convention", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Field Creator");
+    test("Change Field Naming Convention", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Field Creator");
 
       // Wait for Field Naming Convention select (find by looking for the text first)
       await page.waitForSelector("text=Field Naming Convention", {timeout: 1000});
@@ -341,15 +341,15 @@ test.describe("Options", () => {
   });
 
   test.describe("Custom Shortcuts", () => {
-    test("Switch to Custom Shortcuts Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Custom Shortcuts");
+    test("Switch to Custom Shortcuts Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Custom Shortcuts");
 
       // Verify search input is visible
       await expect(page.locator("input[placeholder='Search shortcuts...']")).toBeVisible();
     });
 
-    test("Add Custom Shortcut", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Custom Shortcuts");
+    test("Add Custom Shortcut", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Custom Shortcuts");
 
       // Wait for shortcuts table
       await page.waitForSelector("table.slds-table", {timeout: 1000});
@@ -385,8 +385,8 @@ test.describe("Options", () => {
       await expect(page.locator("text=Test Shortcut")).toBeVisible();
     });
 
-    test("Edit Custom Shortcut", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Custom Shortcuts");
+    test("Edit Custom Shortcut", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Custom Shortcuts");
 
       // Wait for shortcuts table
       await page.waitForSelector("table.slds-table", {timeout: 1000});
@@ -427,8 +427,8 @@ test.describe("Options", () => {
       await expect(page.locator("text=Updated Label")).toBeVisible();
     });
 
-    test("Delete Custom Shortcut", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Custom Shortcuts");
+    test("Delete Custom Shortcut", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Custom Shortcuts");
 
       // Wait for shortcuts table
       await page.waitForSelector("table.slds-table", {timeout: 1000});
@@ -463,8 +463,8 @@ test.describe("Options", () => {
       await expect(page.locator("text=To Delete")).not.toBeVisible();
     });
 
-    test("Search Custom Shortcuts", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Custom Shortcuts");
+    test("Search Custom Shortcuts", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Custom Shortcuts");
 
       // Wait for search input
       await page.waitForSelector("input[placeholder='Search shortcuts...']", {timeout: 1000});
@@ -501,8 +501,8 @@ test.describe("Options", () => {
   });
 
   test.describe("General", () => {
-    test("Export Options", async ({page, extensionId}) => {
-      await page.goto(`chrome-extension://${extensionId}/options.html?host=${mockHost}`);
+    test("Export Options", async ({page, extensionUrl}) => {
+      await page.goto(`${extensionUrl}/options.html?host=${mockHost}`);
 
       await page.waitForSelector("button[title='Export Options']", {timeout: 1000});
 
@@ -519,8 +519,8 @@ test.describe("Options", () => {
       expect(download.suggestedFilename()).toBe("reloadedConfiguration.json");
     });
 
-    test("Import Options", async ({page, extensionId}) => {
-      await page.goto(`chrome-extension://${extensionId}/options.html?host=${mockHost}`);
+    test("Import Options", async ({page, extensionUrl}) => {
+      await page.goto(`${extensionUrl}/options.html?host=${mockHost}`);
 
       await page.waitForSelector("button[title='Import Options']", {timeout: 1000});
 
@@ -556,8 +556,8 @@ test.describe("Options", () => {
   });
 
   test.describe("Metadata", () => {
-    test("Switch to Metadata Tab", async ({page, extensionId}) => {
-      const optionsUrl = `chrome-extension://${extensionId}/options.html?host=${mockHost}`;
+    test("Switch to Metadata Tab", async ({page, extensionUrl}) => {
+      const optionsUrl = `${extensionUrl}/options.html?host=${mockHost}`;
       await page.goto(optionsUrl);
 
       await page.waitForSelector(".sfir-options-tab-container", {timeout: 1000});
@@ -572,8 +572,8 @@ test.describe("Options", () => {
       await expect(page.locator("text=Include managed packages metadata")).toBeVisible();
     });
 
-    test("Toggle Include Managed Packages Metadata", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Metadata");
+    test("Toggle Include Managed Packages Metadata", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Metadata");
 
       // Find Include managed packages metadata checkbox by key
       const checkbox = page.locator("input#includeManagedMetadata");
@@ -595,8 +595,8 @@ test.describe("Options", () => {
       expect(newChecked).toBe(!initialChecked);
     });
 
-    test("Change Sort Metadata By", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Metadata");
+    test("Change Sort Metadata By", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Metadata");
 
       // Wait for Sort metadata components text
       await page.waitForSelector("text=Sort metadata components", {timeout: 1000});
@@ -615,8 +615,8 @@ test.describe("Options", () => {
   });
 
   test.describe("Enable Logs", () => {
-    test("Switch to Enable Logs Tab", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Enable Logs");
+    test("Switch to Enable Logs Tab", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Enable Logs");
 
       // Verify Enable Logs tab is active
       await expect(page.locator(".options-tab:has-text('Enable Logs')")).toHaveClass(/slds-is-active/);
@@ -625,8 +625,8 @@ test.describe("Options", () => {
       await expect(page.locator("text=Debug Level (DeveloperName)")).toBeVisible();
     });
 
-    test("Change Debug Level", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Enable Logs");
+    test("Change Debug Level", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Enable Logs");
 
       // Wait for debug level input
       await page.waitForSelector("input#debugLogDebugLevel", {timeout: 1000});
@@ -642,8 +642,8 @@ test.describe("Options", () => {
       await expect(debugLevelInput).toHaveValue("CustomDebugLevel");
     });
 
-    test("Change Debug Log Time", async ({page, extensionId}) => {
-      await initOptionsPage(page, extensionId, null, "Enable Logs");
+    test("Change Debug Log Time", async ({page, extensionUrl}) => {
+      await initOptionsPage(page, extensionUrl, null, "Enable Logs");
 
       // Wait for debug log time input
       await page.waitForSelector("input#debugLogTimeMinutes", {timeout: 1000});

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -344,8 +344,8 @@ test.describe("Popup", () => {
     });
   });
 
-  async function initPopupPage(page, extensionId) {
-    await page.goto(`chrome-extension://${extensionId}/test-popup.html?host=${mockHost}`);
+  async function initPopupPage(page, extensionUrl) {
+    await page.goto(`${extensionUrl}/test-popup.html?host=${mockHost}`);
 
     //click on the button to open the popup
     await page.locator(".insext-btn").click();
@@ -374,8 +374,8 @@ test.describe("Popup", () => {
   }
 
   test.describe("General", () => {
-    test("Load Popup Page", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Load Popup Page", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       // Verify basic page structure (may not have React content if init didn't work)
       const rootContent = await page.frameLocator(".insext-popup").locator("#root").textContent();
 
@@ -383,8 +383,8 @@ test.describe("Popup", () => {
       await expect(rootContent !== null).toBeTruthy();
     });
 
-    test("Verify Main Sections Exist", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Verify Main Sections Exist", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Verify Data & Metadata section
       await expect(page.frameLocator(".insext-popup").locator("text=Data & Metadata")).toBeVisible();
@@ -399,8 +399,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("a:has-text('Event Monitor')")).toBeVisible();
     });
 
-    test("Change API Version", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Change API Version", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Find API version input
       const apiInput = page.frameLocator(".insext-popup").locator("input#idApiInput");
@@ -414,8 +414,8 @@ test.describe("Popup", () => {
       await expect(apiInput).toHaveValue("64");
     });
 
-    test("Click Data Export Link", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Click Data Export Link", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Find Data Export link
       const exportLink = page.frameLocator(".insext-popup").locator("a:has-text('Data Export')");
@@ -426,8 +426,8 @@ test.describe("Popup", () => {
       expect(href).toContain("data-export.html");
     });
 
-    test("Click Data Import Link", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Click Data Import Link", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Find Data Import link
       const importLink = page.frameLocator(".insext-popup").locator("a:has-text('Data Import')");
@@ -438,8 +438,8 @@ test.describe("Popup", () => {
       expect(href).toContain("data-import.html");
     });
 
-    test("Click REST Explorer Link", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Click REST Explorer Link", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Find REST Explorer link
       const restLink = page.frameLocator(".insext-popup").locator("a:has-text('REST Explorer')");
@@ -450,8 +450,8 @@ test.describe("Popup", () => {
       expect(href).toContain("rest-explore.html");
     });
 
-    test("Click Event Monitor Link", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Click Event Monitor Link", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Find Event Monitor link
       const eventLink = page.frameLocator(".insext-popup").locator("a:has-text('Event Monitor')");
@@ -462,8 +462,8 @@ test.describe("Popup", () => {
       expect(href).toContain("event-monitor.html");
     });
 
-    test("Footer Links Exist", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Footer Links Exist", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Wait for footer to load
       await page.frameLocator(".insext-popup").locator("#footer").waitFor({timeout: 1000});
@@ -485,8 +485,8 @@ test.describe("Popup", () => {
   });
 
   test.describe("Objects Tab", () => {
-    test("Search and Select Object", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search and Select Object", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       await waitForObjectsTabToLoad(page);
       // Type in search input
@@ -504,8 +504,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator(".tab-container .slds-card__body .slds-text-body_small").locator("text=Account")).toBeVisible();
     });
 
-    test("Select Record ID", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Select Record ID", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       await waitForObjectsTabToLoad(page);
 
       // Type a record ID
@@ -522,8 +522,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=" + TEST_CONSTANTS.accountRecordId)).toBeVisible({timeout: 1000});
     });
 
-    test("Show All Data Button", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Show All Data Button", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       await waitForObjectsTabToLoad(page);
 
       // Type and select an object
@@ -540,8 +540,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("a:has-text('Show all data')")).toBeVisible({timeout: 1000});
     });
 
-    test("Object Links (Fields, List, etc.)", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Object Links (Fields, List, etc.)", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       await waitForObjectsTabToLoad(page);
 
       // Type and select an object
@@ -561,8 +561,8 @@ test.describe("Popup", () => {
   });
 
   test.describe("Users Tab", () => {
-    test("Switch to Users Tab", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Switch to Users Tab", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Users tab
       const usersTab = page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')");
@@ -575,8 +575,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("input[placeholder*='Name, username']")).toBeVisible({timeout: 1000});
     });
 
-    test("Search User", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search User", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Users tab
       await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
@@ -595,8 +595,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator(".slds-dropdown__item:has-text('" + TEST_CONSTANTS.testUserSearchTerm + "')").first()).toBeVisible({timeout: 2000});
     });
 
-    test("Select User and View Details", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Select User and View Details", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Users tab
       await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
@@ -624,8 +624,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=" + username).first()).toBeVisible();
     });
 
-    test("User Action Buttons", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("User Action Buttons", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Users tab
       await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
@@ -648,8 +648,8 @@ test.describe("Popup", () => {
       await expect(await page.frameLocator(".insext-popup").locator("a:has-text('PSet')").count()).toBe(2);
     });
 
-    test("Enable Debug Logs", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Enable Debug Logs", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Users tab
       await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Users')").click();
@@ -711,8 +711,8 @@ test.describe("Popup", () => {
       return {referenceIds, stop: () => page.off("request", handler)};
     }
 
-    test("Switch to Shortcuts Tab", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Switch to Shortcuts Tab", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Shortcuts tab
       const shortcutsTab = page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Shortcuts')");
@@ -725,8 +725,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator(shortcutInputSelector)).toBeVisible({timeout: 1000});
     });
 
-    test("Search Shortcut (default: links + metadata)", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut (default: links + metadata)", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -740,8 +740,8 @@ test.describe("Popup", () => {
       expect(capture.referenceIds).toContain("flowsSelect");
     });
 
-    test("Search Shortcut with '/' prefix returns setup links only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '/' prefix returns setup links only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -757,8 +757,8 @@ test.describe("Popup", () => {
       expect(capture.referenceIds).toEqual([]);
     });
 
-    test("Search Shortcut with '!' prefix returns metadata only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '!' prefix returns metadata only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -778,8 +778,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=Sf Inspector")).toBeVisible({timeout: 3000});
     });
 
-    test("Search Shortcut with '!flow' prefix returns flows only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '!flow' prefix returns flows only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -792,8 +792,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=RecordTrigger InspectorTest")).toBeVisible({timeout: 3000});
     });
 
-    test("Search Shortcut with '!profile' prefix returns profiles only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '!profile' prefix returns profiles only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -806,8 +806,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=System Administrator")).toBeVisible({timeout: 3000});
     });
 
-    test("Search Shortcut with '!class' prefix returns Apex classes only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '!class' prefix returns Apex classes only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -824,8 +824,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=SalesforceInspectorTest").first()).toBeVisible({timeout: 3000});
     });
 
-    test("Search Shortcut with '!perm' prefix returns Permission Sets only", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Search Shortcut with '!perm' prefix returns Permission Sets only", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
       const searchInput = await openShortcutsTab(page);
       const capture = captureShortcutMetadataRequests(page);
 
@@ -840,8 +840,8 @@ test.describe("Popup", () => {
   });
 
   test.describe("Org Tab", () => {
-    test("Switch to Org Tab", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Switch to Org Tab", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Org tab
       const orgTab = page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Org')");
@@ -854,8 +854,8 @@ test.describe("Popup", () => {
       await expect(page.frameLocator(".insext-popup").locator("text=Org Id")).toBeVisible({timeout: 1000});
     });
 
-    test("Delete Apex Logs Button", async ({page, extensionId}) => {
-      await initPopupPage(page, extensionId);
+    test("Delete Apex Logs Button", async ({page, extensionUrl}) => {
+      await initPopupPage(page, extensionUrl);
 
       // Click Org tab
       await page.frameLocator(".insext-popup").locator(".slds-tabs_scoped__item:has-text('Org')").click();

--- a/tests/e2e/rest-explore.spec.js
+++ b/tests/e2e/rest-explore.spec.js
@@ -35,8 +35,8 @@ test.describe("REST Explore", () => {
     });
   });
 
-  test("Execute SOQL Query (GET)", async ({page, extensionId}) => {
-    await page.goto(`chrome-extension://${extensionId}/rest-explore.html?host=${mockHost}`);
+  test("Execute SOQL Query (GET)", async ({page, extensionUrl}) => {
+    await page.goto(`${extensionUrl}/rest-explore.html?host=${mockHost}`);
 
     // Wait for app load
     await page.waitForSelector("select.slds-select", {timeout: 1000});
@@ -60,8 +60,8 @@ test.describe("REST Explore", () => {
     await expect(responseCode).toContainText('"Name": "Test Account');
   });
 
-  test("CRUD Flow (POST, PATCH, GET, DELETE)", async ({page, extensionId}) => {
-    await page.goto(`chrome-extension://${extensionId}/rest-explore.html?host=${mockHost}`);
+  test("CRUD Flow (POST, PATCH, GET, DELETE)", async ({page, extensionUrl}) => {
+    await page.goto(`${extensionUrl}/rest-explore.html?host=${mockHost}`);
     // Wait for app load
     await page.waitForSelector("select.slds-select", {timeout: 1000});
 


### PR DESCRIPTION
# Describe your changes

**Draft — supporting evidence for #1291, not a merge candidate.** See the full write-up in [my comment on #1291](https://github.com/tprouvot/Salesforce-Inspector-reloaded/pull/1291).

Short version: the `test-real-org (firefox)` failure on #1291 is not a Firefox compatibility problem — `tests/e2e/fixtures.js` hard-codes `chromium.launchPersistentContext`, so the `--project=firefox` leg never launches Firefox and dies on a missing Chromium binary. This branch fixes that, and gets the extension genuinely installed and running in Playwright's Firefox. It still cannot make the spec suite pass, because Playwright's Firefox (juggler) protocol cannot navigate to `moz-extension://` pages ([playwright#3792](https://github.com/microsoft/playwright/issues/3792)).

## What's here

- **Browser-aware `context` fixture** — Firefox branch alongside the existing Chromium path, with a per-worker profile dir (Firefox locks its profile).
- **Working Firefox extension install** — temporary add-on over the remote debugging protocol via `playwright-webextext`, so no signing is needed. Profile sideloading (the current `playwright.global-setup.js` approach) cannot work: Firefox removes unpacked dirs and unsigned XPIs from the profile at startup regardless of scope prefs.
- **Pinned internal UUID** via `extensions.webextensions.uuids`, so the `moz-extension://` origin is deterministic across runs.
- **`extensionId` → `extensionUrl` fixture rename** across all 14 specs, so page URLs are no longer hard-coded to `chrome-extension://`.

## Verified

RDP `listAddons` after launch:

```json
{
  "id": "salesforceinspector@reloaded",
  "name": "Salesforce Inspector Reloaded",
  "temporarilyInstalled": true,
  "manifestURL": "moz-extension://9c04c81d-73d5-4a34-8feb-1c4bcd571c4a/manifest.json"
}
```

Navigating to that exact URL from the same context:

```
page.goto("moz-extension://9c04c81d-.../manifest.json")
  -> TimeoutError: Timeout 20000ms exceeded, waiting until "load"
```

`about:blank` in the same context navigates fine. That is the blocker, and it is upstream.

Chromium suite still green with the rename: **160 passed, 5 skipped** (mocked, locally).

## Why it's a draft

Every spec works by navigating to an extension page, so the suite cannot run on Firefox as written. Merging this would not turn #1291 green. It is here so the diagnosis is reproducible and the salvageable pieces aren't lost.
