### PR TITLE
Fix (Org Limits): gauge falsely shows full/blue for "0 of 0 consumed" limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Org Limits` Fix gauge falsely displaying as full/blue when a limit is "0 of 0 consumed" [issue #1347](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1347)
 - `Data Import` Fix Object field briefly shows a false "Unknown object" error after page load [issue #1333](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1333) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Popup` Fix Login-as Incognito disconnecting the session on the main tab [issue #1239](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1239) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Event Monitor` Fix "no customChannel found" when the org has more than one custom channel [issue #1323](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1323)

--- a/addon/limits.css
+++ b/addon/limits.css
@@ -59,6 +59,9 @@ figcaption > div {
   border-radius: 0 0 6rem 6rem;
   background: deepskyblue;
 }
+.meter-not-applicable {
+  background: lightgrey;
+}
 .meter-value-container {
   position: absolute;
   bottom: -0.75rem;

--- a/addon/limits.js
+++ b/addon/limits.js
@@ -73,7 +73,7 @@ class Model {
         "description": "...",
         "max": res[key].Max,
         "remaining": res[key].Remaining,
-        "consumption": (res[key].Max - res[key].Remaining) / res[key].Max
+        "consumption": res[key].Max === 0 ? 0 : (res[key].Max - res[key].Remaining) / res[key].Max
       });
     });
     self.allLimitData = self.sortLimits(self.allLimitData, self.sortBy.value);
@@ -109,6 +109,9 @@ let h = React.createElement;
 
 class LimitData extends React.Component {
   render() {
+    // "0 of 0 consumed" means the limit does not apply to this org, not that it is fully consumed
+    let isNotApplicable = this.props.max === 0 && this.props.remaining === 0;
+    let percentage = isNotApplicable ? 0 : Math.round((1 - this.divide(this.props.remaining, this.props.max)) * 100);
     return (
       h("div", {className: "slds-col slds-size_1-of-5 slds-p-top_xx-large"},
         h("figure", {},
@@ -116,7 +119,7 @@ class LimitData extends React.Component {
             className: "gauge"
           },
           h("div", {
-            className: "meter",
+            className: "meter" + (isNotApplicable ? " meter-not-applicable" : ""),
             ref: "meter"
           },
           ""
@@ -126,7 +129,7 @@ class LimitData extends React.Component {
           },
           h("div", {
             className: "meter-value"
-          }, Math.round((1 - this.divide(this.props.remaining, this.props.max)) * 100) + "%")
+          }, percentage + "%")
           )
           ),
           h("figcaption", {}, this.props.label,
@@ -143,7 +146,8 @@ class LimitData extends React.Component {
   }
   componentDidMount() {
     // Animate gauge to relevant value
-    let targetDegree = (this.props.max == 0 || this.props.remaining < 0) ? "180deg" : ((1 - this.divide(this.props.remaining, this.props.max)) * 180) + "deg"; //180deg = 100%, 0deg = 0%
+    let isNotApplicable = this.props.max === 0 && this.props.remaining === 0;
+    let targetDegree = isNotApplicable ? "0deg" : this.props.remaining < 0 ? "180deg" : ((1 - this.divide(this.props.remaining, this.props.max)) * 180) + "deg"; //180deg = 100%, 0deg = 0%
     this.refs.meter.animate([{
       transform: "rotate(0deg)"
     }, {

--- a/tests/e2e/limits.spec.js
+++ b/tests/e2e/limits.spec.js
@@ -62,6 +62,17 @@ test.describe("Org Limits", () => {
     await expect(page.locator("figcaption").first()).toContainText("consumed");
   });
 
+  test("Gauge is gray and shows 0% when limit is 0 of 0 consumed", async ({page, extensionId}) => {
+    await initLimitsPage(page, extensionId);
+
+    // "PrivateConnectOutboundCalloutHourlyLimitMB" is mocked with Max: 0, Remaining: 0
+    const figure = page.locator("figure", {hasText: "Private Connect"});
+    await expect(figure.locator("figcaption")).toContainText("0 of 0 consumed");
+    // Should render as an empty/not-applicable gauge, not a falsely "full" one
+    await expect(figure.locator(".meter-value")).toHaveText("0%");
+    await expect(figure.locator(".meter")).toHaveClass(/meter-not-applicable/);
+  });
+
   test("Copy button is enabled when limits load", async ({page, extensionId}) => {
     await initLimitsPage(page, extensionId);
 

--- a/tests/e2e/test-mock.js
+++ b/tests/e2e/test-mock.js
@@ -655,6 +655,10 @@ export async function routeMock(route, host) {
         "DailyStandardVolumePlatformEvents": {
           "Max": 10000,
           "Remaining": 1000
+        },
+        "PrivateConnectOutboundCalloutHourlyLimitMB": {
+          "Max": 0,
+          "Remaining": 0
         }
       });
       return true;


### PR DESCRIPTION
## Summary
- Some org limits report `Max: 0, Remaining: 0` when the limit doesn't apply to the org (e.g. `Private Connect Outbound Callout Hourly Limit`). The gauge rendered this as **100% consumed** and fully filled/blue, giving a false impression the limit was being approached.
- The gauge (percentage text, rotation animation, and fill color) now renders as **0% / gray** when a limit is `0 of 0 consumed`. Overconsumption (negative remaining) still renders as full/red-equivalent as before.
- Also fixed the `consumption` value used for sorting to be `0` instead of `NaN` in this case.

Fixes #1347

## Test plan
- [x] Added a `0/0` limit fixture (`PrivateConnectOutboundCalloutHourlyLimitMB`) to the e2e mock data
- [x] Added a new Playwright test asserting the gauge shows `0%` and the gray `meter-not-applicable` class for this limit
- [x] Verified the new test fails against the old code (shows `100%`) and passes with the fix
- [x] Ran the full `limits.spec.js` suite (7 tests, all passing)