### PR TITLE
Fix [Data Import]: table header doesn't refresh after column edit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Import` Fix table header doesn't refresh after column edit until Skip is clicked [issue #1342](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1342) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)
 - `Popup` Fix missing record details in the Winter '27 release and resolve missing Org details when no maintenance is scheduled [issue #1316](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1316) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Allow editing Batch Size and Threads during an active import [issue #1036](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1036)

--- a/addon/data-import.js
+++ b/addon/data-import.js
@@ -1454,12 +1454,24 @@ class ColumnMapper extends React.Component {
   constructor(props) {
     super(props);
     this.onColumnValueChange = this.onColumnValueChange.bind(this);
+    this.onColumnValueBlur = this.onColumnValueBlur.bind(this);
+    this.onColumnValueKeyDown = this.onColumnValueKeyDown.bind(this);
     this.onColumnSkipClick = this.onColumnSkipClick.bind(this);
   }
   onColumnValueChange(e) {
     let {model, column} = this.props;
     column.columnValue = e.target.value;
     model.didUpdate();
+  }
+  onColumnValueBlur(e) {
+    let {model} = this.props;
+    model.updateImportTableResult();
+    model.didUpdate();
+  }
+  onColumnValueKeyDown(e) {
+    if (e.key === "Enter") {
+      e.target.blur();
+    }
   }
   onColumnSkipClick(e) {
     let {model, column} = this.props;
@@ -1474,7 +1486,7 @@ class ColumnMapper extends React.Component {
       h("div", {className: "slds-form-element"},
         h("span", {className: "slds-form-element__label", htmlFor: "col-" + column.columnIndex}, column.columnOriginalValue),
         h("div", {className: "slds-form-element__control slds-grid"},
-          h("input", {type: "search", list: "columnlist", value: column.columnValue, onChange: this.onColumnValueChange, className: inputClassName, disabled: model.isWorking(), id: "col-" + column.columnIndex}),
+          h("input", {type: "search", list: "columnlist", value: column.columnValue, onChange: this.onColumnValueChange, onBlur: this.onColumnValueBlur, onKeyDown: this.onColumnValueKeyDown, className: inputClassName, disabled: model.isWorking(), id: "col-" + column.columnIndex}),
           h("div", {className: "slds-size_4-of-12 slds-text-align_right", hidden: !column.columnError()},
             h("span", {className: "slds-text-color_error"}, column.columnError()), " ",
             h("button", {className: "slds-button slds-button_neutral", onClick: this.onColumnSkipClick, hidden: model.isWorking(), title: "Don't import this column"}, "Skip")


### PR DESCRIPTION
# Describe your changes
Fix makes the table update immediately after you finish editing a
column (when you click away or press Enter), so you don't need an
unrelated Skip click to see your changes reflected.

## Problem
Editing a column mapping field directly (typing a new value) did not
refresh the import table header/preview. The refresh only happened
once any Skip button on the page was clicked, even for unrelated
columns. This meant any UI/state that depends on the table header
being in sync with the column list — including the grey-out styling
for skipped columns — didn't update until a Skip click forced a
refresh.

## Root cause
`onColumnValueChange` (fired on typing) only updated `column.columnValue`
and called `model.didUpdate()` (re-render). Unlike `columnSkip()`, it
never called `model.updateImportTableResult()`, which is what rebuilds
`importTableResult` (header, table, colVisibilities, etc.) from the
current column state. So any manual edit left the table header stale
until something else (a Skip click) happened to call
`updateImportTableResult()` and catch it up.

## Fix
Added `onBlur` and `onKeyDown` (Enter) handlers to the column-name
input in `ColumnMapper` that call:
- `model.updateImportTableResult()`
- `model.didUpdate()`

once the user finishes editing a field (blur or Enter), matching what
`columnSkip()` already does. This keeps the table header in sync with
manual edits without waiting on an unrelated Skip click.

## Side effect fixed
This also resolves the previously reported symptom where a manually
typed "_" skip prefix wouldn't grey out the row until Skip was
clicked — that was just one visible consequence of the stale header
refresh, not a separate bug.

## Issue ticket number and link

Closes #1342

## Checklist before requesting a review

- [ ] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
