### PR TITLE
Store the selected API version per org

### DIFF
--- a/addon/inspector.js
+++ b/addon/inspector.js
@@ -2,7 +2,20 @@ import {getRedirectUri, getClientId, isSettingEnabled, Constants} from "./utils.
 import {apiStatistics} from "./api-statistics.js";
 
 export let defaultApiVersion = "66.0";
-export let apiVersion = localStorage.getItem("apiVersion") == null ? defaultApiVersion : localStorage.getItem("apiVersion");
+const apiVersionKey = (sfHost) => sfHost + "_apiVersion";
+const apiVersionMigrationKey = (sfHost) => apiVersionKey(sfHost) + "_migrated";
+export let apiVersion = defaultApiVersion;
+
+export function setApiVersionForOrg(value) {
+  apiVersion = value;
+  localStorage.setItem(apiVersionKey(sfConn.instanceHostname), value);
+}
+
+export function resetApiVersionForOrg() {
+  apiVersion = defaultApiVersion;
+  localStorage.removeItem(apiVersionKey(sfConn.instanceHostname));
+  localStorage.setItem(apiVersionMigrationKey(sfConn.instanceHostname), "true");
+}
 
 export let sessionError;
 const clientId = "Salesforce Inspector Reloaded";
@@ -70,6 +83,25 @@ export let sfConn = {
       if (message) {
         this.instanceHostname = getMyDomain(message.hostname);
         this.sessionId = message.key;
+      }
+    }
+    sfHost = this.instanceHostname;
+    const storedApiVersion = localStorage.getItem(apiVersionKey(sfHost));
+    apiVersion = storedApiVersion ?? defaultApiVersion;
+    const legacyApiVersion = localStorage.getItem("apiVersion");
+    if (!storedApiVersion
+      && legacyApiVersion
+      && localStorage.getItem(apiVersionMigrationKey(sfHost)) !== "true") {
+      try {
+        const releases = await this.rest("services/data/");
+        const supportedVersions = releases
+          .map((release) => release.version)
+          .filter((version) => parseFloat(version) <= parseFloat(legacyApiVersion))
+          .sort((a, b) => parseFloat(a) - parseFloat(b));
+        setApiVersionForOrg(supportedVersions.pop() ?? defaultApiVersion);
+        localStorage.setItem(apiVersionMigrationKey(sfHost), "true");
+      } catch (e) {
+        console.error("Unable to migrate the legacy API version:", e);
       }
     }
     if (localStorage.getItem(sfHost + "_trialExpirationDate") == null) {

--- a/addon/options.js
+++ b/addon/options.js
@@ -1,5 +1,5 @@
 /* global React ReactDOM */
-import {sfConn, apiVersion, defaultApiVersion} from "./inspector.js";
+import {sfConn, apiVersion, setApiVersionForOrg, resetApiVersionForOrg, defaultApiVersion} from "./inspector.js";
 import {nullToEmptyString, getLatestApiVersionFromOrg, Constants, UserInfoModel, createSpinForMethod, DataCache, applyProductionStyling} from "./utils.js";
 import {getFlowScannerRules, FLOW_SCANNER_RULES_STORAGE_KEY} from "./flow-scanner-rules.js";
 /* global initButton, lightningflowscanner */
@@ -630,31 +630,42 @@ class APIVersionOption extends React.Component {
     super(props);
     this.onChangeApiVersion = this.onChangeApiVersion.bind(this);
     this.onRestoreDefaultApiVersion = this.onRestoreDefaultApiVersion.bind(this);
-    this.state = {apiVersion: localStorage.getItem("apiVersion") ? localStorage.getItem("apiVersion") : apiVersion};
+    this.state = {apiVersion};
   }
 
   async onChangeApiVersion(e) {
-    let {sfHost} = this.props.model;
     const inputElt = e.target;
     const newApiVersion = e.target.value;
-    if (this.state.apiVersion < newApiVersion) {
-      const latestApiVersion = await getLatestApiVersionFromOrg(sfHost);
-      if (latestApiVersion >= newApiVersion) {
-        localStorage.setItem("apiVersion", newApiVersion + ".0");
-        this.setState({apiVersion: newApiVersion + ".0"});
+    this.setState({apiVersion: newApiVersion});
+    inputElt.setCustomValidity("");
+    inputElt.removeAttribute("max");
+    if (!inputElt.checkValidity()) {
+      return;
+    }
+    const acceptVersion = () => {
+      const normalizedApiVersion = Number(newApiVersion) + ".0";
+      setApiVersionForOrg(normalizedApiVersion);
+      this.setState({apiVersion: normalizedApiVersion});
+    };
+    if (parseFloat(apiVersion) < parseFloat(newApiVersion)) {
+      const latestApiVersion = await getLatestApiVersionFromOrg();
+      if (inputElt.value !== newApiVersion) {
+        return;
+      }
+      if (parseFloat(latestApiVersion) >= parseFloat(newApiVersion)) {
+        acceptVersion();
       } else {
         inputElt.setAttribute("max", latestApiVersion);
         inputElt.setCustomValidity("Maximum version available: " + latestApiVersion);
         inputElt.reportValidity();
       }
     } else {
-      localStorage.setItem("apiVersion", newApiVersion + ".0");
-      this.setState({apiVersion: newApiVersion + ".0"});
+      acceptVersion();
     }
   }
 
   onRestoreDefaultApiVersion(){
-    localStorage.removeItem("apiVersion");
+    resetApiVersionForOrg();
     this.setState({apiVersion: defaultApiVersion});
   }
   render() {
@@ -668,7 +679,19 @@ class APIVersionOption extends React.Component {
         h("div", {className: "slds-grid slds-grid_align-start slds-grid_vertical-align-center slds-gutters_small"},
           h("div", {className: "slds-col slds-size_1-of-12"},
             h("div", {className: "slds-form-element__control"},
-              h("input", {type: "number", required: true, className: "slds-input", value: nullToEmptyString(this.state.apiVersion.split(".0")[0]), onChange: this.onChangeApiVersion}),
+              h("input", {
+                type: "number",
+                min: Constants.MIN_API_VERSION,
+                step: "1",
+                required: true,
+                className: "slds-input",
+                value: nullToEmptyString(this.state.apiVersion.split(".0")[0]),
+                onChange: this.onChangeApiVersion,
+                onBlur: (e) => {
+                  e.target.setCustomValidity("");
+                  this.setState({apiVersion});
+                }
+              }),
             )
           ),
           this.state.apiVersion != defaultApiVersion ? h("div", {className: "slds-col"},

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1,5 +1,5 @@
 /* global React ReactDOM */
-import {sfConn, apiVersion, sessionError} from "./inspector.js";
+import {sfConn, apiVersion, setApiVersionForOrg, sessionError} from "./inspector.js";
 import {getLinkTarget, isOptionEnabled, isSettingEnabled, getLatestApiVersionFromOrg, setOrgInfo, getPKCEParameters, getBrowserType, getExtensionId, getClientId, getRedirectUri, Constants, copyToClipboard, DataCache, getFlowCompareUrl, isRecordId, getSobjectsList} from "./utils.js";
 import {setupLinks} from "./links.js";
 import AlertBanner from "./components/AlertBanner.js";
@@ -308,14 +308,26 @@ class App extends React.PureComponent {
     }
   }
   async onChangeApi(e) {
-    let {sfHost} = this.props;
     const inputElt = e.target;
     const newApiVersion = e.target.value;
-    if (apiVersion < newApiVersion) {
-      const latestApiVersion = await getLatestApiVersionFromOrg(sfHost);
-      if (latestApiVersion >= newApiVersion) {
-        localStorage.setItem("apiVersion", newApiVersion + ".0");
-        this.setState({apiVersionInput: newApiVersion + ".0"});
+    this.setState({apiVersionInput: newApiVersion});
+    inputElt.setCustomValidity("");
+    inputElt.removeAttribute("max");
+    if (!inputElt.checkValidity()) {
+      return;
+    }
+    const acceptVersion = () => {
+      const normalizedApiVersion = Number(newApiVersion) + ".0";
+      setApiVersionForOrg(normalizedApiVersion);
+      this.setState({apiVersionInput: normalizedApiVersion});
+    };
+    if (parseFloat(apiVersion) < parseFloat(newApiVersion)) {
+      const latestApiVersion = await getLatestApiVersionFromOrg();
+      if (inputElt.value !== newApiVersion) {
+        return;
+      }
+      if (parseFloat(latestApiVersion) >= parseFloat(newApiVersion)) {
+        acceptVersion();
       } else {
         inputElt.setAttribute("max", latestApiVersion);
         inputElt.setCustomValidity(
@@ -324,8 +336,7 @@ class App extends React.PureComponent {
         inputElt.reportValidity();
       }
     } else {
-      localStorage.setItem("apiVersion", newApiVersion + ".0");
-      this.setState({apiVersionInput: newApiVersion + ".0"});
+      acceptVersion();
     }
   }
   componentDidMount() {
@@ -815,8 +826,15 @@ class App extends React.PureComponent {
               id: "idApiInput",
               className: "api-input",
               type: "number",
+              min: Constants.MIN_API_VERSION,
+              step: "1",
+              required: true,
               title: "Update api version",
               onChange: this.onChangeApi,
+              onBlur: (e) => {
+                e.target.setCustomValidity("");
+                this.setState({apiVersionInput: apiVersion});
+              },
               value: apiVersionInput.split(".0")[0],
             })
           ),
@@ -2805,15 +2823,8 @@ class AllDataBoxOrg extends React.PureComponent {
   }
 
   getApiVersion(instanceStatus) {
-    let {sfHost} = this.props;
     if (instanceStatus) {
-      let apiVersion = instanceStatus.releaseNumber.substring(0, 3) / 2 - 64;
-      //store it for maximum version allowed
-      sessionStorage.setItem(
-        sfHost + "_latestApiVersionFromOrg",
-        apiVersion + ".0"
-      );
-      return apiVersion;
+      return instanceStatus.releaseNumber.substring(0, 3) / 2 - 64;
     }
     return null;
   }

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -19,6 +19,7 @@ export class Constants {
   // API Statistics
   static API_DEBUG_STATISTICS_MODE = "apiDebugStatisticsMode";
   static API_DEBUG_STATISTICS = "apiDebugStatistics";
+  static MIN_API_VERSION = 31;
   // Cache Keys
   static CACHE_SOBJECTS_LIST = "sobjectsList";
   // CustomEvent: dispatched when sobjects list is refreshed in background
@@ -319,16 +320,15 @@ export function isSettingEnabled(settingName, defaultValue = false){
   return value === "true";
 }
 
-export async function getLatestApiVersionFromOrg(sfHost) {
-  let latestApiVersionFromOrg = sessionStorage.getItem(sfHost + "_latestApiVersionFromOrg");
-  if (latestApiVersionFromOrg != null) {
-    return latestApiVersionFromOrg;
-  } else {
-    const res = await sfConn.rest("services/data/");
-    latestApiVersionFromOrg = res[res.length - 1].version; //Extract the value of the last version
-    sessionStorage.setItem(sfHost + "_latestApiVersionFromOrg", latestApiVersionFromOrg);
-    return latestApiVersionFromOrg;
+export async function getLatestApiVersionFromOrg() {
+  const releases = await sfConn.rest("services/data/");
+  if (!Array.isArray(releases) || releases.length === 0) {
+    throw new Error("The org returned no supported API release");
   }
+  const latestRelease = releases.reduce((latest, release) =>
+    parseFloat(release.version) > parseFloat(latest.version) ? release : latest
+  );
+  return latestRelease.version;
 }
 
 export async function setOrgInfo(sfHost) {

--- a/tests/e2e/data-import.spec.js
+++ b/tests/e2e/data-import.spec.js
@@ -60,7 +60,7 @@ test.describe("Data Import", () => {
           window.localStorage.setItem(keyPrefix + "_access_token", token);
           window.localStorage.setItem(keyPrefix + "_isSandbox", "true");
           window.localStorage.setItem(keyPrefix + "_orgInstance", "FRA12S");
-          window.localStorage.setItem("apiVersion", version);
+          window.localStorage.setItem(keyPrefix + "_apiVersion", version);
         }
       } catch (e) {
         console.warn("Failed to set localStorage:", e.message);

--- a/tests/e2e/options.spec.js
+++ b/tests/e2e/options.spec.js
@@ -204,16 +204,14 @@ test.describe("Options", () => {
       const apiVersionInput = page.locator("#api input[type='number']").first();
       await expect(apiVersionInput).toBeVisible();
 
-      // Change API version
-      await apiVersionInput.fill("66");
-      await apiVersionInput.press("Enter");
-
-      // Wait for validation/update
-      await page.waitForTimeout(1000);
-
-      // Verify value is updated (or restored if invalid)
-      const value = await apiVersionInput.inputValue();
-      await expect(parseInt(value)).toBeGreaterThanOrEqual(60);
+      // Reject consecutive unsupported values without changing the stored version.
+      await apiVersionInput.fill("99");
+      await apiVersionInput.fill("98");
+      await apiVersionInput.blur();
+      await expect(apiVersionInput).toHaveValue("66");
+      await expect.poll(() => apiVersionInput.evaluate((input, host) =>
+        input.ownerDocument.defaultView.localStorage.getItem(host + "_apiVersion"), mockHost
+      )).toBe("66.0");
     });
 
     test("URL Parameter - Select Tab", async ({page, extensionId}) => {
@@ -231,21 +229,19 @@ test.describe("Options", () => {
 
       // Change API version to non-default
       const apiVersionInput = page.locator("#api input[type='number']").first();
-      await apiVersionInput.fill("66");
+      await apiVersionInput.fill("64");
       await apiVersionInput.press("Enter");
       await page.waitForTimeout(1000);
 
-      // Check if Restore Default button appears
       const restoreButton = page.locator("button:has-text('Restore Default')");
-      if (await restoreButton.count() > 0) {
-        await restoreButton.click();
+      await expect(restoreButton).toBeVisible();
+      await restoreButton.click();
 
-        // Wait for restore
-        await page.waitForTimeout(500);
-
-        // Verify button is gone (version restored to default)
-        await expect(restoreButton).not.toBeVisible();
-      }
+      await expect(restoreButton).not.toBeVisible();
+      await expect.poll(() => apiVersionInput.evaluate((input, host) => ({
+        version: input.ownerDocument.defaultView.localStorage.getItem(host + "_apiVersion"),
+        migrated: input.ownerDocument.defaultView.localStorage.getItem(host + "_apiVersion_migrated")
+      }), mockHost)).toEqual({version: null, migrated: "true"});
     });
 
     test("Delete Token Button", async ({page, extensionId}) => {

--- a/tests/e2e/popup.spec.js
+++ b/tests/e2e/popup.spec.js
@@ -410,8 +410,22 @@ test.describe("Popup", () => {
       await apiInput.fill("64"); //be careful as this value depends on the test-mock.js file and real api versions
       await apiInput.press("Enter");
 
-      // Verify value is updated
+      // Verify value is updated and stored for this org only
       await expect(apiInput).toHaveValue("64");
+      await expect.poll(() => apiInput.evaluate((input, host) =>
+        input.ownerDocument.defaultView.localStorage.getItem(host + "_apiVersion"), mockHost
+      )).toBe("64.0");
+
+      // A partial or unsupported value must never reach storage
+      await apiInput.fill("");
+      await apiInput.blur();
+      await expect(apiInput).toHaveValue("64");
+      await apiInput.fill("9");
+      await apiInput.blur();
+      await expect(apiInput).toHaveValue("64");
+      await expect.poll(() => apiInput.evaluate((input, host) =>
+        input.ownerDocument.defaultView.localStorage.getItem(host + "_apiVersion"), mockHost
+      )).toBe("64.0");
     });
 
     test("Click Data Export Link", async ({page, extensionId}) => {

--- a/tests/e2e/test-helpers.js
+++ b/tests/e2e/test-helpers.js
@@ -59,7 +59,7 @@ export async function injectSessionData(context, {host, token, version, addition
         window.localStorage.setItem(keyPrefix + "_isSandbox", "true");
         window.localStorage.setItem(keyPrefix + "_orgInstance", "FRA12S");
         window.localStorage.setItem(keyPrefix + "_trialExpirationDate", "2026-01-01");
-        window.localStorage.setItem("apiVersion", version);
+        window.localStorage.setItem(keyPrefix + "_apiVersion", version);
       }
     } catch (e) {
       // localStorage might not be accessible in this context, continue anyway


### PR DESCRIPTION
## Summary

- store the selected API version under a per-org key instead of one global key, so raising it for an upgraded org no longer breaks orgs still on the previous release
- migrate the existing global value once per org, capped to the versions that org actually supports, and keep "Restore Default" from being undone by that migration
- reject empty, partial and out-of-range input before it is written, and compare versions numerically instead of lexicographically

## Context

Split out of #1307, which is limited to the stale release shown in the Org tab. That PR removes the cause of a wrong maximum version; this one addresses the fact that the preference itself is global.

The lexicographic comparison is a latent bug of its own: `"68.0" < "7"` is true, so lowering the version to a single digit was treated as an increase and rejected.

## Test plan

- [x] `npx playwright test tests/e2e/popup.spec.js tests/e2e/options.spec.js` (57 passed)
- [x] Popup test asserts the value is stored under `<host>_apiVersion` and that empty or unsupported input never reaches storage
- [x] Options tests assert an unsupported version is refused and that Restore Default clears the org key
- [ ] Manually verify two orgs on different releases keep independent versions
- [ ] Manually verify an existing global value is migrated on first visit and clamped when the org does not support it