### PR TITLE
Fix (Popup): Login-as Incognito invalidating the main tab session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Fix Login-as Incognito disconnecting the session on the main tab [issue #1239](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1239) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/addon/inspector.js
+++ b/addon/inspector.js
@@ -117,7 +117,7 @@ export let sfConn = {
     return tokenData.access_token;
   },
 
-  async rest(url, {logErrors = true, method = "GET", api = "normal", body = undefined, bodyType = "json", responseType = "json", headers = {}, progressHandler = null, useCache = true} = {}, rawResponse) {
+  async rest(url, {logErrors = true, method = "GET", api = "normal", body = undefined, bodyType = "json", responseType = "json", headers = {}, progressHandler = null, useCache = true, suppressSessionError = false} = {}, rawResponse) {
     if (!this.instanceHostname) {
       throw new Error("Instance Hostname not found");
     }
@@ -213,7 +213,7 @@ export let sfConn = {
       let error = xhr.response.length > 0 ? xhr.response[0].message : "New access token needed";
       errorMessage = `401 Unauthorized: ${error}`;
       //set sessionError only if user has already generated a token, which will prevent to display the error when the session is expired and api access control not configured
-      if (localStorage.getItem(this.instanceHostname + Constants.ACCESS_TOKEN)){
+      if (!suppressSessionError && localStorage.getItem(this.instanceHostname + Constants.ACCESS_TOKEN)){
         sessionError = {text: "Access Token Expired", title: "Generate New Token", type: "warning", icon: "warning"};
         showToastBanner();
       }
@@ -225,8 +225,10 @@ export let sfConn = {
     } else if (xhr.status == 403) {
       let error = xhr.response.length > 0 ? xhr.response[0].message : "Error";
       errorMessage = `403 Forbidden: ${error}`;
-      sessionError = {text: error, type: "error", icon: "error"};
-      showToastBanner();
+      if (!suppressSessionError) {
+        sessionError = {text: error, type: "error", icon: "error"};
+        showToastBanner();
+      }
       apiStatistics.trackApiCall("rest", url, method, duration, true, errorMessage);
       let err = new Error();
       err.name = "Forbidden";

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3366,14 +3366,14 @@ class UserDetails extends React.PureComponent {
     return user.IsActive && user.NetworkId;
   }
 
-  getLoginAsLink(userId) {
-    let {sfHost, contextOrgId, contextPath} = this.props;
+  // Relative servlet.su path — used for the plain LoginAs link and as redirect_uri
+  // for the Single Access call in loginAsInIncognito.
+  getLoginAsPath(userId) {
+    let {contextOrgId, contextPath} = this.props;
     const retUrl = contextPath || "/";
     const targetUrl = contextPath || "/";
     return (
-      "https://"
-      + sfHost
-      + "/servlet/servlet.su"
+      "/servlet/servlet.su"
       + "?oid="
       + encodeURIComponent(contextOrgId)
       + "&suorgadminid="
@@ -3385,7 +3385,30 @@ class UserDetails extends React.PureComponent {
     );
   }
 
-  loginAsInIncognito(userId) {
+  getLoginAsLink(userId) {
+    let {sfHost} = this.props;
+    return "https://" + sfHost + this.getLoginAsPath(userId);
+  }
+
+  async loginAsInIncognito(userId) {
+    // Reusing the live session id to bootstrap a second browser context gets flagged
+    // as a hijack and kills the main tab's session. Use Salesforce's Single Access 
+    // UI Bridge API instead - it mints a separate one-time frontdoor URL without 
+    // touching the live session.
+    try {
+      const redirectUri = this.getLoginAsPath(userId).replace(/^\//, "");
+      const singleAccess = await sfConn.rest(
+        "/services/oauth2/singleaccess?redirect_uri=" + encodeURIComponent(redirectUri),
+        {method: "GET"}
+      );
+      if (singleAccess && singleAccess.frontdoor_uri) {
+        this.openUrlInIncognito(singleAccess.frontdoor_uri);
+        return;
+      }
+    } catch (e) {
+      console.error("Single Access UI Bridge request failed, falling back to frontdoor.jsp with session id", e);
+    }
+    // Fallback if Single Access isn't available for this org/token
     const targetUrl
       = "https://"
       + this.sfHost

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -3392,21 +3392,26 @@ class UserDetails extends React.PureComponent {
 
   async loginAsInIncognito(userId) {
     // Reusing the live session id to bootstrap a second browser context gets flagged
-    // as a hijack and kills the main tab's session. Use Salesforce's Single Access 
-    // UI Bridge API instead - it mints a separate one-time frontdoor URL without 
+    // as a hijack and kills the main tab's session. Use Salesforce's Single Access
+    // UI Bridge API instead - it mints a separate one-time frontdoor URL without
     // touching the live session.
+    // suppressSessionError: a 401/403 here is an expected "this org/session doesn't
+    // support Single Access" signal, not a real expired-session event - don't let it
+    // pop the global "Access Token Expired" toast banner on the main tab.
     try {
       const redirectUri = this.getLoginAsPath(userId).replace(/^\//, "");
       const singleAccess = await sfConn.rest(
         "/services/oauth2/singleaccess?redirect_uri=" + encodeURIComponent(redirectUri),
-        {method: "GET"}
+        {method: "GET", suppressSessionError: true}
       );
       if (singleAccess && singleAccess.frontdoor_uri) {
+        console.log("[LoginAs Incognito] Single Access UI Bridge succeeded, using frontdoor_uri");
         this.openUrlInIncognito(singleAccess.frontdoor_uri);
         return;
       }
+      console.warn("[LoginAs Incognito] Single Access UI Bridge returned no frontdoor_uri, falling back to frontdoor.jsp with session id", singleAccess);
     } catch (e) {
-      console.error("Single Access UI Bridge request failed, falling back to frontdoor.jsp with session id", e);
+      console.warn(`[LoginAs Incognito] Single Access UI Bridge request failed (${e.name || "Error"}: ${e.message}), falling back to frontdoor.jsp with session id`, e);
     }
     // Fallback if Single Access isn't available for this org/token
     const targetUrl


### PR DESCRIPTION
# Describe your changes

## Problem
Using "Login As > Incognito > Log out" disconnects the admin's session on the main tab.
Salesforce responds with a 401, hits `SessionTimeServlet`, then fires a SAML
`LogoutRequest` — killing the main tab's session, not just the incognito one.

## Root cause
`loginAsInIncognito` passed the *live* session id (`sfConn.sessionId` — the same
one backing the main tab's cookie) directly to `frontdoor.jsp?sid=...` to
bootstrap the incognito window. Reusing that same live session id from a second
browser context appears to trip Salesforce's session security as a hijack
signal, which invalidates the session and triggers a SAML single logout.

This lines up with issue comment: switching to the OAuth/connected-app
token (a separate token, not the raw UI session cookie) avoided the disconnect.

## Fix
Use Salesforce's [Single Access UI Bridge API](https://help.salesforce.com/s/articleView?id=xcloud.frontdoor_singleaccess.htm)
(`services/oauth2/singleaccess`) to mint a separate, single-use frontdoor URL
instead of exposing/reusing the live session id. This is Salesforce's
documented mechanism for bridging an existing session into a new UI session.

Falls back to the previous `frontdoor.jsp?sid=` behavior if the Single Access
call fails, so the feature doesn't regress for orgs/tokens where it's
unavailable.


## Issue ticket number and link
Closes #1239
Closes #1268

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [ ] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
