### PR TITLE
fix #1318 Restore monospace font in text areas lost with SLDS 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Export` `Data Import` `REST Explore` Restore monospace font in text areas (SOQL editor, CSV paste box, request headers and body) lost with the SLDS 2 migration [feature 1318](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1318) (idea by [Marius Hov Lauritzen](https://github.com/tmariushl))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)
 - `Popup` Fix "Show Field API Names" button not rendering correctly in certain environments [issue #1246](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1246) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Restore LoginAs buttons for frozen users [discussion #1270](https://github.com/tprouvot/Salesforce-Inspector-reloaded/discussions/1270)

--- a/addon/styles/sfir.css
+++ b/addon/styles/sfir.css
@@ -217,6 +217,13 @@ a.download-salesforce {
   max-height: 400px;
 }
 
+/* SLDS resets textarea and .slds-textarea to `font: inherit`; restore the browser-default monospace
+   used before 2.0 (SOQL editor, CSV paste, REST request headers/body, ...). Page-level classes still override this. */
+textarea,
+.slds-textarea {
+  font-family: "SFMono-Regular", "Menlo", "Monaco", "Consolas", monospace;
+}
+
 /* Center datalist dropdown arrow in Object/External ID inputs (data-import) */
 #form-search-object::-webkit-calendar-picker-indicator,
 #form-external-id::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
# Describe your changes

SLDS 2 resets `textarea` and `.slds-textarea` to `font: inherit`, which dropped the browser-default monospace font from the SOQL editor, the Data Import paste box and custom headers, and the REST Explore request headers/body. This adds one rule in `styles/sfir.css` to restore it.

Before / after:

![Before and after](https://raw.githubusercontent.com/RubenHalman/Salesforce-Inspector-reloaded/6a3b2b8ec3202d680c02c59fe05d19643d3f4517/1318/before-after.png)

## Issue ticket number and link

Fixes #1318 (monospace part only, tab contrast not addressed here)

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [x] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)

