### PR TITLE
Show the current release in the Org tab

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -2779,11 +2779,14 @@ class AllDataBoxOrg extends React.PureComponent {
 
   async componentDidMount() {
     let {sfHost} = this.props;
-    let orgInfo = JSON.parse(sessionStorage.getItem(sfHost + "_orgInfo"));
-    if (!orgInfo) {
-      orgInfo = await setOrgInfo(sfHost);
+    const orgInfo = await setOrgInfo(sfHost).catch((e) => {
+      console.error(e);
+      return null;
+    });
+    this.setState({orgInfo});
+    if (orgInfo?.InstanceName) {
+      this.setInstanceStatus(orgInfo.InstanceName);
     }
-    this.setInstanceStatus(orgInfo.InstanceName, sfHost);
   }
 
   contextOrgId() {
@@ -2791,10 +2794,10 @@ class AllDataBoxOrg extends React.PureComponent {
   }
 
   getNextMajorRelease(maintenances) {
-    if (maintenances) {
-      let event = maintenances.find((event) =>
-        event.name.endsWith("Major Release")
-      );
+    let event = maintenances?.find((event) =>
+      event.name.endsWith("Major Release")
+    );
+    if (event) {
       return (
         event.name.replace(" Major Release", "")
         + " on "
@@ -2882,44 +2885,39 @@ class AllDataBoxOrg extends React.PureComponent {
     elt.classList.toggle(success ? "progress-success" : "progress-error");
   }
 
-  setInstanceStatus(instanceName, sfHost) {
-    let instanceStatusLocal = JSON.parse(
-      sessionStorage.getItem(sfHost + "_instanceStatus")
-    );
-    if (instanceStatusLocal == null) {
-      fetch(
-        `https://api.status.salesforce.com/v1/instances/${instanceName}/status`
-      )
-        .then((response) => {
-          response.json().then((result) => {
-            //manually filter to get only the future releases (based on today's date) and sort maintenance since list in not ordered by default
-            result.Maintenances = result.Maintenances.filter(
-              (dt) => dt.plannedEndTime >= new Date().toISOString()
-            ).sort((a, b) =>
-              a.plannedStartTime > b.plannedStartTime
-                ? 1
-                : b.plannedStartTime > a.plannedStartTime
-                  ? -1
-                  : 0
-            );
-            this.setState({instanceStatus: result});
-            sessionStorage.setItem(
-              sfHost + "_instanceStatus",
-              JSON.stringify(result)
-            );
-          });
-        })
-        .catch((e) => {
-          console.error(e);
-        });
-    } else {
-      this.setState({instanceStatus: instanceStatusLocal});
-    }
+  setInstanceStatus(instanceName) {
+    fetch(
+      //credentials are omitted so the load balancer affinity cookie cannot pin the request to an instance reporting a previous release
+      `https://api.status.salesforce.com/v1/instances/${instanceName}/status`,
+      {cache: "no-store", credentials: "omit"}
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Salesforce status API returned ${response.status} for instance ${instanceName}`
+          );
+        }
+        return response.json();
+      })
+      .then((result) => {
+        //manually filter to get only the future releases (based on today's date) and sort maintenance since list in not ordered by default
+        result.Maintenances = (result.Maintenances ?? []).filter(
+          (dt) => dt.plannedEndTime >= new Date().toISOString()
+        ).sort((a, b) =>
+          a.plannedStartTime > b.plannedStartTime
+            ? 1
+            : b.plannedStartTime > a.plannedStartTime
+              ? -1
+              : 0
+        );
+        this.setState({instanceStatus: result});
+      })
+      .catch((e) => console.error(e));
   }
 
   render() {
     let {linkTarget, sfHost} = this.props;
-    let orgInfo = JSON.parse(sessionStorage.getItem(sfHost + "_orgInfo"));
+    let {orgInfo} = this.state;
     return h(
       "div",
       {

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -157,6 +157,18 @@ test.describe("Popup", () => {
       const url = request.url();
       const method = request.method();
 
+      if (url.includes("api.status.salesforce.com/v1/instances/")) {
+        await fulfillSuccess(route, {
+          key: "FRA12S",
+          location: "EMEA",
+          releaseVersion: "Winter '26 Patch 1.0",
+          releaseNumber: "258.1.0",
+          status: "OK",
+          Maintenances: []
+        });
+        return;
+      }
+
       // REST API - Composite Query (user details + Shortcut tab metadata search).
       // Handled before routeMock() because test-mock.js has a generic composite fallback
       // that would otherwise swallow these requests and respond with empty records.
@@ -852,6 +864,11 @@ test.describe("Popup", () => {
 
       // Verify org info table appears
       await expect(page.frameLocator(".insext-popup").locator("text=Org Id")).toBeVisible({timeout: 1000});
+
+      // Release and API version come from the status response, not from a cached one
+      const orgTable = page.frameLocator(".insext-popup").locator(".all-data-box-data");
+      await expect(orgTable.locator("tr").filter({hasText: "Release"}).locator("td")).toHaveText("Winter '26 Patch 1.0 / 258.1.0");
+      await expect(orgTable.locator("tr").filter({hasText: "API vers."}).locator("td")).toHaveText("65");
     });
 
     test("Delete Apex Logs Button", async ({page, extensionId}) => {


### PR DESCRIPTION
## Summary

- omit credentials when calling the status API, so the load balancer affinity cookie cannot pin the request to an instance still reporting the previous release
- stop caching the status response in `sessionStorage`, where it never expired and kept a stale release for the lifetime of the tab

Closes #1306

## Root cause

Measured from `popup.html`, same instant, same URL, all with `cache: "no-store"`, only the credentials mode differs:

| credentials | releaseVersion | updatedAt |
| --- | --- | --- |
| `default` | Summer '26 Patch 14.4 | 2026-08-22T23:30:23.036Z |
| `omit` | Winter '27 Patch 3.3 | 2026-08-31T01:15:20.375Z |
| `include` | Summer '26 Patch 14.4 | 2026-08-22T23:30:23.036Z |

Chrome attaches cookies to extension page requests when the extension holds host permissions, so the default mode sends `akaalb_alb_api_status`, an Akamai load balancer stickiness cookie, and gets an instance that still reports the pre-upgrade release. This reproduces on `releaseCandidate` with an empty `sessionStorage`, so the cache made the stale value persist rather than produce it. A cache buster does not help, since the response is fresh from a pinned instance rather than served from an HTTP cache.

The Org tab also no longer reads org info from `sessionStorage` during render, because without the status cache nothing else triggered a re-render once the query resolved.

## Out of scope

The per-org API version is handled separately in #1308. Once the release is correct, the maximum version offered by the incrementer follows automatically.

## Test plan

- [x] Three mode comparison above, run in the popup context
- [x] `npx playwright test tests/e2e/popup.spec.js tests/e2e/options.spec.js` (57 passed)
- [x] Org tab test asserts Release and API version come from the status response
- [ ] Manually verify the Org tab after reloading the unpacked extension