### PR TITLE
fix: enable keyboard shortcuts on Firefox (#1336)

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -87,7 +87,7 @@ chrome.commands?.onCommand.addListener((command) => {
     });
   } else {
     chrome.tabs.create({
-      url: `chrome-extension://${chrome.i18n.getMessage("@@extension_id")}/${command}.html?host=${sfHost}`
+      url: chrome.runtime.getURL(`${command}.html`) + `?host=${sfHost}`
     });
   }
 });

--- a/addon/manifest-firefox.json
+++ b/addon/manifest-firefox.json
@@ -86,5 +86,67 @@
     "flow-scanner.html"
   ],
   "incognito": "spanning",
-  "manifest_version": 2
+  "manifest_version": 2,
+  "commands": {
+    "open-popup": {
+      "description": "Open popup"
+    },
+    "open-export-autocomplete": {
+      "description": "Fields suggestion in Data Export"
+    },
+    "open-export-execute": {
+      "description": "Run Query in Data Export"
+    },
+    "open-save-modifications": {
+      "description": "Save modifications in Show All Data"
+    },
+    "link-setup": {
+      "description": "Open Setup"
+    },
+    "link-home": {
+      "description": "Open Home Page"
+    },
+    "link-dev": {
+      "description": "Open Developer Console"
+    },
+    "data-export": {
+      "description": "Data Export"
+    },
+    "data-import": {
+      "description": "Data Import"
+    },
+    "dependencies-explorer": {
+      "description": "Dependencies Explorer"
+    },
+    "options": {
+      "description": "Options"
+    },
+    "metadata-retrieve": {
+      "description": "Retrieve Metadata"
+    },
+    "limits": {
+      "description": "Org Limits"
+    },
+    "field-creator": {
+      "description": "Field Creator"
+    },
+    "explore-api": {
+      "description": "Explore API"
+    },
+    "rest-explore": {
+      "description": "REST Explore"
+    },
+    "event-monitor": {
+      "description": "Event Monitor"
+    },
+    "flow-scanner": {
+      "description": "Flow Scanner"
+    },
+    "debug-log": {
+      "description": "Logs Viewer"
+    },
+    "api-statistics": {
+      "description": "API Statistics"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Firefox only lists assignable shortcuts for commands declared in the Firefox manifest. `addon/manifest.json` already declared those commands for Chrome; `addon/manifest-firefox.json` did not, so `about:addons > Manage Extension Shortcuts` showed Salesforce Inspector Reloaded under "The following extensions do not have shortcuts".

This change:
- Copies the Chrome `commands` block into `addon/manifest-firefox.json` so Firefox exposes the same commands.
- Replaces the hardcoded `chrome-extension://` URL in `addon/background.js` with `chrome.runtime.getURL()`, which works for both `chrome-extension://` and `moz-extension://`.

## Motivation

Fixes #1336. The issue describes the missing Firefox `commands` key and the scheme mismatch in the fallback tab-open path.

## Implementation

- `addon/manifest-firefox.json`: add the same command names and descriptions used by the Chrome manifest (no suggested keys, matching Chrome).
- `addon/background.js`: `chrome.tabs.create` now uses `chrome.runtime.getURL(`${command}.html`) + `?host=${sfHost}`.

The existing `chrome.commands?.onCommand` listener is unchanged and is already shared by both builds.

## Testing

- Confirmed `addon/manifest.json` command names and descriptions and mirrored them into the Firefox manifest.
- Validated the updated Firefox manifest as JSON.
- Confirmed the previous `chrome-extension://${chrome.i18n.getMessage("@@extension_id")}/...` string is gone and `chrome.runtime.getURL` is used instead.
- I did not load the unpacked Firefox add-on in a live Firefox profile in this environment.

## Notes

Firefox still requires the user to assign shortcuts under `about:addons > Manage Extension Shortcuts` after this ships; the change only makes those commands available to assign.