### PR TITLE
fix (Data Import): Run button doesn't update when selecting Undelete before data is loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+-`Data Import` Fix Run button doesn't update when selecting Undelete before data is loaded [issue #](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1
 
--`Data Import` Fix Run button doesn't update when selecting Undelete before data is loaded [issue #](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/) (contribution by [Prem Kumar](https://github.com/prem-k-r))
+-`Data Import` Fix Run button doesn't update when selecting Undelete before data is loaded [issue #1331](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1331) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -1108,7 +1108,7 @@ class App extends React.Component {
   }
   onImportUndelete(model){
     //reinit import table to remove __Status column to be able to undelete rows after deleting it
-    if (model.importData.importTable.header.find(c => c.columnValue == "__Status")) {
+    if (model.importData.importTable && model.importData.importTable.header.find(c => c.columnValue == "__Status")) {
       //get indexes to remove
       const indices = model.importData.importTable.header.map((element, index) => element.columnValue.startsWith("__") ? index : undefined).filter(index => index !== undefined);
       //remove indexes from header and data


### PR DESCRIPTION
# Describe your changes

Fix the Run button could get stuck showing the previous action after switching the Action dropdown to Undelete, if no data had been pasted yet

onImportActionChange sets model.importAction/importActionName, then for the Undelete case calls onImportUndelete(model) before calling model.didUpdate() (which triggers the React re-render). onImportUndelete accessed model.importData.importTable.header without checking whether importTable was null — which it is by default until data has been pasted. This threw an uncaught TypeError, aborting the handler before model.didUpdate() ran. The native `<select> `still visually updates (browser default behavior), but the Run button's label — only updated on React re-render — stayed stale.

Fix: added a null-check guard around model.importData.importTable in onImportUndelete so it safely no-ops when there's no table yet, letting didUpdate() always run.


## Issue ticket number and link

Closes #1331 


## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
