### PR TITLE
Fix (Data Export): hidden-column filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.1
 
+- `Data Import` Fix Search filter incorrectly matches data inside hidden object columns [issue #1353](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1353) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Org Limits` Fix gauge falsely displaying as full/blue when a limit is "0 of 0 consumed" [issue #1347](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1347)
 - `Data Import` Fix Run button doesn't update when selecting Undelete before data is loaded [issue #1331](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1331) (contribution by [Prem Kumar](https://github.com/prem-k-r))
 - `Data Import` Fix Object field briefly shows a false "Unknown object" error after page load [issue #1333](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/1333) (contribution by [Prem Kumar](https://github.com/prem-k-r))

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -1261,7 +1261,11 @@ function RecordTable(vm) {
     }
     // If no columns are selected, search all columns
     if (!vm.filterColumns || vm.filterColumns.length === 0) {
-      return row.some(cell => {
+      return row.some((cell, index) => {
+        // Skip hidden columns
+        if (rt.colVisibilities && !rt.colVisibilities[index]) {
+          return false;
+        }
         if (cell == null) {
           return false;
         }
@@ -1274,6 +1278,10 @@ function RecordTable(vm) {
       const columnIndex = header.findIndex(col => col === column);
       if (columnIndex === -1) {
         return false;
+      }
+      // Skip hidden columns even if previously selected
+      if (rt.colVisibilities && !rt.colVisibilities[columnIndex]) {
+          return false;
       }
 
       const cellValue = String(row[columnIndex]);


### PR DESCRIPTION
# Describe your changes

Issue: The isVisible function in RecordTable evaluated all cell data without checking if the corresponding column visibility was toggled off.

Fix: Added a condition to check rt.colVisibilities[index] (and rt.colVisibilities[columnIndex] for targeted column searches). The .some() loop now explicitly skips evaluating cell data if its index corresponds to a hidden column.

## Issue ticket number and link

Closes #1353

## Checklist before requesting a review

- [ ] I have **read and understand** the [Contributions section](https://github.com/tprouvot/Salesforce-Inspector-reloaded#contributions)
- [ ] My PR relates to an existing issue or feature request and **I discussed it with maintainer**
- [x] I used SLDS style and limit the usage of custom CSS
- [x] I have performed a self-review of my code
- [ ] I ran the [unit tests](https://github.com/tprouvot/Salesforce-Inspector-reloaded#unit-tests) and my PR does not break any tests
- [x] I documented the changes I've made on the [CHANGES.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/CHANGES.md) and followed actual conventions
- [ ] I added a new section on [how-to.md](https://github.com/tprouvot/Salesforce-Inspector-reloaded/blob/master/docs/how-to.md) (optional)
