### PR TITLE
Fix: [Options] UI: API tab horizontal overflow and stray bottom margin

### DIFF
--- a/addon/options.js
+++ b/addon/options.js
@@ -664,7 +664,7 @@ class APIVersionOption extends React.Component {
           h(Tooltip, {tooltip: "Update api version", idKey: "APIVersion"})
         ),
       ),
-      h("div", {className: "slds-col slds-size_10-of-12 slds-form-element"},
+      h("div", {className: "slds-col slds-size_9-of-12 slds-form-element"},
         h("div", {className: "slds-grid slds-grid_align-start slds-grid_vertical-align-center slds-gutters_small"},
           h("div", {className: "slds-col slds-size_1-of-12"},
             h("div", {className: "slds-form-element__control"},
@@ -2230,7 +2230,7 @@ class App extends React.Component {
           onClose: this.hideToast
         }),
       h("div", {className: "slds-m-top_xx-large sfir-page-container"},
-        h("div", {className: "slds-card slds-m-around_medium main-container", id: "main-container_header"},
+        h("div", {className: "slds-card slds-m-top_medium slds-m-horizontal_medium main-container", id: "main-container_header"},
           h(OptionsTabSelector, {model, appRef: this})
         )
       )


### PR DESCRIPTION
## Before:
API option tab (horizontal scroll bar):
<img width="959" height="443" alt="image" src="https://github.com/user-attachments/assets/9175f211-8668-4d68-9b39-ff1cbf3351f0" />

Unnecessary bottom margin:
<img width="960" height="445" alt="image" src="https://github.com/user-attachments/assets/9c921196-e266-445c-a0ba-b8d26e68a9bb" />


## After:
<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/6159fd45-0ada-4a3e-88fb-c2a2a0433f6e" />

<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/c8a486cb-fbf8-446d-afa4-0529b90668e9" />


Minor UI changes, @tprouvot please let me know if need an issue and/or changelog.
