### PR TITLE
fix (Show All Data): Resolve missing Description column values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Show All Data` Fix Description column shows "Unknown" when the column is saved as visible [issue #1324](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1324) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -2024,9 +2024,10 @@ class ColumnsVisibiltyBox extends React.Component {
   }
   render() {
     let {rowList, label, content} = this.props;
-    return h("span", {className: "slds-icon_container slds-icon-utility-chevrondown slds-current-color slds-m-left_small", onClick: this.onAvailableColumnsClick},
+    let isOpen = !!rowList.availableColumns; 
+    return h("span", {className: `slds-icon_container slds-icon-utility-chevron${isOpen ? 'up' : 'down'} slds-current-color slds-m-left_small`, onClick: this.onAvailableColumnsClick},
       h("svg", {className: "slds-icon slds-icon_x-small", "aria-hidden": "true"},
-        h("use", {xlinkHref: "symbols.svg#chevrondown"})
+        h("use", {xlinkHref: `symbols.svg#chevron${isOpen ? 'up' : 'down'}`})
       ),
       rowList.availableColumns ? h("section", {
         className: "slds-popover slds-dynamic-menu",

--- a/addon/inspect.js
+++ b/addon/inspect.js
@@ -515,6 +515,12 @@ Structure your response clearly with appropriate headings.`;
         }
         this.hasEntityParticles = true;
         this.fieldRows.resortRows();
+
+        // Trigger field descriptions fetch if 'desc' column is active and hasn't been fetched yet
+        if (this.fieldRows.selectedColumnMap.has("desc") && this.fieldRows.fetchFieldDescriptions) {
+          this.fieldRows.fetchFieldDescriptions = false;
+          this.fieldRows.rows.forEach(fieldRow => fieldRow.showFieldDescription());
+        }
       })
     );
 
@@ -1056,7 +1062,7 @@ class FieldRowList extends RowList {
     };
   }
   showHideColumn(show, col) {
-    if (col == "desc" && this.fetchFieldDescriptions) {
+    if (col == "desc" && show && this.fetchFieldDescriptions && this.model.hasEntityParticles) {
       this.fetchFieldDescriptions = false;
       this.rows.forEach(fieldRow => fieldRow.showFieldDescription());
     }


### PR DESCRIPTION
# Describe your changes

We need to ensure that the field descriptions are actively fetched when the page loads if the column was saved in local storage.
Currently, the FieldRowList class only fetches descriptions when the user manually toggles the column on, which is why toggling it fixes the values. Furthermore, showFieldDescription() relies on the EntityParticle data to be fully loaded before making the API call, which happens asynchronously.
We can solve this by triggering the fetch inside Model.startLoading() immediately after the tooling particles are successfully queried, provided that the column is currently visible. We also need to update showHideColumn() to gracefully wait if a user toggles the column on before the particle query has finished.

+fix: Fields/Relationships show column option chevron direction

## Issue ticket number and link
Closes #1324

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
