### PR TITLE
fix: (Popup) restore record details display for Winter '27 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1
 
-- `Popup` Fix missing record details in the Winter '27 release [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+- `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)
 - `Popup` Fix "Show Field API Names" button not rendering correctly in certain environments [issue #1246](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1246) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Restore LoginAs buttons for frozen users [discussion #1270](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1270)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Fix missing record details in the Winter '27 release [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)
 - `Popup` Fix "Show Field API Names" button not rendering correctly in certain environments [issue #1246](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1246) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Restore LoginAs buttons for frozen users [discussion #1270](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1270)

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3048,9 +3048,11 @@ class AllDataBoxOrg extends React.PureComponent {
                 h(
                   "td",
                   {},
-                  this.getNextMajorRelease(
-                    this.state.instanceStatus?.Maintenances
-                  ) || "None scheduled" 
+                  this.state.instanceStatus
+                    ? this.getNextMajorRelease(
+                        this.state.instanceStatus.Maintenances
+                      ) || "None scheduled"
+                    : ""
                 )
               )
             )

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1836,14 +1836,11 @@ class AllDataBoxSObject extends React.PureComponent {
   getBestMatch(query) {
     let {sobjectsList} = this.props;
     // Find the best match based on the record id or object name from the page URL.
-    if (!query) {
-      return null;
-    }
-    if (!sobjectsList) {
+    if (!query || !sobjectsList) {
       return null;
     }
     let sobject = sobjectsList.find(
-      (sobject) => sobject.name.toLowerCase() == query.toLowerCase()
+      (sobject) => (sobject.name || "").toLowerCase() == query.toLowerCase()
     );
     let queryKeyPrefix = query.substring(0, 3);
     if (!sobject) {
@@ -1879,33 +1876,39 @@ class AllDataBoxSObject extends React.PureComponent {
     let res = sobjectsList
       .filter(
         (sobject) =>
-          sobject.name.toLowerCase().includes(query.toLowerCase())
-          || sobject.label.toLowerCase().includes(query.toLowerCase())
+          (sobject.name || "").toLowerCase().includes(query.toLowerCase())
+          || (sobject.label || "").toLowerCase().includes(query.toLowerCase())
           || sobject.keyPrefix == queryKeyPrefix
       )
-      .map((sobject) => ({
-        recordId: null,
-        sobject,
-        // TO-DO: merge with the sortRank function in data-export
-        relevance:
-          (sobject.keyPrefix == queryKeyPrefix
-            ? 2
-            : sobject.name.toLowerCase() == query.toLowerCase()
-              ? 3
-              : sobject.label.toLowerCase() == query.toLowerCase()
-                ? 4
-                : sobject.name.toLowerCase().startsWith(query.toLowerCase())
-                  ? 5
-                  : sobject.label.toLowerCase().startsWith(query.toLowerCase())
-                    ? 6
-                    : sobject.name.toLowerCase().includes("__" + query.toLowerCase())
-                      ? 7
-                      : sobject.name.toLowerCase().includes("_" + query.toLowerCase())
-                        ? 8
-                        : sobject.label.toLowerCase().includes(" " + query.toLowerCase())
-                          ? 9
-                          : 10) + (sobject.availableApis.length == 0 ? 20 : 0),
-      }));
+      .map((sobject) => {
+        let sName = (sobject.name || "").toLowerCase();
+        let sLabel = (sobject.label || "").toLowerCase();
+        let q = query.toLowerCase();
+        
+        return {
+          recordId: null,
+          sobject,
+          // TO-DO: merge with the sortRank function in data-export
+          relevance:
+            (sobject.keyPrefix == queryKeyPrefix
+              ? 2
+              : sName == q
+                ? 3
+                : sLabel == q
+                  ? 4
+                  : sName.startsWith(q)
+                    ? 5
+                    : sLabel.startsWith(q)
+                      ? 6
+                      : sName.includes("__" + q)
+                        ? 7
+                        : sName.includes("_" + q)
+                          ? 8
+                          : sLabel.includes(" " + q)
+                            ? 9
+                            : 10) + (sobject.availableApis.length == 0 ? 20 : 0),
+        };
+      });
     query = query || contextRecordId || "";
     queryKeyPrefix = query.substring(0, 3);
     if (query.match(/^([a-zA-Z0-9]{15}|[a-zA-Z0-9]{18})$/)) {
@@ -1919,7 +1922,7 @@ class AllDataBoxSObject extends React.PureComponent {
     res.sort(
       (a, b) =>
         a.relevance - b.relevance
-        || a.sobject.name.localeCompare(b.sobject.name)
+        || (a.sobject.name || "").localeCompare(b.sobject.name || "")
     );
     return res;
   }
@@ -1955,6 +1958,7 @@ class AllDataBoxSObject extends React.PureComponent {
   }
 
   resultRender(matches, userQuery) {
+    let qLower = (userQuery || "").toLowerCase();
     return matches.map((value, index) => {
       const itemKey = value.recordId + "#" + value.sobject.name + "#" + index;
       return {
@@ -1966,10 +1970,8 @@ class AllDataBoxSObject extends React.PureComponent {
             {className: "dropdown-item slds-wrap", key: "main-" + itemKey},
             value.recordId
               || h(MarkSubstring, {
-                text: value.sobject.name,
-                start: value.sobject.name
-                  .toLowerCase()
-                  .indexOf(userQuery.toLowerCase()),
+                text: value.sobject.name || "",
+                start: (value.sobject.name || "").toLowerCase().indexOf(qLower),
                 length: userQuery.length,
               }),
             value.sobject.availableApis.length == 0 ? " (Not readable)" : ""
@@ -1985,10 +1987,8 @@ class AllDataBoxSObject extends React.PureComponent {
             }),
             " • ",
             h(MarkSubstring, {
-              text: value.sobject.label,
-              start: value.sobject.label
-                .toLowerCase()
-                .indexOf(userQuery.toLowerCase()),
+              text: value.sobject.label || "",
+              start: (value.sobject.label || "").toLowerCase().indexOf(qLower),
               length: userQuery.length,
             })
           ),

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -2797,14 +2797,17 @@ class AllDataBoxOrg extends React.PureComponent {
 
   getNextMajorRelease(maintenances) {
     if (maintenances) {
-      let event = maintenances.find((event) =>
-        event.name.endsWith("Major Release")
+      let event = maintenances.find((e) =>
+        e && e.name && e.name.endsWith("Major Release")
       );
-      return (
-        event.name.replace(" Major Release", "")
-        + " on "
-        + new Date(event.plannedStartTime).toDateString()
-      );
+      
+      if (event) {
+        return (
+          event.name.replace(" Major Release", "")
+          + " on "
+          + new Date(event.plannedStartTime).toDateString()
+        );
+      }
     }
     return null;
   }
@@ -3047,7 +3050,7 @@ class AllDataBoxOrg extends React.PureComponent {
                   {},
                   this.getNextMajorRelease(
                     this.state.instanceStatus?.Maintenances
-                  )
+                  ) || "None scheduled" 
                 )
               )
             )

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -190,8 +190,8 @@ class App extends React.PureComponent {
           isPopupExpanded: true, // Popup is expanded when we receive this message
         });
       }
-      
-      if ('isFieldsPresent' in e.data) {
+
+      if ("isFieldsPresent" in e.data) {
         this.setState({
           isFieldsPresent: e.data.isFieldsPresent,
         });
@@ -1884,7 +1884,7 @@ class AllDataBoxSObject extends React.PureComponent {
         let sName = (sobject.name || "").toLowerCase();
         let sLabel = (sobject.label || "").toLowerCase();
         let q = query.toLowerCase();
-        
+
         return {
           recordId: null,
           sobject,
@@ -2800,7 +2800,7 @@ class AllDataBoxOrg extends React.PureComponent {
       let event = maintenances.find((e) =>
         e && e.name && e.name.endsWith("Major Release")
       );
-      
+
       if (event) {
         return (
           event.name.replace(" Major Release", "")
@@ -3050,8 +3050,8 @@ class AllDataBoxOrg extends React.PureComponent {
                   {},
                   this.state.instanceStatus
                     ? this.getNextMajorRelease(
-                        this.state.instanceStatus.Maintenances
-                      ) || "None scheduled"
+                      this.state.instanceStatus.Maintenances
+                    ) || "None scheduled"
                     : ""
                 )
               )


### PR DESCRIPTION
# Describe your changes
The Salesforce Winter '27 release likely introduced internal objects in the Global Describe that return null for their API name or label. Because the extension iterates through all objects and directly calls .toLowerCase() on these properties, it throws a TypeError when it hits one of these new null values, breaking the UI.

To fix this, we need to safely handle null or undefined values by falling back to an empty string (sobject.name || "") before calling .toLowerCase().

<img width="1908" height="800" alt="image" src="https://github.com/user-attachments/assets/92dec884-c2da-4d9b-bbfe-018303c75042" />


## Issue ticket number and link

Closes #1316
Closes #1317
Closes #1315

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
