### PR TITLE
fix: stabilize popup record and object detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Popup` Stabilize current-record detection and Object search when popup context and SObject metadata load asynchronously.
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ We all know and love Salesforce Inspector: As the great Søren Krabbe did not ma
 
 ### Other Improvements
 
+- Reliable popup context detection: the extension now consistently recognizes the currently opened Salesforce record and refreshes Object search results even when the popup or SObject metadata finishes loading asynchronously.
 - Favicon and banner customization for each org
 - Allow users to update API Version [feature 58](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/58)
 - Add new "Shortcuts" tab to accelerate setup navigation [feature 42](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/42)

--- a/addon/button.js
+++ b/addon/button.js
@@ -239,6 +239,14 @@ function initButton(sfHost, inInspector) {
         }, "*");
       }
 
+      // The popup can be opened before its React message listener is mounted.
+      // Resend the current page context once the popup explicitly confirms that
+      // it is ready, otherwise the first open can miss both record detection and
+      // the signal that starts loading the Objects tab.
+      if (e.data.insextLoaded && rootEl.classList.contains("insext-active")) {
+        sendPopupContext();
+      }
+
       togglePopup(e.data.insextOpenPopup, e.data.insextClosePopup);
       if (e.data.insextShowApiName) {
         let apiNamesClass = "field-api-name";
@@ -296,13 +304,16 @@ function initButton(sfHost, inInspector) {
         console.error("Copy failed: ", err);
       });
     }
-    function openPopup() {
+    function sendPopupContext() {
       let activeContentElem = document.querySelector("div.windowViewMode-normal.active, section.oneConsoleTab div.windowViewMode-maximized.active.lafPageHost");
       let isFieldsPresent = activeContentElem ? !!activeContentElem.querySelector("record_flexipage-record-field > div, records-record-layout-item > div, div .forcePageBlockItemView") : false;
       popupEl.contentWindow.postMessage({insextUpdateRecordId: true,
         locationHref: location.href,
         isFieldsPresent
       }, "*");
+    }
+    function openPopup() {
+      sendPopupContext();
       rootEl.classList.add("insext-active");
       // These event listeners are only enabled when the popup is active to avoid interfering with Salesforce when not using the inspector
       addEventListener("click", outsidePopupClick);

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -128,6 +128,7 @@ class App extends React.PureComponent {
       apiVersionInput: apiVersion,
       isFieldsPresent: false,
       isPopupExpanded: false, // Track if popup is expanded/active
+      contextUpdateId: 0,
       exportHref: "data-export.html?" + hostArg,
       importHref: "data-import.html?" + hostArg,
       eventMonitorHref: "event-monitor.html?" + hostArg,
@@ -184,11 +185,12 @@ class App extends React.PureComponent {
     if (e.source == parent && e.data) {
       if (e.data.insextUpdateRecordId) {
         let {locationHref} = e.data;
-        this.setState({
+        this.setState((state) => ({
           isInSetup: locationHref.includes("/lightning/setup/"),
           contextUrl: locationHref,
           isPopupExpanded: true, // Popup is expanded when we receive this message
-        });
+          contextUpdateId: state.contextUpdateId + 1,
+        }));
       }
 
       if ("isFieldsPresent" in e.data) {
@@ -397,6 +399,7 @@ class App extends React.PureComponent {
       limitsHref,
       apiStatisticsHref,
       isFieldsPresent,
+      contextUpdateId,
       latestNotesViewed,
       useLegacyDownloadMetadata,
     } = this.state;
@@ -498,6 +501,7 @@ class App extends React.PureComponent {
             inInspector,
             linkTarget,
             contextUrl,
+            contextUpdateId,
             onContextRecordChange: this.onContextRecordChange,
             isFieldsPresent,
             eventMonitorHref,
@@ -986,7 +990,9 @@ class AllDataBox extends React.PureComponent {
 
     this.onSobjectsListRefreshed = (e) => {
       if (e.detail?.sfHost === this.props.sfHost) {
-        this.setState({sobjectsList: e.detail.sobjectsList});
+        this.setState({sobjectsList: e.detail.sobjectsList}, () => {
+          this.refreshSobjectSearch();
+        });
       }
     };
     window.addEventListener(Constants.SOBJECTS_LIST_REFRESHED_EVENT, this.onSobjectsListRefreshed);
@@ -998,7 +1004,8 @@ class AllDataBox extends React.PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     let {activeSearchAspect} = this.state;
-    if (prevProps.contextUrl !== this.props.contextUrl) {
+    const contextUpdated = prevProps.contextUpdateId !== this.props.contextUpdateId;
+    if (prevProps.contextUrl !== this.props.contextUrl || contextUpdated) {
       this.ensureKnownBrowserContext();
     }
 
@@ -1029,7 +1036,7 @@ class AllDataBox extends React.PureComponent {
     }
 
     // If popup just became expanded and Objects tab is active, load sobjects
-    if (popupJustExpanded && this.shouldLoadSobjects()) {
+    if ((popupJustExpanded || contextUpdated) && this.shouldLoadSobjects()) {
       this.loadSobjects();
     }
   }
@@ -1046,7 +1053,7 @@ class AllDataBox extends React.PureComponent {
     }
     // Preload before popup opens: only if option is enabled (not in inspector)
     if (!this.props.isPopupExpanded && !this.props.inInspector) {
-      return isSettingEnabled(Constants.PRELOAD_SOBJECTS_BEFORE_POPUP);
+      return isSettingEnabled(Constants.PRELOAD_SOBJECTS_BEFORE_POPUP, true);
     }
     return false;
   }
@@ -1120,16 +1127,20 @@ class AllDataBox extends React.PureComponent {
         this.setState({
           sobjectsLoading: false,
           sobjectsList,
+        }, () => {
+          this.refreshSobjectSearch();
         });
-        // Only call getMatchesDelayed if the showAllDataBoxSObject component is rendered (i.e., user is on Objects tab)
-        this.refs.showAllDataBoxSObject?.refs?.allDataSearch?.getMatchesDelayed(
-          ""
-        );
       })
       .catch((e) => {
         console.error(e);
         this.setState({sobjectsLoading: false});
       });
+  }
+
+  refreshSobjectSearch() {
+    const search = this.refs.showAllDataBoxSObject?.refs?.allDataSearch;
+    const query = search?.state?.queryString ?? "";
+    search?.getMatchesDelayed(query);
   }
 
   async onClearSobjectsCache() {
@@ -1724,10 +1735,10 @@ class AllDataBoxSObject extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     let {contextRecordId, sobjectsLoading, contextSobject} = this.props;
-    if (prevProps.contextRecordId !== contextRecordId || prevProps.contextSobject !== contextSobject) {
-      this.updateSelection(contextRecordId, contextSobject);
-    }
-    if (prevProps.sobjectsLoading !== sobjectsLoading && !sobjectsLoading) {
+    if (prevProps.contextRecordId !== contextRecordId
+      || prevProps.contextSobject !== contextSobject
+      || prevProps.sobjectsList !== this.props.sobjectsList
+      || (prevProps.sobjectsLoading !== sobjectsLoading && !sobjectsLoading)) {
       this.updateSelection(contextRecordId, contextSobject);
     }
   }

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1177,9 +1177,10 @@ async function fetchSobjectsList(sfHost, currentFetch, cacheEnabled, cachedSobje
         .rest(`/services/data/v${apiVersion}/tooling/query?q=${encodeURIComponent("SELECT COUNT() FROM EntityDefinition")}`)
         .then((res) => {
           const entityNb = res.totalSize;
+          const requests = [];
           for (let bucket = 0; bucket < Math.ceil(entityNb / batchSize); bucket++) {
             const query = `SELECT QualifiedApiName, Label, KeyPrefix, DurableId, IsCustomSetting, RecordTypesSupported, NewUrl, IsEverCreatable FROM EntityDefinition ORDER BY QualifiedApiName LIMIT ${batchSize} OFFSET ${bucket * batchSize}`;
-            sfConn
+            requests.push(sfConn
               .rest(`/services/data/v${apiVersion}/tooling/query?q=${encodeURIComponent(query)}`)
               .then((respEntity) => {
                 for (let record of respEntity.records) {
@@ -1204,8 +1205,9 @@ async function fetchSobjectsList(sfHost, currentFetch, cacheEnabled, cachedSobje
               })
               .catch((err) => {
                 console.error("list entity definitions: ", err);
-              });
+              }));
           }
+          return Promise.all(requests);
         })
         .catch((err) => {
           console.error("count entity definitions: ", err);


### PR DESCRIPTION
# Describe your changes

This PR fixes intermittent failures in the popup where:
Fixes #1340


- The currently opened Salesforce record was not detected.
- The Objects tab sometimes returned no results for valid objects.
- Record and object context could remain stale when reopening the popup.

The issue occurred because the page context message could be sent before the popup's React message listener was ready. SObject metadata and search results also had asynchronous loading races.

## Changes made

- Resend the current Salesforce page context after the popup confirms it is ready.
- Reprocess page context whenever the popup is opened, including when the URL has not changed.
- Restore SObject preloading as the default behavior for faster record detection.
- Refresh Object search results using the user's current search query after metadata finishes loading.
- Re-evaluate record selection when the SObject list is refreshed.
- Wait for all batched `EntityDefinition` requests before completing SObject metadata loading.
- Document the improvement in `README.md` and `CHANGES.md`.

## Testing

Ran the focused popup Objects tab test suite:

```text
4 passed
