### PR TITLE
Fix (data-import): false "Unknown object" error flashes on page load/reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+-`Data Import` Fix Object field briefly shows a false "Unknown object" error after page load [issue #1333](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1333) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -322,6 +322,16 @@ class Model {
     }
   }
 
+  // True while neither the cached sobjects list nor the DescribeInfo fallback has data yet,
+  // e.g. right after a page reload before the async fetches resolve.
+  sobjectListLoading() {
+    if (this.sobjectsList && this.sobjectsList.length > 0) {
+      return false;
+    }
+    let {globalDescribe} = this.describeInfo.describeGlobal(this.apiType == "Tooling");
+    return !globalDescribe;
+  }
+
   idLookupList() {
     let sobjectName = this.importType;
     let sobjectDescribe = this.describeInfo.describeSobject(this.apiType == "Tooling", sobjectName).sobjectDescribe;
@@ -382,6 +392,9 @@ class Model {
 
   importTypeError() {
     let importType = this.importType;
+    if (this.sobjectListLoading()) {
+      return "";
+    }
     if (!this.sobjectList().some(s => s.name.toLowerCase() == importType.toLowerCase())) {
       return "Unknown object";
     }


### PR DESCRIPTION
# Describe your changes

Fixed: the Object field briefly show an incorrect "Unknown object" error right after opening or reloading the tool, until the object list finished loading in the background.

importTypeError() checks the typed object against Model.sobjectList(). sobjectList() depends on this.sobjectsList, populated asynchronously via getSobjectsList(sfHost).then(...), with a fallback to describeInfo.describeGlobal(...) if that cache isn't ready. Until either resolves, sobjectList() returns [], so any object name — valid or not — fails the .some(...) check and importTypeError() returns "Unknown object". The error clears once a later re-render happens after the list finishes loading, but that gap is visible on first render.

Fix: added Model.sobjectListLoading(), which returns true only while neither the cached list nor the describeInfo fallback has data yet. importTypeError() now short-circuits to "" while loading, instead of evaluating against an empty list

## Issue ticket number and link

Closes #1333

## Checklist before requesting a review

- [x] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
