### PR TITLE
fix (Data Export): Filter JSON export to visible rows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Import` Fix "Copy JSON" exporting the entire exported data instead of only filtered results [issue #1348](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1348) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Org Limits` Fix gauge falsely displaying as full/blue when a limit is "0 of 0 consumed" [issue #1347](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1347)
 - `Data Import` Fix Run button doesn't update when selecting Undelete before data is loaded [issue #1331](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1331) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Fix Object field briefly shows a false "Unknown object" error after page load [issue #1333](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1333) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -275,7 +275,8 @@ class Model {
     copyToClipboard(this.exportedData.csvSerialize(this.separator));
   }
   copyAsJson() {
-    copyToClipboard(JSON.stringify(this.exportedData.records, null, "  "));
+    const visibleRecords = this.exportedData.records.filter((_, index) => this.exportedData.rowVisibilities[index + 1]);
+    copyToClipboard(JSON.stringify(visibleRecords, null, "  "));
   }
   downloadAsCsv(){
     const csvContent = this.exportedData.csvSerialize(this.separator);


### PR DESCRIPTION
# Describe your changes

Fix "Copy JSON" exporting the entire exported data instead of only filtered results

## Issue ticket number and link

Closes #1348


## Checklist before requesting a review

- [ ] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
