### PR TITLE
fix(firefox): declare commands + use runtime.getURL for shortcuts

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -87,7 +87,7 @@ chrome.commands?.onCommand.addListener((command) => {
     });
   } else {
     chrome.tabs.create({
-      url: `chrome-extension://${chrome.i18n.getMessage("@@extension_id")}/${command}.html?host=${sfHost}`
+      url: chrome.runtime.getURL(`${command}.html?host=${sfHost}`)
     });
   }
 });

--- a/addon/manifest-firefox.json
+++ b/addon/manifest-firefox.json
@@ -86,5 +86,67 @@
     "flow-scanner.html"
   ],
   "incognito": "spanning",
-  "manifest_version": 2
+  "manifest_version": 2,
+  "commands": {
+    "open-popup": {
+      "description": "Open popup"
+    },
+    "open-export-autocomplete": {
+      "description": "Fields suggestion in Data Export"
+    },
+    "open-export-execute": {
+      "description": "Run Query in Data Export"
+    },
+    "open-save-modifications": {
+      "description": "Save modifications in Show All Data"
+    },
+    "link-setup": {
+      "description": "Open Setup"
+    },
+    "link-home": {
+      "description": "Open Home Page"
+    },
+    "link-dev": {
+      "description": "Open Developer Console"
+    },
+    "data-export": {
+      "description": "Data Export"
+    },
+    "data-import": {
+      "description": "Data Import"
+    },
+    "dependencies-explorer": {
+      "description": "Dependencies Explorer"
+    },
+    "options": {
+      "description": "Options"
+    },
+    "metadata-retrieve": {
+      "description": "Retrieve Metadata"
+    },
+    "limits": {
+      "description": "Org Limits"
+    },
+    "field-creator": {
+      "description": "Field Creator"
+    },
+    "explore-api": {
+      "description": "Explore API"
+    },
+    "rest-explore": {
+      "description": "REST Explore"
+    },
+    "event-monitor": {
+      "description": "Event Monitor"
+    },
+    "flow-scanner": {
+      "description": "Flow Scanner"
+    },
+    "debug-log": {
+      "description": "Logs Viewer"
+    },
+    "api-statistics": {
+      "description": "API Statistics"
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1336

**Cause:** Firefox manifest lacked a `commands` block (Chrome had them), so Firefox listed the extension under “do not have shortcuts”. The shared background listener also opened pages with a hardcoded `chrome-extension://` URL, which breaks on Firefox (`moz-extension://`).

**Fix:**
- Mirror Chrome’s `commands` into `addon/manifest-firefox.json`
- Use `chrome.runtime.getURL()` for command-triggered page opens in `addon/background.js`

**Verify:**
1. `npm run firefox-release-build`
2. Load unpacked from `target/firefox/dist`
3. Firefox → about:addons → Manage Extension Shortcuts — commands should be listed and assignable