### PR TITLE
fix: show LoginAs buttons for frozen users (discussion #1270)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Restore LoginAs buttons for frozen users [discussion #1270](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1270)
 - `Metadata` Add 'Run Relevant Tests' option to metadata deploy Test Level picklist [feature 1286](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1286)
 - `Popup` Fix language flag icons for Catalan and Basque on the Users tab [issue #1196](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1196)
 - `Custom Shortcuts` Add "Global" toggle to share a shortcut across all orgs instead of keeping it specific to the current org [feature 191](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/191)

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3346,8 +3346,7 @@ class UserDetails extends React.PureComponent {
     let {currentUserId} = this.props;
     //Optimistically show login unless it's logged in user's userid or user is inactive.
     //No API to determine if user is allowed to login as given user. See https://salesforce.stackexchange.com/questions/224342/query-can-i-login-as-for-users
-    const isFrozen = !!user?.UserLogins?.records?.[0]?.IsFrozen;
-    if (!user || user.Id == currentUserId || !user.IsActive || isFrozen) {
+    if (!user || user.Id == currentUserId || !user.IsActive) {
       return false;
     }
     return true;


### PR DESCRIPTION
## What

Removes the `IsFrozen` condition from `doSupportLoginAs` so the **LoginAs / Incognito** buttons on the Users tab are shown again for frozen users. The **Unfreeze** button still appears for frozen users, now alongside LoginAs.

## Why

Discussion #1270: users reported the LoginAs button missing in v2.0, typically in sandboxes only. Root cause: 2.0 introduced a check that hides LoginAs when the target user is frozen — but Salesforce itself still allows "Login" as a frozen user from Setup (freezing blocks the user's own login, not login-as). Freezing users is common in sandboxes after a refresh, which explains the "UAT broken / production fine" reports.

Reproduced in a scratch org: freeze a user → LoginAs disappears in 2.0 while the native Setup Login button keeps working; unfreeze → button returns. On 1.x the button showed regardless of frozen state.

## Testing

- `npm run test:e2e:mock -- popup.spec.js`: 27 passed
- eslint on `addon/popup.js`: same error count as releaseCandidate baseline (no new issues)

Potentially fixes #1270 and #1282 